### PR TITLE
Support for Heketi Storage in OpenShift

### DIFF
--- a/apps/glusterfs/volume_entry_create.go
+++ b/apps/glusterfs/volume_entry_create.go
@@ -45,20 +45,22 @@ func (v *VolumeEntry) createVolume(db *bolt.DB,
 		return err
 	}
 
+	// Get all brick hosts
+	stringset := utils.NewStringSet()
+	for _, brick := range vr.Bricks {
+		stringset.Add(brick.Host)
+	}
+	hosts := stringset.Strings()
+	v.Info.Mount.GlusterFS.Hosts = hosts
+
 	// Save volume information
 	v.Info.Mount.GlusterFS.MountPoint = fmt.Sprintf("%v:%v",
-		vr.Bricks[0].Host, vr.Name)
+		hosts[0], vr.Name)
 
 	// Set glusterfs mount volfile-servers options
 	v.Info.Mount.GlusterFS.Options = make(map[string]string)
-	stringset := utils.NewStringSet()
-	for _, brick := range vr.Bricks[1:] {
-		if vr.Bricks[0].Host != brick.Host {
-			stringset.Add(brick.Host)
-		}
-	}
 	v.Info.Mount.GlusterFS.Options["backup-volfile-servers"] =
-		strings.Join(stringset.Strings(), ",")
+		strings.Join(hosts[1:], ",")
 
 	godbc.Ensure(v.Info.Mount.GlusterFS.MountPoint != "")
 	return nil

--- a/client/api/go-client/backup.go
+++ b/client/api/go-client/backup.go
@@ -1,0 +1,52 @@
+//
+// Copyright (c) 2016 The heketi Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package client
+
+import (
+	"github.com/heketi/utils"
+	"io"
+	"net/http"
+)
+
+func (c *Client) BackupDb(w io.Writer) error {
+	// Create a request
+	req, err := http.NewRequest("GET", c.host+"/backup/db", nil)
+	if err != nil {
+		return err
+	}
+
+	// Set token
+	err = c.setToken(req)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	r, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	if r.StatusCode != http.StatusOK {
+		return utils.GetErrorFromResponse(r)
+	}
+
+	// Read data from response
+	defer r.Body.Close()
+	_, err = io.Copy(w, r.Body)
+
+	return err
+}

