### PR TITLE
fix:correct usage of backup-volfile-servers mount option

### DIFF
--- a/apps/glusterfs/models.go
+++ b/apps/glusterfs/models.go
@@ -181,14 +181,14 @@ func (v *VolumeInfoResponse) String() string {
 		"Id: %v\n"+
 		"Cluster Id: %v\n"+
 		"Mount: %v\n"+
-		"Mount Options: backupvolfile-servers=%v\n"+
+		"Mount Options: backup-volfile-servers=%v\n"+
 		"Durability Type: %v\n",
 		v.Name,
 		v.Size,
 		v.Id,
 		v.Cluster,
 		v.Mount.GlusterFS.MountPoint,
-		v.Mount.GlusterFS.Options["backupvolfile-servers"],
+		v.Mount.GlusterFS.Options["backup-volfile-servers"],
 		v.Durability.Type)
 
 	switch v.Durability.Type {

--- a/apps/glusterfs/volume_entry_create.go
+++ b/apps/glusterfs/volume_entry_create.go
@@ -57,7 +57,7 @@ func (v *VolumeEntry) createVolume(db *bolt.DB,
 			stringset.Add(brick.Host)
 		}
 	}
-	v.Info.Mount.GlusterFS.Options["backupvolfile-servers"] =
+	v.Info.Mount.GlusterFS.Options["backup-volfile-servers"] =
 		strings.Join(stringset.Strings(), ",")
 
 	godbc.Ensure(v.Info.Mount.GlusterFS.MountPoint != "")

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -593,7 +593,7 @@ func TestVolumeEntryCreateFourBricks(t *testing.T) {
 	// Check mount information
 	host := strings.Split(info.Mount.GlusterFS.MountPoint, ":")[0]
 	tests.Assert(t, utils.SortedStringHas(nodelist, host), host, nodelist)
-	volfileServers := strings.Split(info.Mount.GlusterFS.Options["backupvolfile-servers"], ",")
+	volfileServers := strings.Split(info.Mount.GlusterFS.Options["backup-volfile-servers"], ",")
 	for index, node := range volfileServers {
 		tests.Assert(t, node != host, index, node, host)
 	}
@@ -667,7 +667,7 @@ func TestVolumeEntryCreateBrickDivision(t *testing.T) {
 	// Check mount information
 	host := strings.Split(info.Mount.GlusterFS.MountPoint, ":")[0]
 	tests.Assert(t, utils.SortedStringHas(nodelist, host), host, nodelist)
-	volfileServers := strings.Split(info.Mount.GlusterFS.Options["backupvolfile-servers"], ",")
+	volfileServers := strings.Split(info.Mount.GlusterFS.Options["backup-volfile-servers"], ",")
 	for index, node := range volfileServers {
 		tests.Assert(t, node != host, index, node, host)
 	}

--- a/client/cli/go/cmds/topology.go
+++ b/client/cli/go/cmds/topology.go
@@ -162,14 +162,14 @@ var topologyInfoCommand = &cobra.Command{
 						"\tId: %v\n"+
 						"\tCluster Id: %v\n"+
 						"\tMount: %v\n"+
-						"\tMount Options: backupvolfile-servers=%v\n"+
+						"\tMount Options: backup-volfile-servers=%v\n"+
 						"\tDurability Type: %v\n",
 						v.Name,
 						v.Size,
 						v.Id,
 						v.Cluster,
 						v.Mount.GlusterFS.MountPoint,
-						v.Mount.GlusterFS.Options["backupvolfile-servers"],
+						v.Mount.GlusterFS.Options["backup-volfile-servers"],
 						v.Durability.Type)
 
 					switch v.Durability.Type {


### PR DESCRIPTION
Just watched a heketi demo and noticed this anomaly with the backup-volfile-server mount option