### PR TITLE
Fix accessor to configuration

### DIFF
--- a/executors/kubeexec/kubeexec.go
+++ b/executors/kubeexec/kubeexec.go
@@ -145,7 +145,7 @@ func NewKubeExecutor(config *KubeConfig) (*KubeExecutor, error) {
 	}
 
 	// Show experimental settings
-	if s.config.RebalanceOnExpansion {
+	if k.config.RebalanceOnExpansion {
 		logger.Warning("Rebalance on volume expansion has been enabled.  This is an EXPERIMENTAL feature")
 	}
 

--- a/executors/kubeexec/kubeexec.go
+++ b/executors/kubeexec/kubeexec.go
@@ -144,6 +144,11 @@ func NewKubeExecutor(config *KubeConfig) (*KubeExecutor, error) {
 		return nil, fmt.Errorf("Namespace must be provided in configuration")
 	}
 
+	// Show experimental settings
+	if s.config.RebalanceOnExpansion {
+		logger.Warning("Rebalance on volume expansion has been enabled.  This is an EXPERIMENTAL feature")
+	}
+
 	godbc.Ensure(k != nil)
 	godbc.Ensure(k.Fstab != "")
 
@@ -286,4 +291,8 @@ func (k *KubeExecutor) ConnectAndExec(host, namespace, resource string,
 	}
 
 	return buffers, nil
+}
+
+func (k *KubeExecutor) RebalanceOnExpansion() bool {
+	return k.config.RebalanceOnExpansion
 }

--- a/executors/kubeexec/kubeexec_test.go
+++ b/executors/kubeexec/kubeexec_test.go
@@ -51,3 +51,40 @@ func TestNewKubeExecutorNoNamespace(t *testing.T) {
 	tests.Assert(t, err != nil)
 	tests.Assert(t, k == nil)
 }
+
+func TestNewKubeExecutorRebalanceOnExpansion(t *testing.T) {
+
+	// This tests access to configurations
+	// from the sshconfig exector
+
+	config := &KubeConfig{
+		Host: "myhost",
+		CLICommandConfig: sshexec.CLICommandConfig{
+			Fstab: "myfstab",
+		},
+		Namespace: "mynamespace",
+	}
+
+	k, err := NewKubeExecutor(config)
+	tests.Assert(t, err == nil)
+	tests.Assert(t, k.Fstab == "myfstab")
+	tests.Assert(t, k.Throttlemap != nil)
+	tests.Assert(t, k.config != nil)
+	tests.Assert(t, k.RebalanceOnExpansion() == false)
+
+	config = &KubeConfig{
+		Host: "myhost",
+		CLICommandConfig: sshexec.CLICommandConfig{
+			Fstab:                "myfstab",
+			RebalanceOnExpansion: true,
+		},
+		Namespace: "mynamespace",
+	}
+
+	k, err = NewKubeExecutor(config)
+	tests.Assert(t, err == nil)
+	tests.Assert(t, k.Fstab == "myfstab")
+	tests.Assert(t, k.Throttlemap != nil)
+	tests.Assert(t, k.config != nil)
+	tests.Assert(t, k.RebalanceOnExpansion() == true)
+}

--- a/executors/sshexec/sshexec.go
+++ b/executors/sshexec/sshexec.go
@@ -183,3 +183,7 @@ func (s *SshExecutor) brickName(brickId string) string {
 func (s *SshExecutor) tpName(brickId string) string {
 	return "tp_" + brickId
 }
+
+func (s *SshExecutor) RebalanceOnExpansion() bool {
+	return s.config.RebalanceOnExpansion
+}

--- a/executors/sshexec/sshexec.go
+++ b/executors/sshexec/sshexec.go
@@ -28,6 +28,7 @@ import (
 
 type RemoteCommandTransport interface {
 	RemoteCommandExecute(host string, commands []string, timeoutMinutes int) ([]string, error)
+	RebalanceOnExpansion() bool
 }
 
 type Ssher interface {

--- a/executors/sshexec/sshexec_test.go
+++ b/executors/sshexec/sshexec_test.go
@@ -79,6 +79,55 @@ func TestNewSshExec(t *testing.T) {
 	tests.Assert(t, s.exec != nil)
 }
 
+func TestSshExecRebalanceOnExpansion(t *testing.T) {
+
+	f := NewFakeSsh()
+	defer tests.Patch(&sshNew,
+		func(logger *utils.Logger, user string, file string) (Ssher, error) {
+			return f, nil
+		}).Restore()
+
+	config := &SshConfig{
+		PrivateKeyFile: "xkeyfile",
+		User:           "xuser",
+		Port:           "100",
+		CLICommandConfig: CLICommandConfig{
+			Fstab: "xfstab",
+		},
+	}
+
+	s, err := NewSshExecutor(config)
+	tests.Assert(t, err == nil)
+	tests.Assert(t, s != nil)
+	tests.Assert(t, s.private_keyfile == config.PrivateKeyFile)
+	tests.Assert(t, s.user == config.User)
+	tests.Assert(t, s.port == config.Port)
+	tests.Assert(t, s.Fstab == config.Fstab)
+	tests.Assert(t, s.exec != nil)
+	tests.Assert(t, s.RebalanceOnExpansion() == false)
+
+	config = &SshConfig{
+		PrivateKeyFile: "xkeyfile",
+		User:           "xuser",
+		Port:           "100",
+		CLICommandConfig: CLICommandConfig{
+			Fstab:                "xfstab",
+			RebalanceOnExpansion: true,
+		},
+	}
+
+	s, err = NewSshExecutor(config)
+	tests.Assert(t, err == nil)
+	tests.Assert(t, s != nil)
+	tests.Assert(t, s.private_keyfile == config.PrivateKeyFile)
+	tests.Assert(t, s.user == config.User)
+	tests.Assert(t, s.port == config.Port)
+	tests.Assert(t, s.Fstab == config.Fstab)
+	tests.Assert(t, s.exec != nil)
+	tests.Assert(t, s.RebalanceOnExpansion() == true)
+
+}
+
 func TestNewSshExecDefaults(t *testing.T) {
 	f := NewFakeSsh()
 	defer tests.Patch(&sshNew,

--- a/executors/sshexec/volume.go
+++ b/executors/sshexec/volume.go
@@ -116,7 +116,7 @@ func (s *SshExecutor) VolumeExpand(host string,
 		maxPerSet)
 
 	// Rebalance if configured
-	if s.config.RebalanceOnExpansion {
+	if s.RebalanceOnExpansion() {
 		commands = append(commands,
 			fmt.Sprintf("gluster --mode=script volume rebalance %v start", volume.Name))
 	}

--- a/executors/sshexec/volume.go
+++ b/executors/sshexec/volume.go
@@ -116,7 +116,7 @@ func (s *SshExecutor) VolumeExpand(host string,
 		maxPerSet)
 
 	// Rebalance if configured
-	if s.RebalanceOnExpansion() {
+	if s.RemoteExecutor.RebalanceOnExpansion() {
 		commands = append(commands,
 			fmt.Sprintf("gluster --mode=script volume rebalance %v start", volume.Name))
 	}


### PR DESCRIPTION
Sshexecutor was trying to access private data from
the Kubeexecutor, and so it was nil, which paniced the server.

Instead create an accessor.

Closes #426

Signed-off-by: Luis Pabón <lpabon@redhat.com>