### PR TITLE
Make sudo configurable

### DIFF
--- a/executors/kubeexec/config.go
+++ b/executors/kubeexec/config.go
@@ -17,37 +17,19 @@
 package kubeexec
 
 import (
-	"testing"
-
 	"github.com/heketi/heketi/executors/sshexec"
-	"github.com/heketi/tests"
 )
 
-func TestNewKubeExecutor(t *testing.T) {
-	config := &KubeConfig{
-		Host: "myhost",
-		CLICommandConfig: sshexec.CLICommandConfig{
-			Fstab: "myfstab",
-		},
-		Namespace: "mynamespace",
-	}
+type KubeConfig struct {
+	sshexec.CLICommandConfig
+	Host      string `json:"host"`
+	CertFile  string `json:"cert"`
+	Insecure  bool   `json:"insecure"`
+	User      string `json:"user"`
+	Password  string `json:"password"`
+	Namespace string `json:"namespace"`
 
-	k, err := NewKubeExecutor(config)
-	tests.Assert(t, err == nil)
-	tests.Assert(t, k.Fstab == "myfstab")
-	tests.Assert(t, k.Throttlemap != nil)
-	tests.Assert(t, k.config != nil)
-}
-
-func TestNewKubeExecutorNoNamespace(t *testing.T) {
-	config := &KubeConfig{
-		Host: "myhost",
-		CLICommandConfig: sshexec.CLICommandConfig{
-			Fstab: "myfstab",
-		},
-	}
-
-	k, err := NewKubeExecutor(config)
-	tests.Assert(t, err != nil)
-	tests.Assert(t, k == nil)
+	// Use POD name instead of using label
+	// to access POD
+	UsePodNames bool `json:"use_pod_names"`
 }

--- a/executors/kubeexec/kubeexec.go
+++ b/executors/kubeexec/kubeexec.go
@@ -49,21 +49,6 @@ const (
 	KubeGlusterFSPodLabelKey = "glusterfs-node"
 )
 
-type KubeConfig struct {
-	Host      string `json:"host"`
-	Sudo      bool   `json:"sudo"`
-	CertFile  string `json:"cert"`
-	Insecure  bool   `json:"insecure"`
-	User      string `json:"user"`
-	Password  string `json:"password"`
-	Namespace string `json:"namespace"`
-	Fstab     string `json:"fstab"`
-
-	// Use POD name instead of using label
-	// to access POD
-	UsePodNames bool `json:"use_pod_names"`
-}
-
 type KubeExecutor struct {
 	// Embed all sshexecutor functions
 	sshexec.SshExecutor
@@ -263,10 +248,7 @@ func (k *KubeExecutor) ConnectAndExec(host, namespace, resource string,
 		// Remove any whitespace
 		command = strings.Trim(command, " ")
 
-		// Determine if we should use sudo
-		if k.config.Sudo {
-			command = "sudo " + command
-		}
+		// SUDO is *not* supported
 
 		// Create REST command
 		req := conn.RESTClient.Post().

--- a/executors/sshexec/brick.go
+++ b/executors/sshexec/brick.go
@@ -59,10 +59,10 @@ func (s *SshExecutor) BrickCreate(host string,
 	commands := []string{
 
 		// Create a directory
-		fmt.Sprintf("sudo mkdir -p %v", mountpoint),
+		fmt.Sprintf("mkdir -p %v", mountpoint),
 
 		// Setup the LV
-		fmt.Sprintf("sudo lvcreate --poolmetadatasize %vK -c 256K -L %vK -T %v/%v -V %vK -n %v",
+		fmt.Sprintf("lvcreate --poolmetadatasize %vK -c 256K -L %vK -T %v/%v -V %vK -n %v",
 			// MetadataSize
 			brick.PoolMetadataSize,
 
@@ -82,19 +82,19 @@ func (s *SshExecutor) BrickCreate(host string,
 			s.brickName(brick.Name)),
 
 		// Format
-		fmt.Sprintf("sudo mkfs.xfs -i size=512 -n size=8192 %v", s.devnode(brick)),
+		fmt.Sprintf("mkfs.xfs -i size=512 -n size=8192 %v", s.devnode(brick)),
 
 		// Fstab
-		fmt.Sprintf("echo \"%v %v xfs rw,inode64,noatime,nouuid 1 2\" | sudo tee -a %v > /dev/null ",
+		fmt.Sprintf("echo \"%v %v xfs rw,inode64,noatime,nouuid 1 2\" | tee -a %v > /dev/null ",
 			s.devnode(brick),
 			mountpoint,
 			s.Fstab),
 
 		// Mount
-		fmt.Sprintf("sudo mount -o rw,inode64,noatime,nouuid %v %v", s.devnode(brick), mountpoint),
+		fmt.Sprintf("mount -o rw,inode64,noatime,nouuid %v %v", s.devnode(brick), mountpoint),
 
 		// Create a directory inside the formated volume for GlusterFS
-		fmt.Sprintf("sudo mkdir %v/brick", mountpoint),
+		fmt.Sprintf("mkdir %v/brick", mountpoint),
 	}
 
 	// Execute commands
@@ -122,7 +122,7 @@ func (s *SshExecutor) BrickDestroy(host string,
 
 	// Try to unmount first
 	commands := []string{
-		fmt.Sprintf("sudo umount %v", s.brickMountPoint(brick)),
+		fmt.Sprintf("umount %v", s.brickMountPoint(brick)),
 	}
 	_, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 5)
 	if err != nil {
@@ -131,7 +131,7 @@ func (s *SshExecutor) BrickDestroy(host string,
 
 	// Now try to remove the LV
 	commands = []string{
-		fmt.Sprintf("sudo lvremove -f %v/%v", s.vgName(brick.VgId), s.tpName(brick.Name)),
+		fmt.Sprintf("lvremove -f %v/%v", s.vgName(brick.VgId), s.tpName(brick.Name)),
 	}
 	_, err = s.RemoteExecutor.RemoteCommandExecute(host, commands, 5)
 	if err != nil {
@@ -140,7 +140,7 @@ func (s *SshExecutor) BrickDestroy(host string,
 
 	// Now cleanup the mount point
 	commands = []string{
-		fmt.Sprintf("sudo rmdir %v", s.brickMountPoint(brick)),
+		fmt.Sprintf("rmdir %v", s.brickMountPoint(brick)),
 	}
 	_, err = s.RemoteExecutor.RemoteCommandExecute(host, commands, 5)
 	if err != nil {
@@ -149,7 +149,7 @@ func (s *SshExecutor) BrickDestroy(host string,
 
 	// Remove from fstab
 	commands = []string{
-		fmt.Sprintf("sudo sed -i.save '/%v/d' %v",
+		fmt.Sprintf("sed -i.save \"/%v/d\" %v",
 			s.brickName(brick.Name),
 			s.Fstab),
 	}
@@ -190,7 +190,7 @@ func (s *SshExecutor) checkThinPoolUsage(host string,
 
 	tp := s.tpName(brick.Name)
 	commands := []string{
-		fmt.Sprintf("sudo lvs --options=lv_name,thin_count --separator=:"),
+		fmt.Sprintf("lvs --options=lv_name,thin_count --separator=:"),
 	}
 
 	// Send command

--- a/executors/sshexec/config.go
+++ b/executors/sshexec/config.go
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2016 The heketi Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package sshexec
+
+type CLICommandConfig struct {
+	Fstab string `json:"fstab"`
+	Sudo  bool   `json:"sudo"`
+
+	// Experimental Settings
+	RebalanceOnExpansion bool `json:"rebalance_on_expansion"`
+}
+
+type SshConfig struct {
+	CLICommandConfig
+	PrivateKeyFile string `json:"keyfile"`
+	User           string `json:"user"`
+	Port           string `json:"port"`
+}

--- a/executors/sshexec/device.go
+++ b/executors/sshexec/device.go
@@ -40,8 +40,8 @@ func (s *SshExecutor) DeviceSetup(host, device, vgid string) (d *executors.Devic
 
 	// Setup commands
 	commands := []string{
-		fmt.Sprintf("sudo pvcreate --metadatasize=128M --dataalignment=256K %v", device),
-		fmt.Sprintf("sudo vgcreate %v %v", s.vgName(vgid), device),
+		fmt.Sprintf("pvcreate --metadatasize=128M --dataalignment=256K %v", device),
+		fmt.Sprintf("vgcreate %v %v", s.vgName(vgid), device),
 	}
 
 	// Execute command
@@ -71,8 +71,8 @@ func (s *SshExecutor) DeviceTeardown(host, device, vgid string) error {
 
 	// Setup commands
 	commands := []string{
-		fmt.Sprintf("sudo vgremove %v", s.vgName(vgid)),
-		fmt.Sprintf("sudo pvremove %v", device),
+		fmt.Sprintf("vgremove %v", s.vgName(vgid)),
+		fmt.Sprintf("pvremove %v", device),
 	}
 
 	// Execute command
@@ -91,7 +91,7 @@ func (s *SshExecutor) getVgSizeFromNode(
 
 	// Setup command
 	commands := []string{
-		fmt.Sprintf("sudo vgdisplay -c %v", s.vgName(vgid)),
+		fmt.Sprintf("vgdisplay -c %v", s.vgName(vgid)),
 	}
 
 	// Execute command

--- a/executors/sshexec/peer.go
+++ b/executors/sshexec/peer.go
@@ -29,7 +29,7 @@ func (s *SshExecutor) PeerProbe(host, newnode string) error {
 	logger.Info("Probing: %v -> %v", host, newnode)
 	// create the commands
 	commands := []string{
-		fmt.Sprintf("sudo gluster peer probe %v", newnode),
+		fmt.Sprintf("gluster peer probe %v", newnode),
 	}
 	_, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 10)
 	if err != nil {
@@ -46,7 +46,7 @@ func (s *SshExecutor) PeerDetach(host, detachnode string) error {
 	// create the commands
 	logger.Info("Detaching node %v", detachnode)
 	commands := []string{
-		fmt.Sprintf("sudo gluster peer detach %v", detachnode),
+		fmt.Sprintf("gluster peer detach %v", detachnode),
 	}
 	_, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 10)
 	if err != nil {

--- a/executors/sshexec/sshexec.go
+++ b/executors/sshexec/sshexec.go
@@ -49,16 +49,6 @@ type SshExecutor struct {
 	port            string
 }
 
-type SshConfig struct {
-	PrivateKeyFile string `json:"keyfile"`
-	User           string `json:"user"`
-	Port           string `json:"port"`
-	Fstab          string `json:"fstab"`
-
-	// Experimental Settings
-	RebalanceOnExpansion bool `json:"rebalance_on_expansion"`
-}
-
 var (
 	logger           = utils.NewLogger("[sshexec]", utils.LEVEL_DEBUG)
 	ErrSshPrivateKey = errors.New("Unable to read private key file")
@@ -179,7 +169,7 @@ func (s *SshExecutor) RemoteCommandExecute(host string,
 	defer s.FreeConnection(host)
 
 	// Execute
-	return s.exec.ConnectAndExec(host+":"+s.port, commands, timeoutMinutes, false)
+	return s.exec.ConnectAndExec(host+":"+s.port, commands, timeoutMinutes, s.config.Sudo)
 }
 
 func (s *SshExecutor) vgName(vgId string) string {

--- a/executors/sshexec/sshexec_test.go
+++ b/executors/sshexec/sshexec_test.go
@@ -64,7 +64,9 @@ func TestNewSshExec(t *testing.T) {
 		PrivateKeyFile: "xkeyfile",
 		User:           "xuser",
 		Port:           "100",
-		Fstab:          "xfstab",
+		CLICommandConfig: CLICommandConfig{
+			Fstab: "xfstab",
+		},
 	}
 
 	s, err := NewSshExecutor(config)

--- a/executors/sshexec/volume.go
+++ b/executors/sshexec/volume.go
@@ -33,7 +33,7 @@ func (s *SshExecutor) VolumeCreate(host string,
 	godbc.Require(volume.Name != "")
 
 	// Create volume command
-	cmd := fmt.Sprintf("sudo gluster --mode=script volume create %v ", volume.Name)
+	cmd := fmt.Sprintf("gluster --mode=script volume create %v ", volume.Name)
 
 	// Add durability settings to the volume command
 	var (
@@ -72,7 +72,7 @@ func (s *SshExecutor) VolumeCreate(host string,
 	commands = append(commands, s.createAddBrickCommands(volume, inSet, inSet, maxPerSet)...)
 
 	// Add command to start the volume
-	commands = append(commands, fmt.Sprintf("sudo gluster volume start %v", volume.Name))
+	commands = append(commands, fmt.Sprintf("gluster volume start %v", volume.Name))
 
 	// Execute command
 	_, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 10)
@@ -118,7 +118,7 @@ func (s *SshExecutor) VolumeExpand(host string,
 	// Rebalance if configured
 	if s.config.RebalanceOnExpansion {
 		commands = append(commands,
-			fmt.Sprintf("sudo gluster --mode=script volume rebalance %v start", volume.Name))
+			fmt.Sprintf("gluster --mode=script volume rebalance %v start", volume.Name))
 	}
 
 	// Execute command
@@ -137,7 +137,7 @@ func (s *SshExecutor) VolumeDestroy(host string, volume string) error {
 	// Shutdown volume
 	commands := []string{
 		// stop gluster volume
-		fmt.Sprintf("sudo gluster --mode=script volume stop %v force", volume),
+		fmt.Sprintf("gluster --mode=script volume stop %v force", volume),
 	}
 
 	// Execute command
@@ -149,7 +149,7 @@ func (s *SshExecutor) VolumeDestroy(host string, volume string) error {
 	// Shutdown volume
 	commands = []string{
 		// stop gluster volume
-		fmt.Sprintf("sudo gluster --mode=script volume delete %v", volume),
+		fmt.Sprintf("gluster --mode=script volume delete %v", volume),
 	}
 
 	// Execute command
@@ -189,7 +189,7 @@ func (s *SshExecutor) createAddBrickCommands(volume *executors.VolumeRequest,
 			}
 
 			// Create a new add-brick command
-			cmd = fmt.Sprintf("sudo gluster --mode=script volume add-brick %v ", volume.Name)
+			cmd = fmt.Sprintf("gluster --mode=script volume add-brick %v ", volume.Name)
 		}
 
 		// Add this brick to the add-brick command
@@ -213,7 +213,7 @@ func (s *SshExecutor) checkForSnapshots(host, volume string) error {
 
 	// Get snapshot information for the specified volume
 	commands := []string{
-		fmt.Sprintf("sudo gluster --mode=script snapshot list %v --xml", volume),
+		fmt.Sprintf("gluster --mode=script snapshot list %v --xml", volume),
 	}
 
 	// Execute command

--- a/extras/docker/gluster/Dockerfile
+++ b/extras/docker/gluster/Dockerfile
@@ -28,7 +28,6 @@ RUN yum --setopt=tsflags=nodocs -q -y install \
   centos-release-gluster \
   ntp \
   epel-release \
-  openssh-server \
   openssh-clients \
   cronie \
   tar \
@@ -57,10 +56,6 @@ RUN chmod 500 /usr/sbin/gluster-setup.sh
 # To avoid the warnings while accessing the container
 RUN sed -i "s/LANG/\#LANG/g" /etc/locale.conf
 
-# Setup ssh
-RUN sed -i '/Defaults    requiretty/c\#Defaults    requiretty' /etc/sudoers
-RUN sed -i '/Port 22/c\Port 2222' /etc/ssh/sshd_config
-
 # Configure LVM so that we can create LVs and snapshots
 RUN sed -i.save -e "s#udev_sync = 1#udev_sync = 0#" \
   -e "s#udev_rules = 1#udev_rules = 0#" \
@@ -71,11 +66,10 @@ RUN echo 'root:password' | chpasswd
 
 # Set SSH public key
 USER root
-RUN mkdir -p /root/.ssh
 
 VOLUME [ “/sys/fs/cgroup”, "/dev", "/run/lvm" , "/var/lib/heketi" ]
 
-EXPOSE 111 245 443 2222 24007 2049 8080 6010 6011 6012 38465 38466 38468 38469 49152 49153 49154 49156 49157 49158 49159 49160 49161 49162
+EXPOSE 111 245 443 24007 2049 8080 6010 6011 6012 38465 38466 38468 38469 49152 49153 49154 49156 49157 49158 49159 49160 49161 49162
 
 RUN systemctl disable nfs-server.service
 RUN systemctl enable rpcbind.service

--- a/pkg/utils/ssh/ssh.go
+++ b/pkg/utils/ssh/ssh.go
@@ -134,10 +134,15 @@ func (s *SshExec) ConnectAndExec(host string, commands []string, timeoutMinutes 
 		session.Stdout = &b
 		session.Stderr = &berr
 
+		// Execute command in a shell
+		command = "/bin/bash -c '" + command + "'"
+
+		// Check if we need to use sudo for the entire command
 		if useSudo {
 			command = "sudo " + command
 		}
 
+		// Execute command
 		err = session.Start(command)
 		if err != nil {
 			return nil, err

--- a/tests/functional/TestManyBricksVolume/config/heketi.json
+++ b/tests/functional/TestManyBricksVolume/config/heketi.json
@@ -28,6 +28,7 @@
 
         "sshexec" : {
             "keyfile" : "config/insecure_private_key",
+            "sudo" : "true",
             "user" : "vagrant"
         }
 	}

--- a/tests/functional/TestOpenShiftSmokeTest/run.sh
+++ b/tests/functional/TestOpenShiftSmokeTest/run.sh
@@ -6,22 +6,35 @@ HEKETI_SERVER_BUILD_DIR=$TOP
 FUNCTIONAL_DIR=${CURRENT_DIR}/..
 HEKETI_SERVER=${FUNCTIONAL_DIR}/heketi-server
 HEKETI_DOCKER_IMG=heketi-docker-ci.img
-DOCKERDIR=$TOP/extras/docker/ci
+GLUSTERFS_DOCKER_IMG=gluster-docker-ci.img
+DOCKERDIR=$TOP/extras/docker
 CLIENTDIR=$TOP/client/cli/go
 
 source ${FUNCTIONAL_DIR}/lib.sh
 
 
 build_docker_file(){
+    echo "Create Heketi Docker image"
     vagrant_heketi_docker=$CURRENT_DIR/vagrant/roles/cluster/files/$HEKETI_DOCKER_IMG
     if [ ! -f "$vagrant_heketi_docker" ] ; then
-        cd $DOCKERDIR
+        cd $DOCKERDIR/ci
         cp $TOP/heketi $DOCKERDIR
         _sudo docker build --rm --tag heketi/heketi:ci . || fail "Unable to create docker container"
         _sudo docker save -o $HEKETI_DOCKER_IMG heketi/heketi:ci || fail "Unable to save docker image"
         cp $HEKETI_DOCKER_IMG $vagrant_heketi_docker
         cd $CURRENT_DIR
     fi
+
+    echo "Create GlusterFS Docker image"
+    vagrant_gluster_docker=$CURRENT_DIR/vagrant/roles/cluster/files/$GLUSTERFS_DOCKER_IMG
+    if [ ! -f "$vagrant_gluster_docker" ] ; then
+        cd $DOCKERDIR/gluster
+        _sudo docker build --rm --tag heketi/gluster:ci . || fail "Unable to create docker container"
+        _sudo docker save -o $GLUSTERFS_DOCKER_IMG heketi/gluster:ci || fail "Unable to save docker image"
+        cp $GLUSTERFS_DOCKER_IMG $vagrant_gluster_docker
+        cd $CURRENT_DIR
+    fi
+
 }
 
 
@@ -42,10 +55,15 @@ deploy_heketi_glusterfs() {
     cd $CURRENT_DIR
 }
 
-teardown_vagrant
+teardown() {
+    teardown_vagrant
+    rm -f $vagrant_heketi_docker $vagrant_gluster_docker > /dev/null 2>&1
+}
+
+teardown
 build_heketi
 copy_client_files
 build_docker_file
 start_vagrant
 deploy_heketi_glusterfs
-teardown_vagrant
+teardown

--- a/tests/functional/TestOpenShiftSmokeTest/vagrant/roles/cluster/tasks/main.yml
+++ b/tests/functional/TestOpenShiftSmokeTest/vagrant/roles/cluster/tasks/main.yml
@@ -23,7 +23,13 @@
   command: docker tag heketi/heketi:ci heketi/heketi:dev
   ignore_errors: yes
 
-- name: upgrade atomic
-  command: atomic host upgrade
+- name: copy gluster docker image
+  copy: src=gluster-docker-ci.img dest=/home/vagrant force=yes mode=0644
+
+- name: register gluster docker image
+  command: docker load -i gluster-docker-ci.img
+
+- name: retag :ci to :latest
+  command: docker tag heketi/gluster:ci heketi/gluster:latest
   ignore_errors: yes
 

--- a/tests/functional/TestSmokeTest/config/heketi.json
+++ b/tests/functional/TestSmokeTest/config/heketi.json
@@ -13,7 +13,8 @@
 
         "sshexec" : {
             "keyfile" : "config/insecure_private_key",
-            "user" : "vagrant"
+            "user" : "vagrant",
+            "sudo" : true
         }
 	}
 }

--- a/tests/functional/TestVolumeNotDeletedWhenNodeIsDown/config/heketi.json
+++ b/tests/functional/TestVolumeNotDeletedWhenNodeIsDown/config/heketi.json
@@ -28,6 +28,7 @@
 
         "sshexec" : {
             "keyfile" : "config/insecure_private_key",
+            "sudo" : "sudo",
             "user" : "vagrant"
         }
 	}

--- a/tests/functional/TestVolumeSnapshotBehavior/config/heketi.json
+++ b/tests/functional/TestVolumeSnapshotBehavior/config/heketi.json
@@ -28,6 +28,7 @@
 
         "sshexec" : {
             "keyfile" : "config/insecure_private_key",
+            "sudo" : "sudo",
             "user" : "vagrant"
         }
 	}


### PR DESCRIPTION
Sudo usage can now be set using the configuration
file heketi.json

There is no need to support sudo in kubeexec,
so we can remove any code that deals with it.

Also update the testing framework to create a
glusterfs container from the repo instead of
using one from Docker hub.

Closes #289
Signed-off-by: Luis Pabón <lpabon@redhat.com>