### PR TITLE
heketi-cli: Improve the readability of json output.

### DIFF
--- a/client/cli/go/commands/cluster_create.go
+++ b/client/cli/go/commands/cluster_create.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+
 	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/lpabon/godbc"
 )
@@ -78,7 +79,7 @@ func (c *ClusterCreateCommand) Exec(args []string) error {
 
 	// Check if JSON should be printed
 	if c.options.Json {
-		data, err := json.Marshal(cluster)
+		data, err := json.MarshalIndent(cluster, "", "    ")
 		if err != nil {
 			return err
 		}

--- a/client/cli/go/commands/cluster_list.go
+++ b/client/cli/go/commands/cluster_list.go
@@ -20,9 +20,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"strings"
+
 	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/lpabon/godbc"
-	"strings"
 )
 
 type ClusterListCommand struct {
@@ -72,7 +73,7 @@ func (c *ClusterListCommand) Exec(args []string) error {
 	}
 
 	if c.options.Json {
-		data, err := json.Marshal(list)
+		data, err := json.MarshalIndent(list, "", "    ")
 		if err != nil {
 			return err
 		}

--- a/client/cli/go/commands/device_info.go
+++ b/client/cli/go/commands/device_info.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+
 	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/lpabon/godbc"
 )
@@ -80,7 +81,7 @@ func (d *DeviceInfoCommand) Exec(args []string) error {
 	}
 
 	if d.options.Json {
-		data, err := json.Marshal(info)
+		data, err := json.MarshalIndent(info, "", "    ")
 		if err != nil {
 			return err
 		}

--- a/client/cli/go/commands/node_add.go
+++ b/client/cli/go/commands/node_add.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+
 	"github.com/heketi/heketi/apps/glusterfs"
 	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/lpabon/godbc"
@@ -109,7 +110,7 @@ func (n *NodeAddCommand) Exec(args []string) error {
 	}
 
 	if n.options.Json {
-		data, err := json.Marshal(node)
+		data, err := json.MarshalIndent(node, "", "    ")
 		if err != nil {
 			return err
 		}

--- a/client/cli/go/commands/node_info.go
+++ b/client/cli/go/commands/node_info.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+
 	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/lpabon/godbc"
 )
@@ -83,7 +84,7 @@ func (n *NodeInfoCommand) Exec(args []string) error {
 	}
 
 	if n.options.Json {
-		data, err := json.Marshal(info)
+		data, err := json.MarshalIndent(info, "", "    ")
 		if err != nil {
 			return err
 		}

--- a/client/cli/go/commands/volume_create.go
+++ b/client/cli/go/commands/volume_create.go
@@ -21,10 +21,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"strings"
+
 	"github.com/heketi/heketi/apps/glusterfs"
 	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/lpabon/godbc"
-	"strings"
 )
 
 type VolumeCreateCommand struct {
@@ -161,7 +162,7 @@ func (v *VolumeCreateCommand) Exec(args []string) error {
 	}
 
 	if v.options.Json {
-		data, err := json.Marshal(volume)
+		data, err := json.MarshalIndent(volume, "", "    ")
 		if err != nil {
 			return err
 		}

--- a/client/cli/go/commands/volume_expand.go
+++ b/client/cli/go/commands/volume_expand.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+
 	"github.com/heketi/heketi/apps/glusterfs"
 	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/lpabon/godbc"
@@ -96,7 +97,7 @@ func (v *VolumeExpandCommand) Exec(args []string) error {
 	}
 
 	if v.options.Json {
-		data, err := json.Marshal(volume)
+		data, err := json.MarshalIndent(volume, "", "    ")
 		if err != nil {
 			return err
 		}

--- a/client/cli/go/commands/volume_info.go
+++ b/client/cli/go/commands/volume_info.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+
 	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/lpabon/godbc"
 )
@@ -82,7 +83,7 @@ func (n *VolumeInfoCommand) Exec(args []string) error {
 	}
 
 	if n.options.Json {
-		data, err := json.Marshal(info)
+		data, err := json.MarshalIndent(info, "", "    ")
 		if err != nil {
 			return err
 		}

--- a/client/cli/go/commands/volume_list.go
+++ b/client/cli/go/commands/volume_list.go
@@ -20,9 +20,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"strings"
+
 	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/lpabon/godbc"
-	"strings"
 )
 
 type VolumeListCommand struct {
@@ -71,7 +72,7 @@ func (c *VolumeListCommand) Exec(args []string) error {
 	}
 
 	if c.options.Json {
-		data, err := json.Marshal(list)
+		data, err := json.MarshalIndent(list, "", "    ")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
At present the json output is not readable by the admin
due to the missing intendation at field keys/values.
This patch fix the issue.

For ex: Before the patch:

[hchiramm@dhcp35-111 go]$ ./heketi-cli -json cluster info 0b7c016bf02bab4a9d512b7ffb02923e
{"id":"0b7c016bf02bab4a9d512b7ffb02923e","nodes":["08e62b1586526b4a79a349d718010929","75d1d22afb654ba90513706c2514aa00","e4f4efa9c01200736d28a9addc82e41b"],"volumes":["07509bb46b08f63f1431e71b5b41fd4e","151b1105b5a50629601476e43de77320","3360fdb87496f65368b4a365be43bb77","3afa0197077b81fa1defd379180884cc","3dddf25df5caeb0a4186abbf53b49b73","5941981f2179bec6a07a23cc5799c5a0","97fc07efde89204a6f7fe5ab60340ed3","997603de2b3d00e0393752b6b1fe05be","cf1f430a80bd6ca8ddf49156d7cc6270","e69d8b61cd08aa1485765598266c8c1d","f6d9fb88f722897219ee37def94b316a"]}[hchiramm@dhcp35-111 go]$

With the patch:

[hchiramm@dhcp35-111 go]]$./heketi-cli -json cluster info 0b7c016bf02bab4a9d512b7ffb02923e
{
   "id": "0b7c016bf02bab4a9d512b7ffb02923e",
   "nodes": [
      "08e62b1586526b4a79a349d718010929",
      "75d1d22afb654ba90513706c2514aa00",
      "e4f4efa9c01200736d28a9addc82e41b"
   ],
   "volumes": [
      "07509bb46b08f63f1431e71b5b41fd4e",
      "151b1105b5a50629601476e43de77320",
      "3360fdb87496f65368b4a365be43bb77",
      "3afa0197077b81fa1defd379180884cc",
      "3dddf25df5caeb0a4186abbf53b49b73",
      "5941981f2179bec6a07a23cc5799c5a0",
      "97fc07efde89204a6f7fe5ab60340ed3",
      "997603de2b3d00e0393752b6b1fe05be",
      "cf1f430a80bd6ca8ddf49156d7cc6270",
      "e69d8b61cd08aa1485765598266c8c1d",
      "f6d9fb88f722897219ee37def94b316a"
   ]
}

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>