### PR TITLE
Update large functional tests

### DIFF
--- a/tests/functional/large/tests/heketi_test.go
+++ b/tests/functional/large/tests/heketi_test.go
@@ -34,7 +34,7 @@ const (
 
 	// VMs
 	DISKS = 24
-	NODES = 18
+	NODES = 30
 )
 
 var (
@@ -66,7 +66,7 @@ func getnodes() []string {
 func setupCluster(t *testing.T) {
 	tests.Assert(t, heketi != nil)
 
-	numclusters := 3
+	numclusters := 5
 	nodespercluster := NODES / numclusters
 	nodes := getnodes()
 	sg := utils.NewStatusGroup()

--- a/tests/functional/large/vagrant/Vagrantfile
+++ b/tests/functional/large/vagrant/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 #
 
-NODES = 18
+NODES = 30
 DISKS = 24
 
 Vagrant.configure("2") do |config|
@@ -31,7 +31,7 @@ Vagrant.configure("2") do |config|
             (0..DISKS-1).each do |d|
                 driverletters = ('b'..'z').to_a
                 storage.vm.provider :libvirt do  |lv|
-                    lv.storage :file, :device => "vd#{driverletters[d]}", :path => "disk-#{i}-#{d}.disk", :size => '8000G'
+                    lv.storage :file, :device => "vd#{driverletters[d]}", :path => "disk-#{i}-#{d}.disk", :size => '4096G'
                     lv.memory = 4096
                     lv.cpus =2
                 end

--- a/tests/functional/large/vagrant/up.sh
+++ b/tests/functional/large/vagrant/up.sh
@@ -1,7 +1,25 @@
 #!/bin/sh
 
-vagrant up --provider=libvirt 
+# Based on blog:
+# https://coderwall.com/p/gy2eng/bring-vagrant-vms-up-in-parallel
+vmup() {
+
+    # Start all vms
+    for id in {0..29}; do
+    vm="storage${id}"
+    echo "[$vm] Bringing up VM"
+
+    vagrant up $vm --provider=libvirt --no-provision &
+    done
+
+    # Start client
+    vagrant up client --provider=libvirt --no-provision &
+
+    # Make sure all child processes have finished before exiting.
+    wait
+}
+
+vmup
 vagrant provision
 vagrant halt
-vagrant up --provider=libvirt
-vagrant provision
+vmup


### PR DESCRIPTION
Allows faster creation of VMs by creating the VMs in parallel. Also
creates 5 clusters of 6 nodes each.