### PR TITLE
functional-tests: skip sudo when already running as root

### DIFF
--- a/tests/functional/TestOpenShiftSmokeTest/run.sh
+++ b/tests/functional/TestOpenShiftSmokeTest/run.sh
@@ -17,8 +17,8 @@ build_docker_file(){
     if [ ! -f "$vagrant_heketi_docker" ] ; then
         cd $DOCKERDIR
         cp $TOP/heketi $DOCKERDIR
-        sudo docker build --rm --tag heketi/heketi:ci . || fail "Unable to create docker container"
-        sudo docker save -o $HEKETI_DOCKER_IMG heketi/heketi:ci || fail "Unable to save docker image"
+        _sudo docker build --rm --tag heketi/heketi:ci . || fail "Unable to create docker container"
+        _sudo docker save -o $HEKETI_DOCKER_IMG heketi/heketi:ci || fail "Unable to save docker image"
         cp $HEKETI_DOCKER_IMG $vagrant_heketi_docker
         cd $CURRENT_DIR
     fi

--- a/tests/functional/lib.sh
+++ b/tests/functional/lib.sh
@@ -8,6 +8,14 @@ println() {
     echo "==> $1"
 }
 
+_sudo() {
+    if [ ${UID} = 0 ] ; then
+        ${@}
+    else
+        sudo -E ${@}
+    fi
+}
+
 HEKETI_PID=
 start_heketi() {
     # Build server if we need to
@@ -27,13 +35,13 @@ start_heketi() {
 
 start_vagrant() {
     cd vagrant
-    sudo -E ./up.sh || fail "unable to start vagrant virtual machines"
+    _sudo ./up.sh || fail "unable to start vagrant virtual machines"
     cd ..
 }
 
 teardown_vagrant() {
     cd vagrant
-    sudo vagrant destroy -f
+    _sudo vagrant destroy -f
     cd ..
 }
 


### PR DESCRIPTION
When running tests in the CentOS CI with the SCL for Vagrant, 'sudo'
cleans the environment to much. This prevents the run.sh scripts from
executing vagrant (not found in $PATH).

The new _sudo() function in lib.sh replaces the normal 'sudo' calls. The
function checks if the tests are run as root already, in which case it
will skip calling 'sudo'.

A few more details on using Vagrant with CentOS can be found on this
wiki page:
  https://wiki.centos.org/SpecialInterestGroup/SCLo/Vagrant

Signed-off-by: Niels de Vos <ndevos@redhat.com>