--- a/client/cli/go/cmds/heketi_storage.go
+++ b/client/cli/go/cmds/heketi_storage.go
@@ -1,0 +1,336 @@
+//
+// Copyright (c) 2016 The heketi Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmds
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+
+	client "github.com/heketi/heketi/client/api/go-client"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/spf13/cobra"
+
+	kubeapi "k8s.io/kubernetes/pkg/api/v1"
+	batch "k8s.io/kubernetes/pkg/apis/batch/v1"
+)
+
+type KubeList struct {
+	APIVersion string        `json:"apiVersion"`
+	Kind       string        `json:"kind"`
+	Items      []interface{} `json:"items"`
+}
+
+const (
+	HeketiStorageJobName      = "heketi-storage-copy-job"
+	HeketiStorageEndpointName = "heketi-storage-endpoints"
+	HeketiStorageSecretName   = "heketi-storage-secret"
+	HeketiStorageVolTagName   = "heketi-storage"
+
+	HeketiStorageVolumeName    = "heketidbstorage"
+	HeketiStorageVolumeSize    = 32
+	HeketiStorageVolumeSizeStr = "32Gi"
+)
+
+var (
+
+	// Override this from command line
+	HeketiStorageJobContainer = "heketi/heketi:dev"
+	heketiStorageListFilename string
+)
+
+func init() {
+	RootCmd.AddCommand(setupHeketiStorageCommand)
+	setupHeketiStorageCommand.Flags().StringVar(&heketiStorageListFilename,
+		"listfile",
+		"heketi-storage.json",
+		"Filename to contain list of objects")
+}
+
+func saveJson(i interface{}, filename string) error {
+
+	// Open File
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Marshal struct to JSON
+	data, err := json.MarshalIndent(i, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	// Save data to file
+	_, err = f.Write(data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createHeketiStorageVolume(c *client.Client) (*api.VolumeInfoResponse, error) {
+
+	// Make sure the volume does not already exist on any cluster
+	clusters, err := c.ClusterList()
+	if err != nil {
+		return nil, err
+	}
+
+	// Go through all the clusters checking volumes
+	for _, clusterId := range clusters.Clusters {
+		cluster, err := c.ClusterInfo(clusterId)
+		if err != nil {
+			return nil, err
+		}
+
+		// Go through all the volumes checking the names
+		for _, volumeId := range cluster.Volumes {
+			volume, err := c.VolumeInfo(volumeId)
+			if err != nil {
+				return nil, err
+			}
+
+			// Check volume name
+			if volume.Name == HeketiStorageVolumeName {
+				return nil, fmt.Errorf("Volume %v alreay exists", HeketiStorageVolumeName)
+			}
+		}
+	}
+
+	// Create request
+	req := &api.VolumeCreateRequest{}
+	req.Size = HeketiStorageVolumeSize
+	req.Durability.Type = api.DurabilityReplicate
+	req.Durability.Replicate.Replica = 3
+	req.Name = HeketiStorageVolumeName
+
+	// Create volume
+	volume, err := c.VolumeCreate(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return volume, nil
+}
+
+func createHeketiSecretFromDb(c *client.Client) (*kubeapi.Secret, error) {
+	var dbfile bytes.Buffer
+
+	// Save db
+	err := c.BackupDb(&dbfile)
+	if err != nil {
+		return nil, fmt.Errorf("ERROR: %v\nUnable to get database from Heketi server", err.Error())
+	}
+
+	// Create Secret
+	secret := &kubeapi.Secret{}
+	secret.Kind = "Secret"
+	secret.APIVersion = "v1"
+	secret.ObjectMeta.Name = HeketiStorageSecretName
+	secret.Data = make(map[string][]byte)
+	secret.Data["heketi.db"] = dbfile.Bytes()
+
+	return secret, nil
+}
+
+func createHeketiEndpointService() *kubeapi.Service {
+
+	service := &kubeapi.Service{}
+	service.Kind = "Service"
+	service.APIVersion = "v1"
+	service.ObjectMeta.Name = HeketiStorageEndpointName
+	service.Spec.Ports = []kubeapi.ServicePort{
+		kubeapi.ServicePort{
+			Port: 1,
+		},
+	}
+
+	return service
+}
+
+func createHeketiStorageEndpoints(c *client.Client,
+	volume *api.VolumeInfoResponse) *kubeapi.Endpoints {
+
+	endpoint := &kubeapi.Endpoints{}
+	endpoint.Kind = "Endpoints"
+	endpoint.APIVersion = "v1"
+	endpoint.ObjectMeta.Name = HeketiStorageEndpointName
+
+	// Initialize slices
+	endpoint.Subsets = make([]kubeapi.EndpointSubset, 3)
+	//len(volume.Mount.GlusterFS.Hosts))
+
+	// Save all nodes in the endpoints
+	for n, host := range []string{"192.168.10.100", "192.168.10.101", "192.168.10.102"} {
+		//for n, host := range volume.Mount.GlusterFS.Hosts {
+
+		// Determine if it is an IP address
+		netIp := net.ParseIP(host)
+		if netIp == nil {
+			// It is not an IP, it is a hostname
+			endpoint.Subsets[n].Addresses = []kubeapi.EndpointAddress{
+				kubeapi.EndpointAddress{
+					Hostname: host,
+				},
+			}
+		} else {
+			// It is an IP
+			endpoint.Subsets[n].Addresses = []kubeapi.EndpointAddress{
+				kubeapi.EndpointAddress{
+					IP: host,
+				},
+			}
+		}
+
+		// Set to port 1
+		endpoint.Subsets[n].Ports = []kubeapi.EndpointPort{
+			kubeapi.EndpointPort{
+				Port: 1,
+			},
+		}
+	}
+
+	return endpoint
+}
+
+func createHeketiCopyJob(volume *api.VolumeInfoResponse) *batch.Job {
+	job := &batch.Job{}
+	job.Kind = "Job"
+	job.APIVersion = "batch/v1"
+	job.ObjectMeta.Name = HeketiStorageJobName
+	job.ObjectMeta.Labels = map[string]string{
+		"deploy-heketi": "support",
+	}
+
+	var (
+		p int32 = 1
+		c int32 = 1
+	)
+	job.Spec.Parallelism = &p
+	job.Spec.Completions = &c
+	job.Spec.Template.ObjectMeta.Name = HeketiStorageJobName
+	job.Spec.Template.Spec.Volumes = []kubeapi.Volume{
+		kubeapi.Volume{
+			Name: HeketiStorageVolTagName,
+			VolumeSource: kubeapi.VolumeSource{
+				Glusterfs: &kubeapi.GlusterfsVolumeSource{
+					EndpointsName: HeketiStorageEndpointName,
+					Path:          volume.Name,
+				},
+			},
+		},
+		kubeapi.Volume{
+			Name: HeketiStorageSecretName,
+			VolumeSource: kubeapi.VolumeSource{
+				Secret: &kubeapi.SecretVolumeSource{
+					SecretName: HeketiStorageSecretName,
+				},
+			},
+		},
+	}
+
+	job.Spec.Template.Spec.Containers = []kubeapi.Container{
+		kubeapi.Container{
+			Name:  "heketi",
+			Image: HeketiStorageJobContainer,
+			Command: []string{
+				"cp",
+				"/db/heketi.db",
+				"/heketi",
+			},
+			VolumeMounts: []kubeapi.VolumeMount{
+				kubeapi.VolumeMount{
+					Name:      HeketiStorageVolTagName,
+					MountPath: "/heketi",
+				},
+				kubeapi.VolumeMount{
+					Name:      HeketiStorageSecretName,
+					MountPath: "/db",
+				},
+			},
+		},
+	}
+	job.Spec.Template.Spec.RestartPolicy = kubeapi.RestartPolicyNever
+
+	return job
+}
+
+var setupHeketiStorageCommand = &cobra.Command{
+	Use:   "setup-openshift-heketi-storage",
+	Short: "Setup OpenShift/Kubernetes persistent storage for Heketi",
+	Long: "Creates a dedicated GlusterFS volume for Heketi.\n" +
+		"Once the volume is created, a Kubernetes/OpenShift\n" +
+		"list object is created to configure the volume.\n",
+	RunE: func(cmd *cobra.Command, args []string) (e error) {
+
+		// Initialize Kubernetes List object
+		list := &KubeList{}
+		list.APIVersion = "v1"
+		list.Kind = "List"
+		list.Items = make([]interface{}, 0)
+
+		// Create client
+		c := client.NewClient(options.Url, options.User, options.Key)
+
+		// Create volume
+		volume, err := createHeketiStorageVolume(c)
+		if err != nil {
+			return err
+		}
+
+		// Cleanup volume on error
+		defer func() {
+			if e != nil {
+				fmt.Fprintln(stderr, "Cleaning up")
+				c.VolumeDelete(volume.Id)
+			}
+		}()
+
+		// Create secret
+		secret, err := createHeketiSecretFromDb(c)
+		if err != nil {
+			return err
+		}
+		list.Items = append(list.Items, secret)
+
+		// Create endpoints
+		endpoints := createHeketiStorageEndpoints(c, volume)
+		list.Items = append(list.Items, endpoints)
+
+		// Create service for the endpoints
+		service := createHeketiEndpointService()
+		list.Items = append(list.Items, service)
+
+		// Create Job which copies db
+		job := createHeketiCopyJob(volume)
+		list.Items = append(list.Items, job)
+
+		// Save list
+		fmt.Fprintf(stdout, "Saving %v\n", heketiStorageListFilename)
+		err = saveJson(list, heketiStorageListFilename)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}

--- a/client/cli/go/cmds/heketi_storage.go
+++ b/client/cli/go/cmds/heketi_storage.go
@@ -176,12 +176,11 @@ func createHeketiStorageEndpoints(c *client.Client,
 	endpoint.ObjectMeta.Name = HeketiStorageEndpointName
 
 	// Initialize slices
-	endpoint.Subsets = make([]kubeapi.EndpointSubset, 3)
-	//len(volume.Mount.GlusterFS.Hosts))
+	endpoint.Subsets = make([]kubeapi.EndpointSubset,
+		len(volume.Mount.GlusterFS.Hosts))
 
 	// Save all nodes in the endpoints
-	for n, host := range []string{"192.168.10.100", "192.168.10.101", "192.168.10.102"} {
-		//for n, host := range volume.Mount.GlusterFS.Hosts {
+	for n, host := range volume.Mount.GlusterFS.Hosts {
 
 		// Determine if it is an IP address
 		netIp := net.ParseIP(host)

--- a/extras/docker/unstable/Dockerfile
+++ b/extras/docker/unstable/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir $BUILD_HOME $GOPATH $HEKETI_CONF_DIR && \
     dnf -q -y clean all && \
     mkdir -p $GOPATH/src/github.com/heketi && \
     cd $GOPATH/src/github.com/heketi && \
-    git clone https://github.com/heketi/heketi.git && \
+    git clone -b backup https://github.com/lpabon/heketi.git && \
     go get github.com/robfig/glock && \
     glock sync github.com/heketi/heketi && \
     cd $GOPATH/src/github.com/heketi/heketi && make && \

--- a/extras/openshift/template/deploy-heketi-template.json
+++ b/extras/openshift/template/deploy-heketi-template.json
@@ -2,17 +2,18 @@
   "kind": "Template",
   "apiVersion": "v1",
   "metadata": {
-    "name": "heketi",
+    "name": "deploy-heketi",
     "labels": {
-      "glusterfs": "heketi-template"
+      "glusterfs": "heketi-template",
+      "deploy-heketi": "support"
     },
     "annotations": {
-      "description": "Heketi service deployment template",
-      "tags": "glusterfs,heketi"
+      "description": "Bootstrap Heketi installation",
+      "tags": "glusterfs,heketi,installation"
     }
   },
   "labels": {
-    "template": "heketi"
+    "template": "deploy-heketi"
   },
   "objects": [
     {
@@ -21,7 +22,8 @@
       "metadata": {
         "name": "heketi",
         "labels": {
-          "glusterfs": "heketi-service"
+          "glusterfs": "heketi-service",
+          "deploy-heketi": "support"
         },
         "annotations": {
           "description": "Exposes Heketi service"
@@ -46,7 +48,8 @@
       "metadata": {
         "name": "heketi",
         "labels": {
-          "glusterfs": "heketi-route"
+          "glusterfs": "heketi-route",
+          "deploy-heketi": "support"
         }
       },
       "spec": {
@@ -62,7 +65,8 @@
       "metadata": {
         "name": "heketi",
         "labels": {
-          "glusterfs": "heketi-dc"
+          "glusterfs": "heketi-dc",
+          "deploy-heketi": "support"
         },
         "annotations": {
           "description": "Defines how to deploy Heketi"
@@ -78,7 +82,8 @@
             "name": "heketi",
             "labels": {
               "name": "heketi",
-              "glusterfs": "heketi-pod"
+              "glusterfs": "heketi-pod",
+              "deploy-heketi": "support"
             }
           },
           "triggers": [
@@ -167,11 +172,7 @@
             ],
             "volumes": [
               {
-                "name": "db",
-                "glusterfs": {
-                  "endpoints" : "heketi-storage-endpoints",
-                  "path" : "heketidbstorage"
-                }
+                "name": "db"
               }
             ]
           }

--- a/extras/openshift/template/glusterfs-template.json
+++ b/extras/openshift/template/glusterfs-template.json
@@ -3,6 +3,9 @@
     "apiVersion": "v1",
     "metadata": {
         "name": "glusterfs",
+        "labels": {
+            "glusterfs": "template"
+        },
         "annotations": {
             "description": "GlusterFS container deployment template",
             "tags": "glusterfs"
@@ -17,6 +20,9 @@
             "apiVersion": "v1",
             "metadata": {
                 "name": "glusterfs-${NODE_GLUSTERFSID}",
+                "labels": {
+                    "glusterfs": "dc"
+                },
                 "annotations": {
                     "description": "Deploys the GlusterFS container"
                 }
@@ -31,6 +37,7 @@
                         "name": "glusterfs",
                         "labels": {
                             "name": "glusterfs",
+                            "glusterfs": "pod",
                             "glusterfsid": "${NODE_GLUSTERFSID}"
                         }
                     },
@@ -88,24 +95,24 @@
                                 "readinessProbe": {
                                     "timeoutSeconds": 3,
                                     "initialDelaySeconds": 3,
-                                "exec": {
+                                    "exec": {
                                         "command": [
                                             "/bin/bash",
                                             "-c",
                                             "systemctl status glusterd.service"
                                         ]
-                                }
+                                    }
                                 },
                                 "livenessProbe": {
                                     "timeoutSeconds": 3,
                                     "initialDelaySeconds": 30,
-                                "exec": {
+                                    "exec": {
                                         "command": [
                                             "/bin/bash",
                                             "-c",
                                             "systemctl status glusterd.service"
                                         ]
-                                }
+                                    }
                                 }
                             }
                         ],

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -167,6 +167,7 @@ type VolumeInfo struct {
 	Cluster string `json:"cluster"`
 	Mount   struct {
 		GlusterFS struct {
+			Hosts      []string          `json:"hosts"`
 			MountPoint string            `json:"device"`
 			Options    map[string]string `json:"options"`
 		} `json:"glusterfs"`

--- a/pkg/kubernetes/pv.go
+++ b/pkg/kubernetes/pv.go
@@ -1,0 +1,62 @@
+//
+// Copyright (c) 2016 The heketi Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package kubernetes
+
+import (
+	"fmt"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+
+	"k8s.io/kubernetes/pkg/api/resource"
+	kubeapi "k8s.io/kubernetes/pkg/api/v1"
+)
+
+func VolumeToPv(volume *api.VolumeInfoResponse,
+	name, endpoint string) *kubeapi.PersistentVolume {
+	// Initialize object
+	pv := &kubeapi.PersistentVolume{}
+	pv.Kind = "PersistentVolume"
+	pv.APIVersion = "v1"
+	pv.Spec.PersistentVolumeReclaimPolicy = kubeapi.PersistentVolumeReclaimRecycle
+	pv.Spec.AccessModes = []kubeapi.PersistentVolumeAccessMode{
+		kubeapi.ReadWriteMany,
+	}
+	pv.Spec.Capacity = make(kubeapi.ResourceList)
+	pv.Spec.Glusterfs = &kubeapi.GlusterfsVolumeSource{}
+
+	// Set path
+	pv.Spec.Capacity[kubeapi.ResourceStorage] =
+		resource.MustParse(fmt.Sprintf("%vGi", volume.Size))
+	pv.Spec.Glusterfs.Path = volume.Name
+
+	// Set name
+	if name == "" {
+		pv.ObjectMeta.Name = "glusterfs-" + volume.Id[:8]
+	} else {
+		pv.ObjectMeta.Name = name
+
+	}
+
+	// Set endpoint
+	if endpoint == "" {
+		pv.Spec.Glusterfs.EndpointsName = "TYPE ENDPOINT HERE"
+	} else {
+		pv.Spec.Glusterfs.EndpointsName = endpoint
+	}
+
+	return pv
+}


### PR DESCRIPTION
To support storage specific for Heketi, a new API call was added
to backup the database.  Creating Heketi storage uses the
following workflow:
 $ heketi-cli setup-openshift-heketi-storage
    This does the following:
    1. Create a volume called heketidbstorage
    2. Download the db and save it as a secret
    3. Create endpoints and a service
    4. Create a Job to copy the database from the secret
       to the volume.
    5. Save all into a List object called 'heketi-storage.json'

User would then copy the storage using the list object.
 $ oc create -f heketi-storage.json

Closes #208 
Signed-off-by: Luis Pabón <lpabon@redhat.com>