### PR TITLE
Travis support for glock

### DIFF
--- a/.travis-fork-fix
+++ b/.travis-fork-fix
@@ -6,8 +6,9 @@
 # will fix the issue.
 
 REPO="github.com/heketi/heketi"
-REPODIR="../../heketi/heketi"
+REPODIR="../../heketi"
 
 if ! git remote -v | grep origin | grep ${REPO} ; then
-    ln -s $PWD ${REPODIR}
+    mkdir -p ${REPODIR}
+    ln -s $PWD ${REPODIR}/heketi
 fi

--- a/.travis-fork-fix
+++ b/.travis-fork-fix
@@ -9,6 +9,5 @@ REPO="github.com/heketi/heketi"
 REPODIR="../../heketi/heketi"
 
 if ! git remote -v | grep origin | grep ${REPO} ; then
-    mv ${REPODIR} ${REPODIR}.orig
     ln -s $PWD ${REPODIR}
 fi

--- a/.travis-fork-fix
+++ b/.travis-fork-fix
@@ -5,10 +5,10 @@
 # from pblcache repo and not from the fork.  This program
 # will fix the issue.
 
-PBLREPO="github.com/heketi/heketi"
-PBLCACHEDIR="../../lpabon/heketi"
+REPO="github.com/heketi/heketi"
+REPODIR="../../heketi/heketi"
 
-if ! git remote -v | grep origin | grep ${PBLREPO} ; then
-    mv ${PBLCACHEDIR} ${PBLCACHEDIR}.orig
-    ln -s $PWD ${PBLCACHEDIR}
+if ! git remote -v | grep origin | grep ${REPO} ; then
+    mv ${REPODIR} ${REPODIR}.orig
+    ln -s $PWD ${REPODIR}
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 install:
+- bash .travis-fork-fix
 - go get github.com/mattn/goveralls
 - go get github.com/robfig/glock
 - glock sync github.com/heketi/heketi
@@ -17,7 +18,6 @@ matrix:
 before_script:
 - if [[ "$GOTOOLS" = "yes" ]] ; then go get golang.org/x/tools/cmd/vet; fi
 - if [[ "$GOTOOLS" = "yes" ]] ; then go get golang.org/x/tools/cmd/cover; fi
-- bash .travis-fork-fix
 script:
 - if [[ "GOTOOLS" = "yes" ]] ; then go fmt ./... | wc -l | grep 0 ; fi
 - if [[ "GOTOOLS" = "yes" ]] ; then go vet ./... ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 install:
 - go get github.com/mattn/goveralls
-- go get -v -d ./...
+- go get github.com/robfig/glock
+- glock sync github.com/heketi/heketi
 env:
   global:
   - secure: tCj+iGIN2GM5yPneme35KIQwqGcXMOLod00qvG/Af0lkjEVJRRNz3gnB3P2dNyj9Nc4FWxSUIjCiIkblOMaEKxPXp1S3Zo7gRBVphyNY5ZvIKeqKoXvBPd6hi9Ft2TaN+4vDczfAKOI/S3/3kN3NmgGCYNTLOues0T4yhVd3v14hoQJxw4Jbjlsj8RGfLrqp+dInFv2tS+xTyK+q/EOiaCpBq4PfK6giKwt943o7jc9v0iWjnP2rWq/AotMo4QutoC0OVeJT8aG41sC5LvlYTBQB22E8Zv439JgHsdhQU1NRd/1VLGKATToxkUxh2Reei42koAWFJ+EfFvAIx03k5+ZYJY7W+Rtuy8jn0uRaZyvvQdUvyT22e9lSJzqkP6JAe7oru9hf9X4K0XSOfMMFUiJDC+rNm0Ajd+r/5h6C+jRqIMDvvFgdlCkM8gKIX1B5N+RM1hxurAGTRpdCPuDVLVeTCbNZCds8jiK1DNky6Ni66plBIV+LKQY3EpjBn0jaWfPdTJbU5OiOb1uadnmzj2yt65Mp3T8QJD3dotURISR8bIS+Xb6vAytKFWmtcqje5Hx4lFTfyrH3gRGjMyeS9j3pVjbbCCV466FHOp9oglpoFv49nXhivPzLqU7mSuLIue+5RZ318HykuBWI+6xAo8aH9nnoBmAWiGCxXwIr13Y=


### PR DESCRIPTION
The repo now uses glock (https://github.com/robfig/glock) to maintain a consistent view of its dependencies.  Travis needed to be updated to use glock.