### PR TITLE
Mount options needed

### DIFF
--- a/executors/sshexec/brick.go
+++ b/executors/sshexec/brick.go
@@ -87,7 +87,7 @@ func (s *SshExecutor) BrickCreate(host string,
 			mountpoint),
 
 		// Mount
-		fmt.Sprintf("sudo mount %v %v", s.devnode(brick), mountpoint),
+		fmt.Sprintf("sudo mount -o rw,inode64,noatime,nouuid %v %v", s.devnode(brick), mountpoint),
 
 		// Create a directory inside the formated volume for GlusterFS
 		fmt.Sprintf("sudo mkdir %v/brick", mountpoint),


### PR DESCRIPTION
Mount options are available for /etc/fstab, but are not
set when first mounting the filesystem.

Closes #210

Signed-off-by: Luis Pabón <lpabon@redhat.com>