### PR TITLE
Node and device state support

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -259,6 +259,11 @@ func (a *App) SetRoutes(router *mux.Router) error {
 			Method:      "DELETE",
 			Pattern:     "/nodes/{id:[A-Fa-f0-9]+}",
 			HandlerFunc: a.NodeDelete},
+		rest.Route{
+			Name:        "NodeSetState",
+			Method:      "POST",
+			Pattern:     "/nodes/{id:[A-Fa-f0-9]+}/state",
+			HandlerFunc: a.NodeSetState},
 
 		// Devices
 		rest.Route{
@@ -276,6 +281,11 @@ func (a *App) SetRoutes(router *mux.Router) error {
 			Method:      "DELETE",
 			Pattern:     "/devices/{id:[A-Fa-f0-9]+}",
 			HandlerFunc: a.DeviceDelete},
+		rest.Route{
+			Name:        "DeviceSetState",
+			Method:      "POST",
+			Pattern:     "/devices/{id:[A-Fa-f0-9]+}/state",
+			HandlerFunc: a.DeviceSetState},
 
 		// Volume
 		rest.Route{

--- a/apps/glusterfs/app_cluster.go
+++ b/apps/glusterfs/app_cluster.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"github.com/boltdb/bolt"
 	"github.com/gorilla/mux"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"net/http"
 )
 
@@ -53,7 +54,7 @@ func (a *App) ClusterCreate(w http.ResponseWriter, r *http.Request) {
 
 func (a *App) ClusterList(w http.ResponseWriter, r *http.Request) {
 
-	var list ClusterListResponse
+	var list api.ClusterListResponse
 
 	// Get all the cluster ids from the DB
 	err := a.db.View(func(tx *bolt.Tx) error {
@@ -88,7 +89,7 @@ func (a *App) ClusterInfo(w http.ResponseWriter, r *http.Request) {
 	id := vars["id"]
 
 	// Get info from db
-	var info *ClusterInfoResponse
+	var info *api.ClusterInfoResponse
 	err := a.db.View(func(tx *bolt.Tx) error {
 
 		// Create a db entry from the id

--- a/apps/glusterfs/app_cluster_test.go
+++ b/apps/glusterfs/app_cluster_test.go
@@ -20,14 +20,16 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/boltdb/bolt"
-	"github.com/gorilla/mux"
-	"github.com/heketi/tests"
-	"github.com/heketi/utils"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/boltdb/bolt"
+	"github.com/gorilla/mux"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/tests"
+	"github.com/heketi/utils"
 )
 
 func init() {
@@ -59,7 +61,7 @@ func TestClusterCreate(t *testing.T) {
 	tests.Assert(t, r.StatusCode == http.StatusCreated)
 
 	// Read JSON
-	var msg ClusterInfoResponse
+	var msg api.ClusterInfoResponse
 	err = utils.GetJsonFromResponse(r, &msg)
 	tests.Assert(t, err == nil)
 
@@ -132,7 +134,7 @@ func TestClusterList(t *testing.T) {
 	tests.Assert(t, r.Header.Get("Content-Type") == "application/json; charset=UTF-8")
 
 	// Read response
-	var msg ClusterListResponse
+	var msg api.ClusterListResponse
 	err = utils.GetJsonFromResponse(r, &msg)
 	tests.Assert(t, err == nil)
 
@@ -219,7 +221,7 @@ func TestClusterInfo(t *testing.T) {
 	tests.Assert(t, r.Header.Get("Content-Type") == "application/json; charset=UTF-8")
 
 	// Read response
-	var msg ClusterInfoResponse
+	var msg api.ClusterInfoResponse
 	err = utils.GetJsonFromResponse(r, &msg)
 	tests.Assert(t, err == nil)
 

--- a/apps/glusterfs/app_volume_test.go
+++ b/apps/glusterfs/app_volume_test.go
@@ -18,10 +18,6 @@ package glusterfs
 
 import (
 	"bytes"
-	"github.com/boltdb/bolt"
-	"github.com/gorilla/mux"
-	"github.com/heketi/tests"
-	"github.com/heketi/utils"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -31,6 +27,12 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/boltdb/bolt"
+	"github.com/gorilla/mux"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/tests"
+	"github.com/heketi/utils"
 )
 
 func init() {
@@ -408,7 +410,7 @@ func TestVolumeCreate(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Query queue until finished
-	var info VolumeInfoResponse
+	var info api.VolumeInfoResponse
 	for {
 		r, err = http.Get(location.String())
 		tests.Assert(t, err == nil)
@@ -432,7 +434,7 @@ func TestVolumeCreate(t *testing.T) {
 	tests.Assert(t, info.Name == "vol_"+info.Id)
 	tests.Assert(t, info.Snapshot.Enable == false)
 	tests.Assert(t, info.Snapshot.Factor == 1)
-	tests.Assert(t, info.Durability.Type == DURABILITY_STRING_DISTRIBUTE_ONLY)
+	tests.Assert(t, info.Durability.Type == api.DurabilityDistributeOnly)
 }
 
 func TestVolumeInfoIdNotFound(t *testing.T) {
@@ -480,9 +482,9 @@ func TestVolumeInfo(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Create a volume
-	req := &VolumeCreateRequest{}
+	req := &api.VolumeCreateRequest{}
 	req.Size = 100
-	req.Durability.Type = DURABILITY_STRING_EC
+	req.Durability.Type = api.DurabilityEC
 	v := NewVolumeEntryFromRequest(req)
 	tests.Assert(t, v != nil)
 	err = v.Create(app.db, app.executor, app.allocator)
@@ -496,7 +498,7 @@ func TestVolumeInfo(t *testing.T) {
 	tests.Assert(t, r.Header.Get("Content-Type") == "application/json; charset=UTF-8")
 
 	// Read response
-	var msg VolumeInfoResponse
+	var msg api.VolumeInfoResponse
 	err = utils.GetJsonFromResponse(r, &msg)
 	tests.Assert(t, err == nil)
 
@@ -532,7 +534,7 @@ func TestVolumeListEmpty(t *testing.T) {
 	tests.Assert(t, r.Header.Get("Content-Type") == "application/json; charset=UTF-8")
 
 	// Read response
-	var msg VolumeListResponse
+	var msg api.VolumeListResponse
 	err = utils.GetJsonFromResponse(r, &msg)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, len(msg.Volumes) == 0)
@@ -576,7 +578,7 @@ func TestVolumeList(t *testing.T) {
 	tests.Assert(t, r.Header.Get("Content-Type") == "application/json; charset=UTF-8")
 
 	// Read response
-	var msg VolumeListResponse
+	var msg api.VolumeListResponse
 	err = utils.GetJsonFromResponse(r, &msg)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, len(msg.Volumes) == numvolumes)
@@ -812,7 +814,7 @@ func TestVolumeExpand(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Query queue until finished
-	var info VolumeInfoResponse
+	var info api.VolumeInfoResponse
 	for {
 		r, err := http.Get(location.String())
 		tests.Assert(t, err == nil)

--- a/apps/glusterfs/brick_entry_test.go
+++ b/apps/glusterfs/brick_entry_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/heketi/heketi/executors"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/tests"
 )
 
@@ -42,7 +43,6 @@ func TestNewBrickEntry(t *testing.T) {
 	tests.Assert(t, b.Info.DeviceId == deviceid)
 	tests.Assert(t, b.Info.NodeId == nodeid)
 	tests.Assert(t, b.Info.Size == size)
-	tests.Assert(t, b.State == BRICK_STATE_NEW)
 }
 
 func TestBrickEntryMarshal(t *testing.T) {
@@ -172,7 +172,7 @@ func TestNewBrickEntryNewInfoResponse(t *testing.T) {
 	})
 	tests.Assert(t, err == nil)
 
-	var info *BrickInfo
+	var info *api.BrickInfo
 	err = app.db.View(func(tx *bolt.Tx) error {
 		brick, err := NewBrickEntryFromId(tx, b.Id())
 		if err != nil {

--- a/apps/glusterfs/cluster_entry.go
+++ b/apps/glusterfs/cluster_entry.go
@@ -19,14 +19,16 @@ package glusterfs
 import (
 	"bytes"
 	"encoding/gob"
+	"sort"
+
 	"github.com/boltdb/bolt"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/utils"
 	"github.com/lpabon/godbc"
-	"sort"
 )
 
 type ClusterEntry struct {
-	Info ClusterInfoResponse
+	Info api.ClusterInfoResponse
 }
 
 func ClusterList(tx *bolt.Tx) ([]string, error) {
@@ -87,9 +89,9 @@ func (c *ClusterEntry) Delete(tx *bolt.Tx) error {
 	return EntryDelete(tx, c, c.Info.Id)
 }
 
-func (c *ClusterEntry) NewClusterInfoResponse(tx *bolt.Tx) (*ClusterInfoResponse, error) {
+func (c *ClusterEntry) NewClusterInfoResponse(tx *bolt.Tx) (*api.ClusterInfoResponse, error) {
 
-	info := &ClusterInfoResponse{}
+	info := &api.ClusterInfoResponse{}
 	*info = c.Info
 
 	return info, nil

--- a/apps/glusterfs/cluster_entry_test.go
+++ b/apps/glusterfs/cluster_entry_test.go
@@ -17,12 +17,14 @@
 package glusterfs
 
 import (
-	"github.com/boltdb/bolt"
-	"github.com/heketi/tests"
-	"github.com/heketi/utils"
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/boltdb/bolt"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/tests"
+	"github.com/heketi/utils"
 )
 
 func createSampleClusterEntry() *ClusterEntry {
@@ -339,7 +341,7 @@ func TestNewClusterEntryNewInfoResponse(t *testing.T) {
 	})
 	tests.Assert(t, err == nil)
 
-	var info *ClusterInfoResponse
+	var info *api.ClusterInfoResponse
 	err = app.db.View(func(tx *bolt.Tx) error {
 		cluster, err := NewClusterEntryFromId(tx, c.Info.Id)
 		if err != nil {

--- a/apps/glusterfs/dbentry.go
+++ b/apps/glusterfs/dbentry.go
@@ -1,0 +1,154 @@
+//
+// Copyright (c) 2015 The heketi Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package glusterfs
+
+import (
+	"github.com/boltdb/bolt"
+	"github.com/lpabon/godbc"
+)
+
+type DbEntry interface {
+	BucketName() string
+	Marshal() ([]byte, error)
+	Unmarshal(buffer []byte) error
+}
+
+// Checks if the key already exists in the database.  If it does not exist,
+// then it will save the key value pair in the datababucket se
+func EntryRegister(tx *bolt.Tx, entry DbEntry, key string, value []byte) ([]byte, error) {
+	godbc.Require(tx != nil)
+	godbc.Require(len(key) > 0)
+
+	// Access bucket
+	b := tx.Bucket([]byte(entry.BucketName()))
+	if b == nil {
+		err := ErrDbAccess
+		logger.Err(err)
+		return nil, err
+	}
+
+	// Check if key exists already
+	val := b.Get([]byte(key))
+	if val != nil {
+		return val, ErrKeyExists
+	}
+
+	// Key does not exist.  We can save it
+	err := b.Put([]byte(key), value)
+	if err != nil {
+		logger.Err(err)
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func EntryKeys(tx *bolt.Tx, bucket string) []string {
+	list := make([]string, 0)
+
+	// Get all the cluster ids from the DB
+	b := tx.Bucket([]byte(bucket))
+	if b == nil {
+		return nil
+	}
+
+	err := b.ForEach(func(k, v []byte) error {
+		list = append(list, string(k))
+		return nil
+	})
+	if err != nil {
+		return nil
+	}
+
+	return list
+}
+
+func EntrySave(tx *bolt.Tx, entry DbEntry, key string) error {
+	godbc.Require(tx != nil)
+	godbc.Require(len(key) > 0)
+
+	// Access bucket
+	b := tx.Bucket([]byte(entry.BucketName()))
+	if b == nil {
+		err := ErrDbAccess
+		logger.Err(err)
+		return err
+	}
+
+	// Save device entry to db
+	buffer, err := entry.Marshal()
+	if err != nil {
+		logger.Err(err)
+		return err
+	}
+
+	// Save data using the id as the key
+	err = b.Put([]byte(key), buffer)
+	if err != nil {
+		logger.Err(err)
+		return err
+	}
+
+	return nil
+}
+
+func EntryDelete(tx *bolt.Tx, entry DbEntry, key string) error {
+	godbc.Require(tx != nil)
+	godbc.Require(len(key) > 0)
+
+	// Access bucket
+	b := tx.Bucket([]byte(entry.BucketName()))
+	if b == nil {
+		err := ErrDbAccess
+		logger.Err(err)
+		return err
+	}
+
+	// Delete key
+	err := b.Delete([]byte(key))
+	if err != nil {
+		logger.LogError("Unable to delete key [%v] in db: %v", key, err.Error())
+		return err
+	}
+
+	return nil
+}
+
+func EntryLoad(tx *bolt.Tx, entry DbEntry, key string) error {
+	godbc.Require(tx != nil)
+	godbc.Require(len(key) > 0)
+
+	b := tx.Bucket([]byte(entry.BucketName()))
+	if b == nil {
+		err := ErrDbAccess
+		logger.Err(err)
+		return err
+	}
+
+	val := b.Get([]byte(key))
+	if val == nil {
+		return ErrNotFound
+	}
+
+	err := entry.Unmarshal(val)
+	if err != nil {
+		logger.Err(err)
+		return err
+	}
+
+	return nil
+}

--- a/apps/glusterfs/dbentry_test.go
+++ b/apps/glusterfs/dbentry_test.go
@@ -1,0 +1,86 @@
+//
+// Copyright (c) 2016 The heketi Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package glusterfs
+
+import (
+	"github.com/boltdb/bolt"
+	"github.com/heketi/tests"
+	"os"
+	"testing"
+	"time"
+)
+
+type testDbEntry struct {
+}
+
+func (t *testDbEntry) BucketName() string {
+	return "TestBucket"
+}
+
+func (t *testDbEntry) Marshal() ([]byte, error) {
+	return nil, nil
+}
+
+func (t *testDbEntry) Unmarshal(data []byte) error {
+	return nil
+}
+
+func TestEntryRegister(t *testing.T) {
+	tmpfile := tests.Tempfile()
+
+	// Setup BoltDB database
+	db, err := bolt.Open(tmpfile, 0600, &bolt.Options{Timeout: 3 * time.Second})
+	tests.Assert(t, err == nil)
+	defer os.Remove(tmpfile)
+
+	// Create a bucket
+	entry := &testDbEntry{}
+	err = db.Update(func(tx *bolt.Tx) error {
+
+		// Create Cluster Bucket
+		_, err := tx.CreateBucketIfNotExists([]byte(entry.BucketName()))
+		tests.Assert(t, err == nil)
+
+		// Register a value
+		_, err = EntryRegister(tx, entry, "mykey", []byte("myvalue"))
+		tests.Assert(t, err == nil)
+
+		return nil
+	})
+	tests.Assert(t, err == nil)
+
+	// Try to write key again
+	err = db.Update(func(tx *bolt.Tx) error {
+
+		// Save again, it should not work
+		val, err := EntryRegister(tx, entry, "mykey", []byte("myvalue"))
+		tests.Assert(t, err == ErrKeyExists)
+		tests.Assert(t, string(val) == "myvalue")
+
+		// Remove key
+		err = EntryDelete(tx, entry, "mykey")
+		tests.Assert(t, err == nil)
+
+		// Register again
+		_, err = EntryRegister(tx, entry, "mykey", []byte("myvalue"))
+		tests.Assert(t, err == nil)
+
+		return nil
+	})
+	tests.Assert(t, err == nil)
+
+}

--- a/apps/glusterfs/device_entry_test.go
+++ b/apps/glusterfs/device_entry_test.go
@@ -17,17 +17,20 @@
 package glusterfs
 
 import (
-	"github.com/boltdb/bolt"
-	"github.com/heketi/tests"
-	"github.com/heketi/utils"
 	"os"
 	"reflect"
+	"sort"
 	"testing"
+
+	"github.com/boltdb/bolt"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/tests"
+	"github.com/heketi/utils"
 )
 
 func createSampleDeviceEntry(nodeid string, disksize uint64) *DeviceEntry {
 
-	req := &DeviceAddRequest{}
+	req := &api.DeviceAddRequest{}
 	req.NodeId = nodeid
 	req.Name = "/dev/" + utils.GenUUID()[:8]
 
@@ -52,7 +55,7 @@ func TestNewDeviceEntry(t *testing.T) {
 }
 
 func TestNewDeviceEntryFromRequest(t *testing.T) {
-	req := &DeviceAddRequest{}
+	req := &api.DeviceAddRequest{}
 	req.NodeId = "123"
 	req.Name = "/dev/" + utils.GenUUID()
 
@@ -70,7 +73,7 @@ func TestNewDeviceEntryFromRequest(t *testing.T) {
 }
 
 func TestNewDeviceEntryMarshal(t *testing.T) {
-	req := &DeviceAddRequest{}
+	req := &api.DeviceAddRequest{}
 	req.NodeId = "abc"
 	req.Name = "/dev/" + utils.GenUUID()
 
@@ -94,7 +97,7 @@ func TestNewDeviceEntryMarshal(t *testing.T) {
 }
 
 func TestDeviceEntryNewBrickEntry(t *testing.T) {
-	req := &DeviceAddRequest{}
+	req := &api.DeviceAddRequest{}
 	req.NodeId = "abc"
 	req.Name = "/dev/" + utils.GenUUID()
 
@@ -187,7 +190,7 @@ func TestDeviceEntryRegister(t *testing.T) {
 	defer app.Close()
 
 	// Create a device
-	req := &DeviceAddRequest{}
+	req := &api.DeviceAddRequest{}
 	req.NodeId = "abc"
 	req.Name = "/dev/" + utils.GenUUID()
 
@@ -212,7 +215,7 @@ func TestDeviceEntryRegister(t *testing.T) {
 	tests.Assert(t, err != nil)
 
 	// Create another device on a different node device
-	req = &DeviceAddRequest{}
+	req = &api.DeviceAddRequest{}
 	req.NodeId = "def"
 	req.Name = "/dev/" + utils.GenUUID()
 
@@ -256,7 +259,7 @@ func TestNewDeviceEntryFromId(t *testing.T) {
 	defer app.Close()
 
 	// Create a device
-	req := &DeviceAddRequest{}
+	req := &api.DeviceAddRequest{}
 	req.NodeId = "abc"
 	req.Name = "/dev/" + utils.GenUUID()
 
@@ -296,7 +299,7 @@ func TestNewDeviceEntrySaveDelete(t *testing.T) {
 	defer app.Close()
 
 	// Create a device
-	req := &DeviceAddRequest{}
+	req := &api.DeviceAddRequest{}
 	req.NodeId = "abc"
 	req.Name = "/dev/" + utils.GenUUID()
 
@@ -393,7 +396,7 @@ func TestNewDeviceEntryNewInfoResponseBadBrickIds(t *testing.T) {
 	defer app.Close()
 
 	// Create a device
-	req := &DeviceAddRequest{}
+	req := &api.DeviceAddRequest{}
 	req.NodeId = "abc"
 	req.Name = "/dev/" + utils.GenUUID()
 
@@ -411,7 +414,7 @@ func TestNewDeviceEntryNewInfoResponseBadBrickIds(t *testing.T) {
 	})
 	tests.Assert(t, err == nil)
 
-	var info *DeviceInfoResponse
+	var info *api.DeviceInfoResponse
 	err = app.db.View(func(tx *bolt.Tx) error {
 		device, err := NewDeviceEntryFromId(tx, d.Info.Id)
 		if err != nil {
@@ -438,7 +441,7 @@ func TestNewDeviceEntryNewInfoResponse(t *testing.T) {
 	defer app.Close()
 
 	// Create a device
-	req := &DeviceAddRequest{}
+	req := &api.DeviceAddRequest{}
 	req.NodeId = "abc"
 	req.Name = "/dev/" + utils.GenUUID()
 
@@ -469,7 +472,7 @@ func TestNewDeviceEntryNewInfoResponse(t *testing.T) {
 	})
 	tests.Assert(t, err == nil)
 
-	var info *DeviceInfoResponse
+	var info *api.DeviceInfoResponse
 	err = app.db.View(func(tx *bolt.Tx) error {
 		device, err := NewDeviceEntryFromId(tx, d.Info.Id)
 		if err != nil {
@@ -533,4 +536,159 @@ func TestDeviceEntryStorage(t *testing.T) {
 	tests.Assert(t, d.Info.Storage.Free == 2000)
 	tests.Assert(t, d.Info.Storage.Total == 2000)
 	tests.Assert(t, d.Info.Storage.Used == 0)
+}
+
+func TestDeviceSetStateFailed(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	// Create allocator
+	mockAllocator := NewMockAllocator(app.db)
+	app.allocator = mockAllocator
+
+	// Create cluster entry
+	c := NewClusterEntry()
+	c.Info.Id = "cluster"
+
+	// Create a node
+	n := NewNodeEntry()
+	tests.Assert(t, n != nil)
+	tests.Assert(t, n.State == api.EntryStateOnline)
+
+	// Initialize node
+	n.Info.Id = "node"
+	n.Info.ClusterId = "cluster"
+	n.Devices = sort.StringSlice{"d1"}
+
+	// Create device entry
+	d := NewDeviceEntry()
+	d.Info.Id = "d1"
+	d.Info.Name = "/d1"
+	d.NodeId = "node"
+
+	// Add to allocator
+	mockAllocator.AddDevice(c, n, d)
+
+	// Save in db
+	app.db.Update(func(tx *bolt.Tx) error {
+		err := c.Save(tx)
+		tests.Assert(t, err == nil)
+
+		err = n.Save(tx)
+		tests.Assert(t, err == nil)
+
+		err = d.Save(tx)
+		tests.Assert(t, err == nil)
+
+		// Check ring
+		tests.Assert(t, len(mockAllocator.clustermap[c.Info.Id]) == 1)
+		tests.Assert(t, mockAllocator.clustermap[c.Info.Id][0] == d.Info.Id)
+
+		// Set failed
+		err = d.SetState(tx, mockAllocator, api.EntryStateFailed)
+		tests.Assert(t, d.State == api.EntryStateFailed)
+		tests.Assert(t, err == nil)
+
+		// Check it was removed from ring
+		tests.Assert(t, len(mockAllocator.clustermap[c.Info.Id]) == 0)
+
+		// Set failed again
+		err = d.SetState(tx, mockAllocator, api.EntryStateFailed)
+		tests.Assert(t, d.State == api.EntryStateFailed)
+		tests.Assert(t, err == nil)
+
+		// Set offline
+		err = d.SetState(tx, mockAllocator, api.EntryStateOffline)
+		tests.Assert(t, d.State == api.EntryStateFailed)
+		tests.Assert(t, err != nil)
+		tests.Assert(t, len(mockAllocator.clustermap[c.Info.Id]) == 0)
+
+		// Set online
+		err = d.SetState(tx, mockAllocator, api.EntryStateOnline)
+		tests.Assert(t, d.State == api.EntryStateFailed)
+		tests.Assert(t, err != nil)
+		tests.Assert(t, len(mockAllocator.clustermap[c.Info.Id]) == 0)
+
+		return nil
+
+	})
+}
+
+func TestDeviceSetStateOfflineOnline(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	// Create allocator
+	mockAllocator := NewMockAllocator(app.db)
+	app.allocator = mockAllocator
+
+	// Create cluster entry
+	c := NewClusterEntry()
+	c.Info.Id = "cluster"
+
+	// Create a node
+	n := NewNodeEntry()
+	tests.Assert(t, n != nil)
+	tests.Assert(t, n.State == api.EntryStateOnline)
+
+	// Initialize node
+	n.Info.Id = "node"
+	n.Info.ClusterId = "cluster"
+	n.Devices = sort.StringSlice{"d1"}
+
+	// Create device entry
+	d := NewDeviceEntry()
+	d.Info.Id = "d1"
+	d.Info.Name = "/d1"
+	d.NodeId = "node"
+
+	// Add to allocator
+	mockAllocator.AddDevice(c, n, d)
+
+	// Save in db
+	app.db.Update(func(tx *bolt.Tx) error {
+		err := c.Save(tx)
+		tests.Assert(t, err == nil)
+
+		err = n.Save(tx)
+		tests.Assert(t, err == nil)
+
+		err = d.Save(tx)
+		tests.Assert(t, err == nil)
+
+		// Check ring
+		tests.Assert(t, len(mockAllocator.clustermap[c.Info.Id]) == 1)
+		tests.Assert(t, mockAllocator.clustermap[c.Info.Id][0] == d.Info.Id)
+
+		// Set offline
+		err = d.SetState(tx, mockAllocator, api.EntryStateOffline)
+		tests.Assert(t, d.State == api.EntryStateOffline)
+		tests.Assert(t, err == nil)
+
+		// Check it was removed from ring
+		tests.Assert(t, len(mockAllocator.clustermap[c.Info.Id]) == 0)
+
+		// Set offline again
+		err = d.SetState(tx, mockAllocator, api.EntryStateOffline)
+		tests.Assert(t, d.State == api.EntryStateOffline)
+		tests.Assert(t, err == nil)
+
+		// Set online
+		err = d.SetState(tx, mockAllocator, api.EntryStateOnline)
+		tests.Assert(t, d.State == api.EntryStateOnline)
+		tests.Assert(t, err == nil)
+		tests.Assert(t, len(mockAllocator.clustermap[c.Info.Id]) == 1)
+		tests.Assert(t, mockAllocator.clustermap[c.Info.Id][0] == d.Info.Id)
+
+		return nil
+
+	})
 }

--- a/apps/glusterfs/entry.go
+++ b/apps/glusterfs/entry.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2015 The heketi Authors
+// Copyright (c) 2016 The heketi Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,138 +17,17 @@
 package glusterfs
 
 import (
-	"github.com/boltdb/bolt"
-	"github.com/lpabon/godbc"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
-type DbEntry interface {
-	BucketName() string
-	Marshal() ([]byte, error)
-	Unmarshal(buffer []byte) error
+type Entry struct {
+	State api.EntryState
 }
 
-// Checks if the key already exists in the database.  If it does not exist,
-// then it will save the key value pair in the datababucket se
-func EntryRegister(tx *bolt.Tx, entry DbEntry, key string, value []byte) ([]byte, error) {
-	godbc.Require(tx != nil)
-	godbc.Require(len(key) > 0)
-
-	// Access bucket
-	b := tx.Bucket([]byte(entry.BucketName()))
-	if b == nil {
-		err := ErrDbAccess
-		logger.Err(err)
-		return nil, err
-	}
-
-	// Check if key exists already
-	val := b.Get([]byte(key))
-	if val != nil {
-		return val, ErrKeyExists
-	}
-
-	// Key does not exist.  We can save it
-	err := b.Put([]byte(key), value)
-	if err != nil {
-		logger.Err(err)
-		return nil, err
-	}
-
-	return nil, nil
+func (e *Entry) isOnline() bool {
+	return e.State == api.EntryStateOnline
 }
 
-func EntryKeys(tx *bolt.Tx, bucket string) []string {
-	list := make([]string, 0)
-
-	// Get all the cluster ids from the DB
-	b := tx.Bucket([]byte(bucket))
-	if b == nil {
-		return nil
-	}
-
-	err := b.ForEach(func(k, v []byte) error {
-		list = append(list, string(k))
-		return nil
-	})
-	if err != nil {
-		return nil
-	}
-
-	return list
-}
-
-func EntrySave(tx *bolt.Tx, entry DbEntry, key string) error {
-	godbc.Require(tx != nil)
-	godbc.Require(len(key) > 0)
-
-	// Access bucket
-	b := tx.Bucket([]byte(entry.BucketName()))
-	if b == nil {
-		err := ErrDbAccess
-		logger.Err(err)
-		return err
-	}
-
-	// Save device entry to db
-	buffer, err := entry.Marshal()
-	if err != nil {
-		logger.Err(err)
-		return err
-	}
-
-	// Save data using the id as the key
-	err = b.Put([]byte(key), buffer)
-	if err != nil {
-		logger.Err(err)
-		return err
-	}
-
-	return nil
-}
-
-func EntryDelete(tx *bolt.Tx, entry DbEntry, key string) error {
-	godbc.Require(tx != nil)
-	godbc.Require(len(key) > 0)
-
-	// Access bucket
-	b := tx.Bucket([]byte(entry.BucketName()))
-	if b == nil {
-		err := ErrDbAccess
-		logger.Err(err)
-		return err
-	}
-
-	// Delete key
-	err := b.Delete([]byte(key))
-	if err != nil {
-		logger.LogError("Unable to delete key [%v] in db: %v", key, err.Error())
-		return err
-	}
-
-	return nil
-}
-
-func EntryLoad(tx *bolt.Tx, entry DbEntry, key string) error {
-	godbc.Require(tx != nil)
-	godbc.Require(len(key) > 0)
-
-	b := tx.Bucket([]byte(entry.BucketName()))
-	if b == nil {
-		err := ErrDbAccess
-		logger.Err(err)
-		return err
-	}
-
-	val := b.Get([]byte(key))
-	if val == nil {
-		return ErrNotFound
-	}
-
-	err := entry.Unmarshal(val)
-	if err != nil {
-		logger.Err(err)
-		return err
-	}
-
-	return nil
+func (e *Entry) SetOnline() {
+	e.State = api.EntryStateOnline
 }

--- a/apps/glusterfs/entry_test.go
+++ b/apps/glusterfs/entry_test.go
@@ -17,70 +17,25 @@
 package glusterfs
 
 import (
-	"github.com/boltdb/bolt"
-	"github.com/heketi/tests"
-	"os"
 	"testing"
-	"time"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/tests"
 )
 
-type testDbEntry struct {
-}
+func TestEntryStates(t *testing.T) {
+	e := &Entry{}
 
-func (t *testDbEntry) BucketName() string {
-	return "TestBucket"
-}
+	tests.Assert(t, e.State == api.EntryStateUnknown)
+	tests.Assert(t, e.isOnline() == false)
 
-func (t *testDbEntry) Marshal() ([]byte, error) {
-	return nil, nil
-}
+	e.State = api.EntryStateOnline
+	tests.Assert(t, e.isOnline())
 
-func (t *testDbEntry) Unmarshal(data []byte) error {
-	return nil
-}
+	e.State = api.EntryStateOffline
+	tests.Assert(t, e.isOnline() == false)
 
-func TestEntryRegister(t *testing.T) {
-	tmpfile := tests.Tempfile()
-
-	// Setup BoltDB database
-	db, err := bolt.Open(tmpfile, 0600, &bolt.Options{Timeout: 3 * time.Second})
-	tests.Assert(t, err == nil)
-	defer os.Remove(tmpfile)
-
-	// Create a bucket
-	entry := &testDbEntry{}
-	err = db.Update(func(tx *bolt.Tx) error {
-
-		// Create Cluster Bucket
-		_, err := tx.CreateBucketIfNotExists([]byte(entry.BucketName()))
-		tests.Assert(t, err == nil)
-
-		// Register a value
-		_, err = EntryRegister(tx, entry, "mykey", []byte("myvalue"))
-		tests.Assert(t, err == nil)
-
-		return nil
-	})
-	tests.Assert(t, err == nil)
-
-	// Try to write key again
-	err = db.Update(func(tx *bolt.Tx) error {
-
-		// Save again, it should not work
-		val, err := EntryRegister(tx, entry, "mykey", []byte("myvalue"))
-		tests.Assert(t, err == ErrKeyExists)
-		tests.Assert(t, string(val) == "myvalue")
-
-		// Remove key
-		err = EntryDelete(tx, entry, "mykey")
-		tests.Assert(t, err == nil)
-
-		// Register again
-		_, err = EntryRegister(tx, entry, "mykey", []byte("myvalue"))
-		tests.Assert(t, err == nil)
-
-		return nil
-	})
-	tests.Assert(t, err == nil)
+	e.State = api.EntryStateFailed
+	tests.Assert(t, e.isOnline() == false)
 
 }

--- a/apps/glusterfs/node_entry_test.go
+++ b/apps/glusterfs/node_entry_test.go
@@ -17,18 +17,21 @@
 package glusterfs
 
 import (
-	"github.com/boltdb/bolt"
-	"github.com/heketi/tests"
-	"github.com/heketi/utils"
 	"os"
 	"reflect"
+	"sort"
 	"testing"
+
+	"github.com/boltdb/bolt"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/tests"
+	"github.com/heketi/utils"
 )
 
 func createSampleNodeEntry() *NodeEntry {
-	req := &NodeAddRequest{
+	req := &api.NodeAddRequest{
 		ClusterId: "123",
-		Hostnames: HostAddresses{
+		Hostnames: api.HostAddresses{
 			Manage:  []string{"manage" + utils.GenUUID()[:8]},
 			Storage: []string{"storage" + utils.GenUUID()[:8]},
 		},
@@ -48,9 +51,9 @@ func TestNewNodeEntry(t *testing.T) {
 }
 
 func TestNewNodeEntryFromRequest(t *testing.T) {
-	req := &NodeAddRequest{
+	req := &api.NodeAddRequest{
 		ClusterId: "123",
-		Hostnames: HostAddresses{
+		Hostnames: api.HostAddresses{
 			Manage:  []string{"manage"},
 			Storage: []string{"storage"},
 		},
@@ -70,9 +73,9 @@ func TestNewNodeEntryFromRequest(t *testing.T) {
 }
 
 func TestNewNodeEntryMarshal(t *testing.T) {
-	req := &NodeAddRequest{
+	req := &api.NodeAddRequest{
 		ClusterId: "123",
-		Hostnames: HostAddresses{
+		Hostnames: api.HostAddresses{
 			Manage:  []string{"manage"},
 			Storage: []string{"storage"},
 		},
@@ -127,9 +130,9 @@ func TestNodeEntryRegister(t *testing.T) {
 	defer app.Close()
 
 	// Create a node
-	req := &NodeAddRequest{
+	req := &api.NodeAddRequest{
 		ClusterId: "123",
-		Hostnames: HostAddresses{
+		Hostnames: api.HostAddresses{
 			Manage:  []string{"manage"},
 			Storage: []string{"storage"},
 		},
@@ -156,9 +159,9 @@ func TestNodeEntryRegister(t *testing.T) {
 	tests.Assert(t, err != nil)
 
 	// Create a new node on *different* cluster
-	req = &NodeAddRequest{
+	req = &api.NodeAddRequest{
 		ClusterId: "abc",
-		Hostnames: HostAddresses{
+		Hostnames: api.HostAddresses{
 			// Same name as previous
 			Manage:  []string{"manage"},
 			Storage: []string{"storage"},
@@ -177,9 +180,9 @@ func TestNodeEntryRegister(t *testing.T) {
 	tests.Assert(t, err != nil)
 
 	// Add a new node
-	req = &NodeAddRequest{
+	req = &api.NodeAddRequest{
 		ClusterId: "3",
-		Hostnames: HostAddresses{
+		Hostnames: api.HostAddresses{
 			Manage:  []string{"manage2"},
 			Storage: []string{"storage2"},
 		},
@@ -241,9 +244,9 @@ func TestNewNodeEntryFromId(t *testing.T) {
 	defer app.Close()
 
 	// Create a node
-	req := &NodeAddRequest{
+	req := &api.NodeAddRequest{
 		ClusterId: "123",
-		Hostnames: HostAddresses{
+		Hostnames: api.HostAddresses{
 			Manage:  []string{"manage"},
 			Storage: []string{"storage"},
 		},
@@ -284,9 +287,9 @@ func TestNewNodeEntrySaveDelete(t *testing.T) {
 	defer app.Close()
 
 	// Create a node
-	req := &NodeAddRequest{
+	req := &api.NodeAddRequest{
 		ClusterId: "123",
-		Hostnames: HostAddresses{
+		Hostnames: api.HostAddresses{
 			Manage:  []string{"manage"},
 			Storage: []string{"storage"},
 		},
@@ -383,9 +386,9 @@ func TestNewNodeEntryNewInfoResponse(t *testing.T) {
 	defer app.Close()
 
 	// Create a node
-	req := &NodeAddRequest{
+	req := &api.NodeAddRequest{
 		ClusterId: "123",
-		Hostnames: HostAddresses{
+		Hostnames: api.HostAddresses{
 			Manage:  []string{"manage"},
 			Storage: []string{"storage"},
 		},
@@ -400,7 +403,7 @@ func TestNewNodeEntryNewInfoResponse(t *testing.T) {
 	})
 	tests.Assert(t, err == nil)
 
-	var info *NodeInfoResponse
+	var info *api.NodeInfoResponse
 	err = app.db.View(func(tx *bolt.Tx) error {
 		node, err := NewNodeEntryFromId(tx, n.Info.Id)
 		if err != nil {
@@ -424,4 +427,159 @@ func TestNewNodeEntryNewInfoResponse(t *testing.T) {
 	tests.Assert(t, len(info.Hostnames.Storage) == 1)
 	tests.Assert(t, reflect.DeepEqual(info.Hostnames.Manage, n.Info.Hostnames.Manage))
 	tests.Assert(t, reflect.DeepEqual(info.Hostnames.Storage, n.Info.Hostnames.Storage))
+}
+
+func TestNodeSetStateFailed(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	// Create allocator
+	mockAllocator := NewMockAllocator(app.db)
+	app.allocator = mockAllocator
+
+	// Create cluster entry
+	c := NewClusterEntry()
+	c.Info.Id = "cluster"
+
+	// Create a node
+	n := NewNodeEntry()
+	tests.Assert(t, n != nil)
+	tests.Assert(t, n.State == api.EntryStateOnline)
+
+	// Initialize node
+	n.Info.Id = "node"
+	n.Info.ClusterId = "cluster"
+	n.Devices = sort.StringSlice{"d1"}
+
+	// Create device entry
+	d := NewDeviceEntry()
+	d.Info.Id = "d1"
+	d.Info.Name = "/d1"
+	d.NodeId = "node"
+
+	// Add to allocator
+	mockAllocator.AddDevice(c, n, d)
+
+	// Save in db
+	app.db.Update(func(tx *bolt.Tx) error {
+		err := c.Save(tx)
+		tests.Assert(t, err == nil)
+
+		err = n.Save(tx)
+		tests.Assert(t, err == nil)
+
+		err = d.Save(tx)
+		tests.Assert(t, err == nil)
+
+		// Check ring
+		tests.Assert(t, len(mockAllocator.clustermap[c.Info.Id]) == 1)
+		tests.Assert(t, mockAllocator.clustermap[c.Info.Id][0] == d.Info.Id)
+
+		// Set failed
+		err = n.SetState(tx, mockAllocator, api.EntryStateFailed)
+		tests.Assert(t, n.State == api.EntryStateFailed)
+		tests.Assert(t, err == nil)
+
+		// Check it was removed from ring
+		tests.Assert(t, len(mockAllocator.clustermap[c.Info.Id]) == 0)
+
+		// Set failed again
+		err = n.SetState(tx, mockAllocator, api.EntryStateFailed)
+		tests.Assert(t, n.State == api.EntryStateFailed)
+		tests.Assert(t, err == nil)
+
+		// Set offline
+		err = n.SetState(tx, mockAllocator, api.EntryStateOffline)
+		tests.Assert(t, n.State == api.EntryStateFailed)
+		tests.Assert(t, err != nil)
+		tests.Assert(t, len(mockAllocator.clustermap[c.Info.Id]) == 0)
+
+		// Set online
+		err = n.SetState(tx, mockAllocator, api.EntryStateOnline)
+		tests.Assert(t, n.State == api.EntryStateFailed)
+		tests.Assert(t, err != nil)
+		tests.Assert(t, len(mockAllocator.clustermap[c.Info.Id]) == 0)
+
+		return nil
+
+	})
+}
+
+func TestNodeSetStateOfflineOnline(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	// Create allocator
+	mockAllocator := NewMockAllocator(app.db)
+	app.allocator = mockAllocator
+
+	// Create cluster entry
+	c := NewClusterEntry()
+	c.Info.Id = "cluster"
+
+	// Create a node
+	n := NewNodeEntry()
+	tests.Assert(t, n != nil)
+	tests.Assert(t, n.State == api.EntryStateOnline)
+
+	// Initialize node
+	n.Info.Id = "node"
+	n.Info.ClusterId = "cluster"
+	n.Devices = sort.StringSlice{"d1"}
+
+	// Create device entry
+	d := NewDeviceEntry()
+	d.Info.Id = "d1"
+	d.Info.Name = "/d1"
+	d.NodeId = "node"
+
+	// Add to allocator
+	mockAllocator.AddDevice(c, n, d)
+
+	// Save in db
+	app.db.Update(func(tx *bolt.Tx) error {
+		err := c.Save(tx)
+		tests.Assert(t, err == nil)
+
+		err = n.Save(tx)
+		tests.Assert(t, err == nil)
+
+		err = d.Save(tx)
+		tests.Assert(t, err == nil)
+
+		// Check ring
+		tests.Assert(t, len(mockAllocator.clustermap[c.Info.Id]) == 1)
+		tests.Assert(t, mockAllocator.clustermap[c.Info.Id][0] == d.Info.Id)
+
+		// Set offline
+		err = n.SetState(tx, mockAllocator, api.EntryStateOffline)
+		tests.Assert(t, n.State == api.EntryStateOffline)
+		tests.Assert(t, err == nil)
+
+		// Check it was removed from ring
+		tests.Assert(t, len(mockAllocator.clustermap[c.Info.Id]) == 0)
+
+		// Set offline again
+		err = n.SetState(tx, mockAllocator, api.EntryStateOffline)
+		tests.Assert(t, n.State == api.EntryStateOffline)
+		tests.Assert(t, err == nil)
+
+		// Set online
+		err = n.SetState(tx, mockAllocator, api.EntryStateOnline)
+		tests.Assert(t, n.State == api.EntryStateOnline)
+		tests.Assert(t, err == nil)
+		tests.Assert(t, len(mockAllocator.clustermap[c.Info.Id]) == 1)
+		tests.Assert(t, mockAllocator.clustermap[c.Info.Id][0] == d.Info.Id)
+
+		return nil
+
+	})
 }

--- a/apps/glusterfs/volume_durability.go
+++ b/apps/glusterfs/volume_durability.go
@@ -20,12 +20,6 @@ import (
 	"github.com/heketi/heketi/executors"
 )
 
-const (
-	DURABILITY_STRING_REPLICATE       = "replicate"
-	DURABILITY_STRING_DISTRIBUTE_ONLY = "none"
-	DURABILITY_STRING_EC              = "disperse"
-)
-
 type VolumeDurability interface {
 	BrickSizeGenerator(size uint64) func() (int, uint64, error)
 	BricksInSet() int

--- a/apps/glusterfs/volume_durability_ec.go
+++ b/apps/glusterfs/volume_durability_ec.go
@@ -18,9 +18,22 @@ package glusterfs
 
 import (
 	"github.com/heketi/heketi/executors"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
-func (d *DisperseDurability) SetDurability() {
+type VolumeDisperseDurability struct {
+	api.DisperseDurability
+}
+
+func NewVolumeDisperseDurability(d *api.DisperseDurability) *VolumeDisperseDurability {
+	v := &VolumeDisperseDurability{}
+	v.Data = d.Data
+	v.Redundancy = d.Redundancy
+
+	return v
+}
+
+func (d *VolumeDisperseDurability) SetDurability() {
 	if d.Data == 0 {
 		d.Data = DEFAULT_EC_DATA
 	}
@@ -29,7 +42,7 @@ func (d *DisperseDurability) SetDurability() {
 	}
 }
 
-func (d *DisperseDurability) BrickSizeGenerator(size uint64) func() (int, uint64, error) {
+func (d *VolumeDisperseDurability) BrickSizeGenerator(size uint64) func() (int, uint64, error) {
 
 	sets := 1
 	return func() (int, uint64, error) {
@@ -55,11 +68,11 @@ func (d *DisperseDurability) BrickSizeGenerator(size uint64) func() (int, uint64
 	}
 }
 
-func (d *DisperseDurability) BricksInSet() int {
+func (d *VolumeDisperseDurability) BricksInSet() int {
 	return d.Data + d.Redundancy
 }
 
-func (d *DisperseDurability) SetExecutorVolumeRequest(v *executors.VolumeRequest) {
+func (d *VolumeDisperseDurability) SetExecutorVolumeRequest(v *executors.VolumeRequest) {
 	v.Type = executors.DurabilityDispersion
 	v.Data = d.Data
 	v.Redundancy = d.Redundancy

--- a/apps/glusterfs/volume_durability_none.go
+++ b/apps/glusterfs/volume_durability_none.go
@@ -21,7 +21,7 @@ import (
 )
 
 type NoneDurability struct {
-	ReplicaDurability
+	VolumeReplicaDurability
 }
 
 func NewNoneDurability() *NoneDurability {

--- a/apps/glusterfs/volume_durability_replica.go
+++ b/apps/glusterfs/volume_durability_replica.go
@@ -18,15 +18,27 @@ package glusterfs
 
 import (
 	"github.com/heketi/heketi/executors"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
-func (r *ReplicaDurability) SetDurability() {
+type VolumeReplicaDurability struct {
+	api.ReplicaDurability
+}
+
+func NewVolumeReplicaDurability(r *api.ReplicaDurability) *VolumeReplicaDurability {
+	v := &VolumeReplicaDurability{}
+	v.Replica = r.Replica
+
+	return v
+}
+
+func (r *VolumeReplicaDurability) SetDurability() {
 	if r.Replica == 0 {
 		r.Replica = DEFAULT_REPLICA
 	}
 }
 
-func (r *ReplicaDurability) BrickSizeGenerator(size uint64) func() (int, uint64, error) {
+func (r *VolumeReplicaDurability) BrickSizeGenerator(size uint64) func() (int, uint64, error) {
 
 	sets := 1
 	return func() (int, uint64, error) {
@@ -48,11 +60,11 @@ func (r *ReplicaDurability) BrickSizeGenerator(size uint64) func() (int, uint64,
 	}
 }
 
-func (r *ReplicaDurability) BricksInSet() int {
+func (r *VolumeReplicaDurability) BricksInSet() int {
 	return r.Replica
 }
 
-func (r *ReplicaDurability) SetExecutorVolumeRequest(v *executors.VolumeRequest) {
+func (r *VolumeReplicaDurability) SetExecutorVolumeRequest(v *executors.VolumeRequest) {
 	v.Type = executors.DurabilityReplica
 	v.Replica = r.Replica
 }

--- a/apps/glusterfs/volume_durability_test.go
+++ b/apps/glusterfs/volume_durability_test.go
@@ -17,9 +17,10 @@
 package glusterfs
 
 import (
+	"testing"
+
 	"github.com/heketi/heketi/executors"
 	"github.com/heketi/tests"
-	"testing"
 )
 
 func TestNoneDurabilityDefaults(t *testing.T) {
@@ -31,7 +32,7 @@ func TestNoneDurabilityDefaults(t *testing.T) {
 }
 
 func TestDisperseDurabilityDefaults(t *testing.T) {
-	r := &DisperseDurability{}
+	r := &VolumeDisperseDurability{}
 	tests.Assert(t, r.Data == 0)
 	tests.Assert(t, r.Redundancy == 0)
 
@@ -41,7 +42,7 @@ func TestDisperseDurabilityDefaults(t *testing.T) {
 }
 
 func TestReplicaDurabilityDefaults(t *testing.T) {
-	r := &ReplicaDurability{}
+	r := &VolumeReplicaDurability{}
 	tests.Assert(t, r.Replica == 0)
 
 	r.SetDurability()
@@ -59,7 +60,7 @@ func TestNoneDurabilitySetExecutorRequest(t *testing.T) {
 }
 
 func TestDisperseDurabilitySetExecutorRequest(t *testing.T) {
-	r := &DisperseDurability{}
+	r := &VolumeDisperseDurability{}
 	r.SetDurability()
 
 	v := &executors.VolumeRequest{}
@@ -70,7 +71,7 @@ func TestDisperseDurabilitySetExecutorRequest(t *testing.T) {
 }
 
 func TestReplicaDurabilitySetExecutorRequest(t *testing.T) {
-	r := &ReplicaDurability{}
+	r := &VolumeReplicaDurability{}
 	r.SetDurability()
 
 	v := &executors.VolumeRequest{}
@@ -123,10 +124,9 @@ func TestNoneDurability(t *testing.T) {
 
 func TestDisperseDurability(t *testing.T) {
 
-	r := &DisperseDurability{
-		Data:       8,
-		Redundancy: 3,
-	}
+	r := &VolumeDisperseDurability{}
+	r.Data = 8
+	r.Redundancy = 3
 
 	gen := r.BrickSizeGenerator(200 * GB)
 
@@ -151,10 +151,10 @@ func TestDisperseDurability(t *testing.T) {
 }
 
 func TestDisperseDurabilityLargeBrickGenerator(t *testing.T) {
-	r := &DisperseDurability{
-		Data:       8,
-		Redundancy: 3,
-	}
+	r := &VolumeDisperseDurability{}
+	r.Data = 8
+	r.Redundancy = 3
+
 	gen := r.BrickSizeGenerator(800 * TB)
 
 	// Gen 1
@@ -166,9 +166,9 @@ func TestDisperseDurabilityLargeBrickGenerator(t *testing.T) {
 }
 
 func TestReplicaDurabilityGenerator(t *testing.T) {
-	r := &ReplicaDurability{
-		Replica: 2,
-	}
+	r := &VolumeReplicaDurability{}
+	r.Replica = 2
+
 	gen := r.BrickSizeGenerator(100 * GB)
 
 	// Gen 1
@@ -208,9 +208,9 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 }
 
 func TestReplicaDurabilityLargeBrickGenerator(t *testing.T) {
-	r := &ReplicaDurability{
-		Replica: 2,
-	}
+	r := &VolumeReplicaDurability{}
+	r.Replica = 2
+
 	gen := r.BrickSizeGenerator(100 * TB)
 
 	// Gen 1

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -27,14 +27,15 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/heketi/heketi/executors"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/tests"
 	"github.com/heketi/utils"
 )
 
 func createSampleVolumeEntry(size int) *VolumeEntry {
-	req := &VolumeCreateRequest{}
+	req := &api.VolumeCreateRequest{}
 	req.Size = size
-	req.Durability.Type = DURABILITY_STRING_REPLICATE
+	req.Durability.Type = api.DurabilityReplicate
 	req.Durability.Replicate.Replica = 2
 
 	v := NewVolumeEntryFromRequest(req)
@@ -110,7 +111,7 @@ func TestNewVolumeEntry(t *testing.T) {
 
 func TestNewVolumeEntryFromRequestOnlySize(t *testing.T) {
 
-	req := &VolumeCreateRequest{}
+	req := &api.VolumeCreateRequest{}
 	req.Size = 1024
 
 	v := NewVolumeEntryFromRequest(req)
@@ -129,7 +130,7 @@ func TestNewVolumeEntryFromRequestReplica(t *testing.T) {
 
 	// :TODO: add tests for each durability
 
-	req := &VolumeCreateRequest{}
+	req := &api.VolumeCreateRequest{}
 	req.Size = 1024
 
 	v := NewVolumeEntryFromRequest(req)
@@ -146,7 +147,7 @@ func TestNewVolumeEntryFromRequestReplica(t *testing.T) {
 
 func TestNewVolumeEntryFromRequestClusters(t *testing.T) {
 
-	req := &VolumeCreateRequest{}
+	req := &api.VolumeCreateRequest{}
 	req.Size = 1024
 	req.Clusters = []string{"abc", "def"}
 
@@ -163,7 +164,7 @@ func TestNewVolumeEntryFromRequestClusters(t *testing.T) {
 
 func TestNewVolumeEntryFromRequestSnapshotEnabledDefaultFactor(t *testing.T) {
 
-	req := &VolumeCreateRequest{}
+	req := &api.VolumeCreateRequest{}
 	req.Size = 1024
 	req.Clusters = []string{"abc", "def"}
 	req.Snapshot.Enable = true
@@ -181,7 +182,7 @@ func TestNewVolumeEntryFromRequestSnapshotEnabledDefaultFactor(t *testing.T) {
 
 func TestNewVolumeEntryFromRequestSnapshotFactor(t *testing.T) {
 
-	req := &VolumeCreateRequest{}
+	req := &api.VolumeCreateRequest{}
 	req.Size = 1024
 	req.Clusters = []string{"abc", "def"}
 	req.Snapshot.Enable = true
@@ -200,7 +201,7 @@ func TestNewVolumeEntryFromRequestSnapshotFactor(t *testing.T) {
 
 func TestNewVolumeEntryFromRequestName(t *testing.T) {
 
-	req := &VolumeCreateRequest{}
+	req := &api.VolumeCreateRequest{}
 	req.Size = 1024
 	req.Clusters = []string{"abc", "def"}
 	req.Snapshot.Enable = true
@@ -220,7 +221,7 @@ func TestNewVolumeEntryFromRequestName(t *testing.T) {
 
 func TestNewVolumeEntryMarshal(t *testing.T) {
 
-	req := &VolumeCreateRequest{}
+	req := &api.VolumeCreateRequest{}
 	req.Size = 1024
 	req.Clusters = []string{"abc", "def"}
 	req.Snapshot.Enable = true
@@ -380,7 +381,7 @@ func TestNewVolumeEntryNewInfoResponse(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Retreive info response
-	var info *VolumeInfoResponse
+	var info *api.VolumeInfoResponse
 	err = app.db.View(func(tx *bolt.Tx) error {
 		volume, err := NewVolumeEntryFromId(tx, v.Info.Id)
 		if err != nil {
@@ -543,7 +544,7 @@ func TestVolumeEntryCreateFourBricks(t *testing.T) {
 	tests.Assert(t, err == nil, err)
 
 	// Check database
-	var info *VolumeInfoResponse
+	var info *api.VolumeInfoResponse
 	var nodelist sort.StringSlice
 	err = app.db.View(func(tx *bolt.Tx) error {
 		entry, err := NewVolumeEntryFromId(tx, v.Info.Id)
@@ -624,7 +625,7 @@ func TestVolumeEntryCreateBrickDivision(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Check database volume does not exist
-	var info *VolumeInfoResponse
+	var info *api.VolumeInfoResponse
 	var nodelist sort.StringSlice
 	err = app.db.View(func(tx *bolt.Tx) error {
 		entry, err := NewVolumeEntryFromId(tx, v.Info.Id)
@@ -697,7 +698,7 @@ func TestVolumeEntryCreateMaxBrickSize(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Get volume information
-	var info *VolumeInfoResponse
+	var info *api.VolumeInfoResponse
 	err = app.db.View(func(tx *bolt.Tx) error {
 		entry, err := NewVolumeEntryFromId(tx, v.Info.Id)
 		if err != nil {
@@ -761,7 +762,7 @@ func TestVolumeEntryCreateOnClustersRequested(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Check database volume does not exist
-	var info *VolumeInfoResponse
+	var info *api.VolumeInfoResponse
 	err = app.db.View(func(tx *bolt.Tx) error {
 		entry, err := NewVolumeEntryFromId(tx, v.Info.Id)
 		if err != nil {
@@ -870,7 +871,7 @@ func TestVolumeEntryCreateCheckingClustersForSpace(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Check database volume exists
-	var info *VolumeInfoResponse
+	var info *api.VolumeInfoResponse
 	err = app.db.View(func(tx *bolt.Tx) error {
 		entry, err := NewVolumeEntryFromId(tx, v.Info.Id)
 		if err != nil {
@@ -917,7 +918,7 @@ func TestVolumeEntryCreateWithSnapshot(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Check database volume exists
-	var info *VolumeInfoResponse
+	var info *api.VolumeInfoResponse
 	err = app.db.View(func(tx *bolt.Tx) error {
 		entry, err := NewVolumeEntryFromId(tx, v.Info.Id)
 		if err != nil {

--- a/client/api/go-client/client.go
+++ b/client/api/go-client/client.go
@@ -19,18 +19,15 @@ package client
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/heketi/heketi/apps/glusterfs"
-	"github.com/heketi/utils"
 	"net/http"
 	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/heketi/utils"
 )
 
 const (
-	MAX_CONCURRENT_REQUESTS                  = 32
-	VOLUME_CREATE_DURABILITY_TYPE_DISPERSION = glusterfs.DURABILITY_STRING_EC
-	VOLUME_CREATE_DURABILITY_TYPE_REPLICATE  = glusterfs.DURABILITY_STRING_REPLICATE
-	VOLUME_CREATE_DURABILITY_TYPE_NONE       = glusterfs.DURABILITY_STRING_DISTRIBUTE_ONLY
+	MAX_CONCURRENT_REQUESTS = 32
 )
 
 // Client object

--- a/client/api/go-client/client_test.go
+++ b/client/api/go-client/client_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/heketi/heketi/apps/glusterfs"
 	"github.com/heketi/heketi/middleware"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/tests"
 	"github.com/heketi/utils"
 )
@@ -70,7 +71,7 @@ func TestTopology(t *testing.T) {
 	tests.Assert(t, c != nil)
 
 	//Create multiple clusters
-	clusteridlist := make([]glusterfs.ClusterInfoResponse, 0)
+	clusteridlist := make([]api.ClusterInfoResponse, 0)
 	for m := 0; m < 4; m++ {
 		cluster, err := c.ClusterCreate()
 		tests.Assert(t, err == nil)
@@ -106,9 +107,9 @@ func TestTopology(t *testing.T) {
 	tests.Assert(t, topology.ClusterList[0].Id == cluster.Id)
 
 	// Create multiple nodes and add devices to the nodes
-	nodeinfos := make([]glusterfs.NodeInfoResponse, 0)
+	nodeinfos := make([]api.NodeInfoResponse, 0)
 	for n := 0; n < 4; n++ {
-		nodeReq := &glusterfs.NodeAddRequest{}
+		nodeReq := &api.NodeAddRequest{}
 		nodeReq.ClusterId = cluster.Id
 		nodeReq.Hostnames.Manage = []string{"manage" + fmt.Sprintf("%v", n)}
 		nodeReq.Hostnames.Storage = []string{"storage" + fmt.Sprintf("%v", n)}
@@ -126,7 +127,7 @@ func TestTopology(t *testing.T) {
 			go func() {
 				defer sg.Done()
 
-				deviceReq := &glusterfs.DeviceAddRequest{}
+				deviceReq := &api.DeviceAddRequest{}
 				deviceReq.Name = "sd" + utils.GenUUID()[:8]
 				deviceReq.NodeId = node.Id
 
@@ -145,9 +146,9 @@ func TestTopology(t *testing.T) {
 	tests.Assert(t, len(list.Volumes) == 0)
 
 	//Create multiple volumes to the cluster
-	volumeinfos := make([]glusterfs.VolumeInfoResponse, 0)
+	volumeinfos := make([]api.VolumeInfoResponse, 0)
 	for n := 0; n < 4; n++ {
-		volumeReq := &glusterfs.VolumeCreateRequest{}
+		volumeReq := &api.VolumeCreateRequest{}
 		volumeReq.Size = 10
 		volume, err := c.VolumeCreate(volumeReq)
 		tests.Assert(t, err == nil)
@@ -298,7 +299,7 @@ func TestClientNode(t *testing.T) {
 	tests.Assert(t, len(cluster.Volumes) == 0)
 
 	// Add node to unknown cluster
-	nodeReq := &glusterfs.NodeAddRequest{}
+	nodeReq := &api.NodeAddRequest{}
 	nodeReq.ClusterId = "badid"
 	nodeReq.Hostnames.Manage = []string{"manage"}
 	nodeReq.Hostnames.Storage = []string{"storage"}
@@ -311,6 +312,7 @@ func TestClientNode(t *testing.T) {
 	node, err := c.NodeAdd(nodeReq)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, node.Zone == nodeReq.Zone)
+	tests.Assert(t, node.State == api.EntryStateOnline)
 	tests.Assert(t, node.Id != "")
 	tests.Assert(t, reflect.DeepEqual(nodeReq.Hostnames, node.Hostnames))
 	tests.Assert(t, len(node.DevicesInfo) == 0)
@@ -320,9 +322,27 @@ func TestClientNode(t *testing.T) {
 	tests.Assert(t, err != nil)
 	tests.Assert(t, info == nil)
 
+	// Set offline
+	err = c.NodeState(node.Id, &api.StateRequest{
+		State: api.EntryStateOffline,
+	})
+	tests.Assert(t, err == nil)
+
 	// Get node info
 	info, err = c.NodeInfo(node.Id)
 	tests.Assert(t, err == nil)
+	tests.Assert(t, info.State == api.EntryStateOffline)
+
+	// Set online
+	err = c.NodeState(node.Id, &api.StateRequest{
+		State: api.EntryStateOnline,
+	})
+	tests.Assert(t, err == nil)
+
+	// Get node info
+	info, err = c.NodeInfo(node.Id)
+	tests.Assert(t, err == nil)
+	tests.Assert(t, info.State == api.EntryStateOnline)
 	tests.Assert(t, reflect.DeepEqual(info, node))
 
 	// Delete invalid node
@@ -362,7 +382,7 @@ func TestClientDevice(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Create node request packet
-	nodeReq := &glusterfs.NodeAddRequest{}
+	nodeReq := &api.NodeAddRequest{}
 	nodeReq.ClusterId = cluster.Id
 	nodeReq.Hostnames.Manage = []string{"manage"}
 	nodeReq.Hostnames.Storage = []string{"storage"}
@@ -373,7 +393,7 @@ func TestClientDevice(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Create a device request
-	deviceReq := &glusterfs.DeviceAddRequest{}
+	deviceReq := &api.DeviceAddRequest{}
 	deviceReq.Name = "sda"
 	deviceReq.NodeId = node.Id
 
@@ -394,9 +414,29 @@ func TestClientDevice(t *testing.T) {
 	tests.Assert(t, err != nil)
 
 	// Get device information
-	deviceInfo, err := c.DeviceInfo(info.DevicesInfo[0].Id)
+	deviceId := info.DevicesInfo[0].Id
+	deviceInfo, err := c.DeviceInfo(deviceId)
 	tests.Assert(t, err == nil)
+	tests.Assert(t, deviceInfo.State == api.EntryStateOnline)
 	tests.Assert(t, reflect.DeepEqual(*deviceInfo, info.DevicesInfo[0]))
+
+	// Set offline
+	err = c.DeviceState(deviceId, &api.StateRequest{
+		State: api.EntryStateOffline,
+	})
+	tests.Assert(t, err == nil)
+	deviceInfo, err = c.DeviceInfo(deviceId)
+	tests.Assert(t, err == nil)
+	tests.Assert(t, deviceInfo.State == api.EntryStateOffline)
+
+	// Set online
+	err = c.DeviceState(deviceId, &api.StateRequest{
+		State: api.EntryStateOnline,
+	})
+	tests.Assert(t, err == nil)
+	deviceInfo, err = c.DeviceInfo(deviceId)
+	tests.Assert(t, err == nil)
+	tests.Assert(t, deviceInfo.State == api.EntryStateOnline)
 
 	// Try to delete node, and will not until we delete the device
 	err = c.NodeDelete(node.Id)
@@ -440,7 +480,7 @@ func TestClientVolume(t *testing.T) {
 
 	// Create node request packet
 	for n := 0; n < 4; n++ {
-		nodeReq := &glusterfs.NodeAddRequest{}
+		nodeReq := &api.NodeAddRequest{}
 		nodeReq.ClusterId = cluster.Id
 		nodeReq.Hostnames.Manage = []string{"manage" + fmt.Sprintf("%v", n)}
 		nodeReq.Hostnames.Storage = []string{"storage" + fmt.Sprintf("%v", n)}
@@ -457,7 +497,7 @@ func TestClientVolume(t *testing.T) {
 			go func() {
 				defer sg.Done()
 
-				deviceReq := &glusterfs.DeviceAddRequest{}
+				deviceReq := &api.DeviceAddRequest{}
 				deviceReq.Name = "sd" + utils.GenUUID()[:8]
 				deviceReq.NodeId = node.Id
 
@@ -476,7 +516,7 @@ func TestClientVolume(t *testing.T) {
 	tests.Assert(t, len(list.Volumes) == 0)
 
 	// Create a volume
-	volumeReq := &glusterfs.VolumeCreateRequest{}
+	volumeReq := &api.VolumeCreateRequest{}
 	volumeReq.Size = 10
 	volume, err := c.VolumeCreate(volumeReq)
 	tests.Assert(t, err == nil)
@@ -499,7 +539,7 @@ func TestClientVolume(t *testing.T) {
 	tests.Assert(t, reflect.DeepEqual(info, volume))
 
 	// Expand volume with a bad id
-	expandReq := &glusterfs.VolumeExpandRequest{}
+	expandReq := &api.VolumeExpandRequest{}
 	expandReq.Size = 10
 	volumeInfo, err := c.VolumeExpand("badid", expandReq)
 	tests.Assert(t, err != nil)

--- a/client/api/go-client/cluster.go
+++ b/client/api/go-client/cluster.go
@@ -18,12 +18,12 @@ package client
 
 import (
 	"bytes"
-	"github.com/heketi/heketi/apps/glusterfs"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/utils"
 	"net/http"
 )
 
-func (c *Client) ClusterCreate() (*glusterfs.ClusterInfoResponse, error) {
+func (c *Client) ClusterCreate() (*api.ClusterInfoResponse, error) {
 
 	// Create a request
 	req, err := http.NewRequest("POST", c.host+"/clusters", bytes.NewBuffer([]byte(`{}`)))
@@ -48,7 +48,7 @@ func (c *Client) ClusterCreate() (*glusterfs.ClusterInfoResponse, error) {
 	}
 
 	// Read JSON response
-	var cluster glusterfs.ClusterInfoResponse
+	var cluster api.ClusterInfoResponse
 	err = utils.GetJsonFromResponse(r, &cluster)
 	r.Body.Close()
 	if err != nil {
@@ -58,7 +58,7 @@ func (c *Client) ClusterCreate() (*glusterfs.ClusterInfoResponse, error) {
 	return &cluster, nil
 }
 
-func (c *Client) ClusterInfo(id string) (*glusterfs.ClusterInfoResponse, error) {
+func (c *Client) ClusterInfo(id string) (*api.ClusterInfoResponse, error) {
 
 	// Create request
 	req, err := http.NewRequest("GET", c.host+"/clusters/"+id, nil)
@@ -82,7 +82,7 @@ func (c *Client) ClusterInfo(id string) (*glusterfs.ClusterInfoResponse, error) 
 	}
 
 	// Read JSON response
-	var cluster glusterfs.ClusterInfoResponse
+	var cluster api.ClusterInfoResponse
 	err = utils.GetJsonFromResponse(r, &cluster)
 	r.Body.Close()
 	if err != nil {
@@ -92,7 +92,7 @@ func (c *Client) ClusterInfo(id string) (*glusterfs.ClusterInfoResponse, error) 
 	return &cluster, nil
 }
 
-func (c *Client) ClusterList() (*glusterfs.ClusterListResponse, error) {
+func (c *Client) ClusterList() (*api.ClusterListResponse, error) {
 
 	// Create request
 	req, err := http.NewRequest("GET", c.host+"/clusters", nil)
@@ -116,7 +116,7 @@ func (c *Client) ClusterList() (*glusterfs.ClusterListResponse, error) {
 	}
 
 	// Read JSON response
-	var clusters glusterfs.ClusterListResponse
+	var clusters api.ClusterListResponse
 	err = utils.GetJsonFromResponse(r, &clusters)
 	if err != nil {
 		return nil, err

--- a/client/api/go-client/topology.go
+++ b/client/api/go-client/topology.go
@@ -16,11 +16,13 @@
 
 package client
 
-import "github.com/heketi/heketi/apps/glusterfs"
+import (
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+)
 
-func (c *Client) TopologyInfo() (*glusterfs.TopologyInfoResponse, error) {
-	topo := &glusterfs.TopologyInfoResponse{
-		ClusterList: make([]glusterfs.Cluster, 0),
+func (c *Client) TopologyInfo() (*api.TopologyInfoResponse, error) {
+	topo := &api.TopologyInfoResponse{
+		ClusterList: make([]api.Cluster, 0),
 	}
 	clusterlist, err := c.ClusterList()
 	if err != nil {
@@ -31,10 +33,10 @@ func (c *Client) TopologyInfo() (*glusterfs.TopologyInfoResponse, error) {
 		if err != nil {
 			return nil, err
 		}
-		cluster := glusterfs.Cluster{
+		cluster := api.Cluster{
 			Id:      clusteri.Id,
-			Volumes: make([]glusterfs.VolumeInfoResponse, 0),
-			Nodes:   make([]glusterfs.NodeInfoResponse, 0),
+			Volumes: make([]api.VolumeInfoResponse, 0),
+			Nodes:   make([]api.NodeInfoResponse, 0),
 		}
 		cluster.Id = clusteri.Id
 

--- a/client/api/go-client/volume.go
+++ b/client/api/go-client/volume.go
@@ -19,14 +19,15 @@ package client
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/heketi/heketi/apps/glusterfs"
-	"github.com/heketi/utils"
 	"net/http"
 	"time"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/utils"
 )
 
-func (c *Client) VolumeCreate(request *glusterfs.VolumeCreateRequest) (
-	*glusterfs.VolumeInfoResponse, error) {
+func (c *Client) VolumeCreate(request *api.VolumeCreateRequest) (
+	*api.VolumeInfoResponse, error) {
 
 	// Marshal request to JSON
 	buffer, err := json.Marshal(request)
@@ -68,7 +69,7 @@ func (c *Client) VolumeCreate(request *glusterfs.VolumeCreateRequest) (
 	}
 
 	// Read JSON response
-	var volume glusterfs.VolumeInfoResponse
+	var volume api.VolumeInfoResponse
 	err = utils.GetJsonFromResponse(r, &volume)
 	r.Body.Close()
 	if err != nil {
@@ -79,8 +80,8 @@ func (c *Client) VolumeCreate(request *glusterfs.VolumeCreateRequest) (
 
 }
 
-func (c *Client) VolumeExpand(id string, request *glusterfs.VolumeExpandRequest) (
-	*glusterfs.VolumeInfoResponse, error) {
+func (c *Client) VolumeExpand(id string, request *api.VolumeExpandRequest) (
+	*api.VolumeInfoResponse, error) {
 
 	// Marshal request to JSON
 	buffer, err := json.Marshal(request)
@@ -122,7 +123,7 @@ func (c *Client) VolumeExpand(id string, request *glusterfs.VolumeExpandRequest)
 	}
 
 	// Read JSON response
-	var volume glusterfs.VolumeInfoResponse
+	var volume api.VolumeInfoResponse
 	err = utils.GetJsonFromResponse(r, &volume)
 	r.Body.Close()
 	if err != nil {
@@ -133,7 +134,7 @@ func (c *Client) VolumeExpand(id string, request *glusterfs.VolumeExpandRequest)
 
 }
 
-func (c *Client) VolumeList() (*glusterfs.VolumeListResponse, error) {
+func (c *Client) VolumeList() (*api.VolumeListResponse, error) {
 
 	// Create request
 	req, err := http.NewRequest("GET", c.host+"/volumes", nil)
@@ -157,7 +158,7 @@ func (c *Client) VolumeList() (*glusterfs.VolumeListResponse, error) {
 	}
 
 	// Read JSON response
-	var volumes glusterfs.VolumeListResponse
+	var volumes api.VolumeListResponse
 	err = utils.GetJsonFromResponse(r, &volumes)
 	if err != nil {
 		return nil, err
@@ -166,7 +167,7 @@ func (c *Client) VolumeList() (*glusterfs.VolumeListResponse, error) {
 	return &volumes, nil
 }
 
-func (c *Client) VolumeInfo(id string) (*glusterfs.VolumeInfoResponse, error) {
+func (c *Client) VolumeInfo(id string) (*api.VolumeInfoResponse, error) {
 
 	// Create request
 	req, err := http.NewRequest("GET", c.host+"/volumes/"+id, nil)
@@ -190,7 +191,7 @@ func (c *Client) VolumeInfo(id string) (*glusterfs.VolumeInfoResponse, error) {
 	}
 
 	// Read JSON response
-	var volume glusterfs.VolumeInfoResponse
+	var volume api.VolumeInfoResponse
 	err = utils.GetJsonFromResponse(r, &volume)
 	r.Body.Close()
 	if err != nil {

--- a/client/api/python/heketi/heketi.py
+++ b/client/api/python/heketi/heketi.py
@@ -144,6 +144,11 @@ class HeketiClient(object):
         req = self._make_request('DELETE', uri)
         return req.status_code == requests.codes.NO_CONTENT
 
+    def node_state(self, node_id, state_request={}):
+        uri = '/nodes/' + node_id + '/state'
+        req = self._make_request('POST', uri, state_request)
+        return req.status_code == requests.codes.ok
+
     def device_add(self, device_options={}):
         ''' device_options is a dict with parameters to be passed \
             in the json request: \
@@ -163,6 +168,11 @@ class HeketiClient(object):
         uri = '/devices/' + device_id
         req = self._make_request('DELETE', uri)
         return req.status_code == requests.codes.NO_CONTENT
+
+    def device_state(self, device_id, state_request={}):
+        uri = "/devices/" + device_id + "/state"
+        req = self._make_request('POST', uri, state_request)
+        return req.status_code == requests.codes.ok
 
     def volume_create(self, volume_options={}):
         ''' volume_options is a dict with volume creation options:

--- a/client/api/python/test/unit/test_client.py
+++ b/client/api/python/test/unit/test_client.py
@@ -91,6 +91,22 @@ class test_heketi(unittest.TestCase):
         # Get node info
         info = c.node_info(node['id'])
         self.assertEqual(True, info == node)
+        self.assertEqual(info['state'], 'online')
+
+        # Set offline
+        state = {}
+        state['state'] = 'offline'
+        self.assertEqual(True, c.node_state(node['id'], state))
+
+        # Get node info
+        info = c.node_info(node['id'])
+        self.assertEqual(info['state'], 'offline')
+
+        state['state'] = 'online'
+        self.assertEqual(True, c.node_state(node['id'], state))
+
+        info = c.node_info(node['id'])
+        self.assertEqual(info['state'], 'online')
 
         # Delete invalid node
         with self.assertRaises(requests.exceptions.HTTPError):
@@ -149,8 +165,24 @@ class test_heketi(unittest.TestCase):
             c.device_info("badid")
 
         # Get device information
-        device_info = c.device_info(info['devices'][0]['id'])
+        device_id = info['devices'][0]['id']
+        device_info = c.device_info(device_id)
         self.assertEqual(True, device_info == info['devices'][0])
+
+        # Set offline
+        state = {}
+        state['state'] = 'offline'
+        self.assertEqual(True, c.device_state(device_id, state))
+
+        # Get device info
+        info = c.device_info(device_id)
+        self.assertEqual(info['state'], 'offline')
+
+        state['state'] = 'online'
+        self.assertEqual(True, c.device_state(device_id, state))
+
+        info = c.device_info(device_id)
+        self.assertEqual(info['state'], 'online')
 
         # Try to delete node, and will not until we delete the device
         with self.assertRaises(requests.exceptions.HTTPError):

--- a/client/api/python/unittests.sh
+++ b/client/api/python/unittests.sh
@@ -17,7 +17,15 @@ sleep 2
 tox -e py27
 results=$?
 
+
 # kill server
 kill $pid
+
+if [ $results -ne 0 ] ; then
+    exit $results
+fi
+
+tox -e pep8
+results=$?
 
 exit $results

--- a/client/cli/go/cmds/topology.go
+++ b/client/cli/go/cmds/topology.go
@@ -22,8 +22,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/heketi/heketi/apps/glusterfs"
 	client "github.com/heketi/heketi/client/api/go-client"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/spf13/cobra"
 )
 
@@ -37,8 +37,8 @@ var jsonConfigFile string
 
 // Config file
 type ConfigFileNode struct {
-	Devices []string                 `json:"devices"`
-	Node    glusterfs.NodeAddRequest `json:"node"`
+	Devices []string           `json:"devices"`
+	Node    api.NodeAddRequest `json:"node"`
 }
 type ConfigFileCluster struct {
 	Nodes []ConfigFileNode `json:"nodes"`
@@ -108,7 +108,7 @@ var topologyLoadCommand = &cobra.Command{
 				for _, device := range node.Devices {
 					fmt.Fprintf(stdout, "\t\tAdding device %v ... ", device)
 
-					req := &glusterfs.DeviceAddRequest{}
+					req := &api.DeviceAddRequest{}
 					req.Name = device
 					req.NodeId = nodeInfo.Id
 					err := heketi.DeviceAdd(req)
@@ -173,12 +173,12 @@ var topologyInfoCommand = &cobra.Command{
 						v.Durability.Type)
 
 					switch v.Durability.Type {
-					case DURABILITY_STRING_EC:
+					case api.DurabilityEC:
 						s += fmt.Sprintf("\tDisperse Data: %v\n"+
 							"\tDisperse Redundancy: %v\n",
 							v.Durability.Disperse.Data,
 							v.Durability.Disperse.Redundancy)
-					case DURABILITY_STRING_REPLICATE:
+					case api.DurabilityReplicate:
 						s += fmt.Sprintf("\tReplica: %v\n",
 							v.Durability.Replicate.Replica)
 					}
@@ -210,11 +210,13 @@ var topologyInfoCommand = &cobra.Command{
 				for j, _ := range topoinfo.ClusterList[i].Nodes {
 					info := topoinfo.ClusterList[i].Nodes[j]
 					fmt.Fprintf(stdout, "\n\tNode Id: %v\n"+
+						"\tState: %v\n"+
 						"\tCluster Id: %v\n"+
 						"\tZone: %v\n"+
 						"\tManagement Hostname: %v\n"+
 						"\tStorage Hostname: %v\n",
 						info.Id,
+						info.State,
 						info.ClusterId,
 						info.Zone,
 						info.Hostnames.Manage[0],
@@ -225,11 +227,13 @@ var topologyInfoCommand = &cobra.Command{
 					for j, d := range info.DevicesInfo {
 						fmt.Fprintf(stdout, "\t\tId:%-35v"+
 							"Name:%-20v"+
+							"State:%-10v"+
 							"Size (GiB):%-8v"+
 							"Used (GiB):%-8v"+
 							"Free (GiB):%-8v\n",
 							d.Id,
 							d.Name,
+							d.State,
 							d.Storage.Total/(1024*1024),
 							d.Storage.Used/(1024*1024),
 							d.Storage.Free/(1024*1024))

--- a/client/cli/go/cmds/volume.go
+++ b/client/cli/go/cmds/volume.go
@@ -23,12 +23,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/heketi/heketi/apps/glusterfs"
 	"github.com/heketi/heketi/client/api/go-client"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubernetes/pkg/api/resource"
-	api "k8s.io/kubernetes/pkg/api/v1"
+	kubeapi "k8s.io/kubernetes/pkg/api/v1"
 )
 
 var (
@@ -152,10 +152,10 @@ var volumeCreateCommand = &cobra.Command{
 		}
 
 		// Create request blob
-		req := &glusterfs.VolumeCreateRequest{}
+		req := &api.VolumeCreateRequest{}
 		req.Size = size
 		req.Clusters = clusters_
-		req.Durability.Type = durability
+		req.Durability.Type = api.DurabilityType(durability)
 		req.Durability.Replicate.Replica = replica
 		req.Durability.Disperse.Data = disperseData
 		req.Durability.Disperse.Redundancy = redundancy
@@ -182,19 +182,19 @@ var volumeCreateCommand = &cobra.Command{
 		if kubePvFile != "" || kubePv {
 
 			// Initialize object
-			pv := &api.PersistentVolume{}
+			pv := &kubeapi.PersistentVolume{}
 			pv.Kind = "PersistentVolume"
 			pv.APIVersion = "v1"
-			pv.Spec.PersistentVolumeReclaimPolicy = api.PersistentVolumeReclaimRecycle
-			pv.Spec.AccessModes = []api.PersistentVolumeAccessMode{
-				api.ReadWriteMany,
+			pv.Spec.PersistentVolumeReclaimPolicy = kubeapi.PersistentVolumeReclaimRecycle
+			pv.Spec.AccessModes = []kubeapi.PersistentVolumeAccessMode{
+				kubeapi.ReadWriteMany,
 			}
-			pv.Spec.Capacity = make(api.ResourceList)
-			pv.Spec.Glusterfs = &api.GlusterfsVolumeSource{}
+			pv.Spec.Capacity = make(kubeapi.ResourceList)
+			pv.Spec.Glusterfs = &kubeapi.GlusterfsVolumeSource{}
 
 			// Set values
 			pv.ObjectMeta.Name = "glusterfs-" + volume.Id[:8]
-			pv.Spec.Capacity[api.ResourceStorage] =
+			pv.Spec.Capacity[kubeapi.ResourceStorage] =
 				resource.MustParse(fmt.Sprintf("%vGi", volume.Size))
 			pv.Spec.Glusterfs.Path = volume.Name
 
@@ -286,7 +286,7 @@ var volumeExpandCommand = &cobra.Command{
 		}
 
 		// Create request
-		req := &glusterfs.VolumeExpandRequest{}
+		req := &api.VolumeExpandRequest{}
 		req.Size = expandSize
 
 		// Create client


### PR DESCRIPTION
New APIs are now available which allow callers to set a node
or a device offline and online again.  If a node is placed
offline, then all of its disks are removed from the ring. If
a device is moved offline, then only that device is removed
from the ring.

New State API is available to accomplish this:
  POST /devices/<id>/state
  POST /nodes/<id>/state

The normal XInfo API calls can be used to get state information.

This patch also includes the following changes:

* All API structures moved to pkg/glusterfs/api
* Go and Python Client API support for state
* Heketi-cli support for state

Signed-off-by: Luis Pabón <lpabon@redhat.com>