### PR TITLE
Optimize ssh connections

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -79,6 +79,9 @@ func NewApp(configIo io.Reader) *App {
 	default:
 		return nil
 	}
+	if app.executor == nil {
+		return nil
+	}
 	logger.Debug("Loaded %v executor", app.conf.Executor)
 
 	// Set db is set in the configuration file

--- a/executors/sshexec/peer.go
+++ b/executors/sshexec/peer.go
@@ -18,26 +18,20 @@ package sshexec
 
 import (
 	"fmt"
-	"github.com/heketi/heketi/utils/ssh"
 	"github.com/lpabon/godbc"
 )
 
-func (s *SshExecutor) PeerProbe(exec_host, newnode string) error {
+func (s *SshExecutor) PeerProbe(host, newnode string) error {
 
-	godbc.Require(exec_host != "")
+	godbc.Require(host != "")
 	godbc.Require(newnode != "")
 
-	exec := ssh.NewSshExecWithKeyFile(logger, s.user, s.private_keyfile)
-	if exec == nil {
-		return ErrSshPrivateKey
-	}
-
-	logger.Info("Probing: %v -> %v", exec_host, newnode)
+	logger.Info("Probing: %v -> %v", host, newnode)
 	// create the commands
 	commands := []string{
 		fmt.Sprintf("sudo gluster peer probe %v", newnode),
 	}
-	_, err := exec.ConnectAndExec(exec_host+":22", commands, 5)
+	_, err := s.sshExec(host, commands, 5)
 	if err != nil {
 		return err
 	}
@@ -45,21 +39,16 @@ func (s *SshExecutor) PeerProbe(exec_host, newnode string) error {
 	return nil
 }
 
-func (s *SshExecutor) PeerDetach(exec_host, detachnode string) error {
-	godbc.Require(exec_host != "")
+func (s *SshExecutor) PeerDetach(host, detachnode string) error {
+	godbc.Require(host != "")
 	godbc.Require(detachnode != "")
-
-	exec := ssh.NewSshExecWithKeyFile(logger, s.user, s.private_keyfile)
-	if exec == nil {
-		return ErrSshPrivateKey
-	}
 
 	// create the commands
 	logger.Info("Detaching node %v", detachnode)
 	commands := []string{
 		fmt.Sprintf("sudo gluster peer detach %v", detachnode),
 	}
-	_, err := exec.ConnectAndExec(exec_host+":22", commands, 5)
+	_, err := s.sshExec(host, commands, 5)
 	if err != nil {
 		logger.Err(err)
 	}

--- a/executors/sshexec/sshexec.go
+++ b/executors/sshexec/sshexec.go
@@ -39,8 +39,8 @@ type SshExecutor struct {
 }
 
 type SshConfig struct {
-	PrivateKeyFile     string `json:"keyfile"`
-	User               string `json:"user"`
+	PrivateKeyFile string `json:"keyfile"`
+	User           string `json:"user"`
 
 	// Experimental Settings
 	RebalanceOnExpansion bool `json:"rebalance_on_expansion"`

--- a/utils/ssh/ssh.go
+++ b/utils/ssh/ssh.go
@@ -35,10 +35,6 @@ type SshExec struct {
 	logger       *utils.Logger
 }
 
-var (
-	maxconnections = make(chan bool, 8)
-)
-
 func getKeyFile(file string) (key ssh.Signer, err error) {
 	buf, err := ioutil.ReadFile(file)
 	if err != nil {
@@ -110,12 +106,6 @@ func NewSshExecWithKeyFile(logger *utils.Logger, user string, file string) *SshE
 
 // This function was based from https://github.com/coreos/etcd-manager/blob/master/main.go
 func (s *SshExec) ConnectAndExec(host string, commands []string, timeoutMinutes int) ([]string, error) {
-
-	// Wait here for a turn
-	maxconnections <- true
-	defer func() {
-		<-maxconnections
-	}()
 
 	buffers := make([]string, len(commands))
 


### PR DESCRIPTION
Instead of a global throttle, use a throttle per host.  This
requires the creation of a channel per host.

Closes #181