### PR TITLE
cli: Label secret

### DIFF
--- a/client/cli/go/cmds/heketi_storage.go
+++ b/client/cli/go/cmds/heketi_storage.go
@@ -145,6 +145,9 @@ func createHeketiSecretFromDb(c *client.Client) (*kubeapi.Secret, error) {
 	secret.Kind = "Secret"
 	secret.APIVersion = "v1"
 	secret.ObjectMeta.Name = HeketiStorageSecretName
+	secret.ObjectMeta.Labels = map[string]string{
+		"deploy-heketi": "support",
+	}
 	secret.Data = make(map[string][]byte)
 	secret.Data["heketi.db"] = dbfile.Bytes()
 


### PR DESCRIPTION
When using setup-openshift-heketi-storage, the secret was not
being deleted because it was missing the 'deploy-heketi'
label.

Closes #411

Signed-off-by: Luis Pabón <lpabon@redhat.com>