### PR TITLE
Do not delete the volume with the database

### DIFF
--- a/apps/glusterfs/app_volume.go
+++ b/apps/glusterfs/app_volume.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/gorilla/mux"
+	"github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
 )
@@ -225,6 +226,12 @@ func (a *App) VolumeDelete(w http.ResponseWriter, r *http.Request) {
 			return err
 		} else if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return err
+		}
+
+		if volume.Info.Name == db.HeketiStorageVolumeName {
+			err := fmt.Errorf("Cannot delete volume containing the Heketi database")
+			http.Error(w, err.Error(), http.StatusConflict)
 			return err
 		}
 

--- a/client/cli/go/cmds/heketi_storage.go
+++ b/client/cli/go/cmds/heketi_storage.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	client "github.com/heketi/heketi/client/api/go-client"
+	"github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/spf13/cobra"
 
@@ -42,7 +43,6 @@ const (
 	HeketiStorageSecretName   = "heketi-storage-secret"
 	HeketiStorageVolTagName   = "heketi-storage"
 
-	HeketiStorageVolumeName    = "heketidbstorage"
 	HeketiStorageVolumeSize    = 32
 	HeketiStorageVolumeSizeStr = "32Gi"
 )
@@ -109,8 +109,8 @@ func createHeketiStorageVolume(c *client.Client) (*api.VolumeInfoResponse, error
 			}
 
 			// Check volume name
-			if volume.Name == HeketiStorageVolumeName {
-				return nil, fmt.Errorf("Volume %v alreay exists", HeketiStorageVolumeName)
+			if volume.Name == db.HeketiStorageVolumeName {
+				return nil, fmt.Errorf("Volume %v alreay exists", db.HeketiStorageVolumeName)
 			}
 		}
 	}
@@ -120,7 +120,7 @@ func createHeketiStorageVolume(c *client.Client) (*api.VolumeInfoResponse, error
 	req.Size = HeketiStorageVolumeSize
 	req.Durability.Type = api.DurabilityReplicate
 	req.Durability.Replicate.Replica = 3
-	req.Name = HeketiStorageVolumeName
+	req.Name = db.HeketiStorageVolumeName
 
 	// Create volume
 	volume, err := c.VolumeCreate(req)

--- a/pkg/db/dbvolume.go
+++ b/pkg/db/dbvolume.go
@@ -1,0 +1,21 @@
+//
+// Copyright (c) 2016 The heketi Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package db
+
+const (
+	HeketiStorageVolumeName = "heketidbstorage"
+)


### PR DESCRIPTION
Once created, the volume holding the database with the name
in pkg/db/dbvolume.go cannot be deleted.

Closes #403

Signed-off-by: Luis Pabón <lpabon@redhat.com>