### PR TITLE
Log configuration support

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -42,7 +42,7 @@ const (
 )
 
 var (
-	logger     = utils.NewLogger("[heketi]", utils.LEVEL_DEBUG)
+	logger     = utils.NewLogger("[heketi]", utils.LEVEL_INFO)
 	dbfilename = "heketi.db"
 )
 
@@ -66,6 +66,9 @@ func NewApp(configIo io.Reader) *App {
 	if app.conf == nil {
 		return nil
 	}
+
+	// Setup loglevel
+	app.setLogLevel(app.conf.Loglevel)
 
 	// Setup asynchronous manager
 	app.asyncManager = rest.NewAsyncHttpManager(ASYNC_ROUTE)
@@ -161,6 +164,23 @@ func NewApp(configIo io.Reader) *App {
 	logger.Info("GlusterFS Application Loaded")
 
 	return app
+}
+
+func (a *App) setLogLevel(level string) {
+	switch level {
+	case "none":
+		logger.SetLevel(utils.LEVEL_NOLOG)
+	case "critical":
+		logger.SetLevel(utils.LEVEL_CRITICAL)
+	case "error":
+		logger.SetLevel(utils.LEVEL_ERROR)
+	case "warning":
+		logger.SetLevel(utils.LEVEL_WARNING)
+	case "info":
+		logger.SetLevel(utils.LEVEL_INFO)
+	case "debug":
+		logger.SetLevel(utils.LEVEL_DEBUG)
+	}
 }
 
 func (a *App) setAdvSettings() {

--- a/apps/glusterfs/app_config.go
+++ b/apps/glusterfs/app_config.go
@@ -27,6 +27,7 @@ type GlusterFSConfig struct {
 	Executor  string            `json:"executor"`
 	Allocator string            `json:"allocator"`
 	SshConfig sshexec.SshConfig `json:"sshexec"`
+	Loglevel  string            `json:"loglevel"`
 
 	// advanced settings
 	BrickMaxSize int `json:"brick_max_size_gb"`

--- a/etc/heketi.json
+++ b/etc/heketi.json
@@ -35,6 +35,13 @@
     },
 
     "_db_comment": "Database file name",
-    "db": "/var/lib/heketi/heketi.db"
+    "db": "/var/lib/heketi/heketi.db",
+
+    "_loglevel_comment": [
+      "Set log level. Choices are:",
+      "  none, critical, error, warning, info, debug",
+      "Default is warning"
+    ],
+    "loglevel" : "debug"
   }
 }


### PR DESCRIPTION
Now the glusterfs.loglevel can be set in the JSON configuration.

Closes #222

Signed-off-by: Luis Pabón <lpabon@redhat.com>