### PR TITLE
Conflict management support

### DIFF
--- a/apps/glusterfs/entry_test.go
+++ b/apps/glusterfs/entry_test.go
@@ -1,0 +1,86 @@
+//
+// Copyright (c) 2016 The heketi Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package glusterfs
+
+import (
+	"github.com/boltdb/bolt"
+	"github.com/heketi/tests"
+	"os"
+	"testing"
+	"time"
+)
+
+type testDbEntry struct {
+}
+
+func (t *testDbEntry) BucketName() string {
+	return "TestBucket"
+}
+
+func (t *testDbEntry) Marshal() ([]byte, error) {
+	return nil, nil
+}
+
+func (t *testDbEntry) Unmarshal(data []byte) error {
+	return nil
+}
+
+func TestEntryRegister(t *testing.T) {
+	tmpfile := tests.Tempfile()
+
+	// Setup BoltDB database
+	db, err := bolt.Open(tmpfile, 0600, &bolt.Options{Timeout: 3 * time.Second})
+	tests.Assert(t, err == nil)
+	defer os.Remove(tmpfile)
+
+	// Create a bucket
+	entry := &testDbEntry{}
+	err = db.Update(func(tx *bolt.Tx) error {
+
+		// Create Cluster Bucket
+		_, err := tx.CreateBucketIfNotExists([]byte(entry.BucketName()))
+		tests.Assert(t, err == nil)
+
+		// Register a value
+		_, err = EntryRegister(tx, entry, "mykey", []byte("myvalue"))
+		tests.Assert(t, err == nil)
+
+		return nil
+	})
+	tests.Assert(t, err == nil)
+
+	// Try to write key again
+	err = db.Update(func(tx *bolt.Tx) error {
+
+		// Save again, it should not work
+		val, err := EntryRegister(tx, entry, "mykey", []byte("myvalue"))
+		tests.Assert(t, err == ErrKeyExists)
+		tests.Assert(t, string(val) == "myvalue")
+
+		// Remove key
+		err = EntryDelete(tx, entry, "mykey")
+		tests.Assert(t, err == nil)
+
+		// Register again
+		_, err = EntryRegister(tx, entry, "mykey", []byte("myvalue"))
+		tests.Assert(t, err == nil)
+
+		return nil
+	})
+	tests.Assert(t, err == nil)
+
+}

--- a/apps/glusterfs/errors.go
+++ b/apps/glusterfs/errors.go
@@ -29,4 +29,5 @@ var (
 	ErrMininumBrickSize = errors.New("Minimum brick size limit reached.  Out of space.")
 	ErrDbAccess         = errors.New("Unable to access db")
 	ErrAccessList       = errors.New("Unable to access list")
+	ErrKeyExists        = errors.New("Key already exists in the database")
 )


### PR DESCRIPTION
Heketi now checks to make sure that nodes or devices in nodes
are not added again to the database.  If a node is added with the
same host name, it will return HTTP Status Conflict.  For devices,
device names on the same node will return HTTP Status Conflict.

Signed-off-by: Luis Pabón <lpabon@redhat.com>