### PR TITLE
Increase the PV Metadata size

### DIFF
--- a/executors/sshexec/device.go
+++ b/executors/sshexec/device.go
@@ -40,7 +40,7 @@ func (s *SshExecutor) DeviceSetup(host, device, vgid string) (d *executors.Devic
 
 	// Setup commands
 	commands := []string{
-		fmt.Sprintf("sudo pvcreate --dataalignment 256K %v", device),
+		fmt.Sprintf("sudo pvcreate --metadatasize=128M --dataalignment=256K %v", device),
 		fmt.Sprintf("sudo vgcreate %v %v", s.vgName(vgid), device),
 	}
 


### PR DESCRIPTION
It has been found that only a 100 volumes could be created
limited by the small size of the metadata in the PV. The
solution is to increase the size of the metadata size to
128MB.  This should allow for (guessing) 12K volumes.

Closes #268

Signed-off-by: Luis Pabón <lpabon@redhat.com>