### PR TITLE
heketi-cli: version error fixed

### DIFF
--- a/client/cli/go/cmds/root.go
+++ b/client/cli/go/cmds/root.go
@@ -73,7 +73,7 @@ func initConfig() {
 	// Check server
 	if options.Url == "" {
 		options.Url = os.Getenv("HEKETI_CLI_SERVER")
-		if options.Url == "" {
+		if options.Url == "" && !version {
 			fmt.Fprintf(stderr, "Server must be provided\n")
 			os.Exit(3)
 		}


### PR DESCRIPTION
Version was throwing error "Server must be provided"
Version does not require heketi server as it specific to only cli.

Signed-off-by: Mohamed Ashiq Liyazudeen <mliyazud@redhat.com>