### PR TITLE
Allow configuration of snapshot limit

### DIFF
--- a/client/cli/go/cmds/volume.go
+++ b/client/cli/go/cmds/volume.go
@@ -75,7 +75,7 @@ func init() {
 		"\n\tOptional: Amount of storage to allocate for snapshot support."+
 			"\n\tMust be greater 1.0.  For example if a 10TiB volume requires 5TiB of"+
 			"\n\tsnapshot storage, then snapshot-factor would be set to 1.5.  If the"+
-			"\n\tvalue is set to 1, then snapshots will not be enabled for this volume")
+			"\n\tvalue is set to 1, then snapshots will consume the storage allocated")
 	volumeCreateCommand.Flags().StringVar(&clusters, "clusters", "",
 		"\n\tOptional: Comma separated list of cluster ids where this volume"+
 			"\n\tmust be allocated. If ommitted, Heketi will allocate the volume"+

--- a/executors/kubeexec/kubeexec.go
+++ b/executors/kubeexec/kubeexec.go
@@ -296,3 +296,7 @@ func (k *KubeExecutor) ConnectAndExec(host, namespace, resource string,
 func (k *KubeExecutor) RebalanceOnExpansion() bool {
 	return k.config.RebalanceOnExpansion
 }
+
+func (k *KubeExecutor) SnapShotLimit() int {
+	return k.config.SnapShotLimit
+}

--- a/executors/sshexec/config.go
+++ b/executors/sshexec/config.go
@@ -17,8 +17,9 @@
 package sshexec
 
 type CLICommandConfig struct {
-	Fstab string `json:"fstab"`
-	Sudo  bool   `json:"sudo"`
+	Fstab         string `json:"fstab"`
+	Sudo          bool   `json:"sudo"`
+	SnapShotLimit int    `json:"snapshot_limit"`
 
 	// Experimental Settings
 	RebalanceOnExpansion bool `json:"rebalance_on_expansion"`

--- a/executors/sshexec/peer.go
+++ b/executors/sshexec/peer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lpabon/godbc"
 )
 
+// :TODO: Rename this function to NodeInit or something
 func (s *SshExecutor) PeerProbe(host, newnode string) error {
 
 	godbc.Require(host != "")
@@ -34,6 +35,19 @@ func (s *SshExecutor) PeerProbe(host, newnode string) error {
 	_, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 10)
 	if err != nil {
 		return err
+	}
+
+	// Determine if there is a snapshot limit configuration setting
+	if s.RemoteExecutor.SnapShotLimit() > 0 {
+		logger.Info("Setting snapshot limit")
+		commands = []string{
+			fmt.Sprintf("gluster --mode=script snapshot config snap-max-hard-limit %v",
+				s.RemoteExecutor.SnapShotLimit()),
+		}
+		_, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 10)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/executors/sshexec/peer_test.go
+++ b/executors/sshexec/peer_test.go
@@ -1,0 +1,108 @@
+//
+// Copyright (c) 2016 The heketi Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package sshexec
+
+import (
+	"testing"
+
+	"github.com/heketi/heketi/pkg/utils"
+	"github.com/heketi/tests"
+)
+
+func TestSshExecPeerProbe(t *testing.T) {
+
+	f := NewFakeSsh()
+	defer tests.Patch(&sshNew,
+		func(logger *utils.Logger, user string, file string) (Ssher, error) {
+			return f, nil
+		}).Restore()
+
+	config := &SshConfig{
+		PrivateKeyFile: "xkeyfile",
+		User:           "xuser",
+		CLICommandConfig: CLICommandConfig{
+			Fstab: "/my/fstab",
+		},
+	}
+
+	s, err := NewSshExecutor(config)
+	tests.Assert(t, err == nil)
+	tests.Assert(t, s != nil)
+
+	// Mock ssh function
+	f.FakeConnectAndExec = func(host string,
+		commands []string,
+		timeoutMinutes int,
+		useSudo bool) ([]string, error) {
+
+		tests.Assert(t, host == "host:22", host)
+		tests.Assert(t, len(commands) == 1)
+		tests.Assert(t, commands[0] == "gluster peer probe newnode", commands)
+
+		return nil, nil
+	}
+
+	// Call function
+	err = s.PeerProbe("host", "newnode")
+	tests.Assert(t, err == nil, err)
+
+	// Now set the snapshot limit
+	config = &SshConfig{
+		PrivateKeyFile: "xkeyfile",
+		User:           "xuser",
+		CLICommandConfig: CLICommandConfig{
+			Fstab:         "/my/fstab",
+			SnapShotLimit: 14,
+		},
+	}
+
+	s, err = NewSshExecutor(config)
+	tests.Assert(t, err == nil)
+	tests.Assert(t, s != nil)
+
+	// Mock ssh function
+	count := 0
+	f.FakeConnectAndExec = func(host string,
+		commands []string,
+		timeoutMinutes int,
+		useSudo bool) ([]string, error) {
+
+		switch count {
+		case 0:
+			tests.Assert(t, host == "host:22", host)
+			tests.Assert(t, len(commands) == 1)
+			tests.Assert(t, commands[0] == "gluster peer probe newnode", commands)
+
+		case 1:
+			tests.Assert(t, host == "host:22", host)
+			tests.Assert(t, len(commands) == 1)
+			tests.Assert(t, commands[0] == "gluster --mode=script snapshot config snap-max-hard-limit 14", commands)
+
+		default:
+			tests.Assert(t, false, "Should not be reached")
+		}
+		count++
+
+		return nil, nil
+	}
+
+	// Call function
+	err = s.PeerProbe("host", "newnode")
+	tests.Assert(t, err == nil, err)
+	tests.Assert(t, count == 2)
+
+}

--- a/executors/sshexec/sshexec.go
+++ b/executors/sshexec/sshexec.go
@@ -29,6 +29,7 @@ import (
 type RemoteCommandTransport interface {
 	RemoteCommandExecute(host string, commands []string, timeoutMinutes int) ([]string, error)
 	RebalanceOnExpansion() bool
+	SnapShotLimit() int
 }
 
 type Ssher interface {
@@ -187,4 +188,8 @@ func (s *SshExecutor) tpName(brickId string) string {
 
 func (s *SshExecutor) RebalanceOnExpansion() bool {
 	return s.config.RebalanceOnExpansion
+}
+
+func (s *SshExecutor) SnapShotLimit() int {
+	return s.config.SnapShotLimit
 }

--- a/executors/sshexec/volume.go
+++ b/executors/sshexec/volume.go
@@ -72,7 +72,7 @@ func (s *SshExecutor) VolumeCreate(host string,
 	commands = append(commands, s.createAddBrickCommands(volume, inSet, inSet, maxPerSet)...)
 
 	// Add command to start the volume
-	commands = append(commands, fmt.Sprintf("gluster volume start %v", volume.Name))
+	commands = append(commands, fmt.Sprintf("gluster --mode=script volume start %v", volume.Name))
 
 	// Execute command
 	_, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 10)

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -222,31 +222,30 @@ func (v *VolumeInfoResponse) String() string {
 			v.Durability.Disperse.Data,
 			v.Durability.Disperse.Redundancy)
 	case DurabilityReplicate:
-		s += fmt.Sprintf("Replica: %v\n",
+		s += fmt.Sprintf("Distributed+Replica: %v\n",
 			v.Durability.Replicate.Replica)
 	}
 
 	if v.Snapshot.Enable {
-		s += fmt.Sprintf("Snapshot: Enabled\n"+
-			"Snapshot Factor: %.2f\n",
+		s += fmt.Sprintf("Snapshot Factor: %.2f\n",
 			v.Snapshot.Factor)
-	} else {
-		s += "Snapshot: Disabled\n"
 	}
 
-	s += "\nBricks:\n"
-	for _, b := range v.Bricks {
-		s += fmt.Sprintf("Id: %v\n"+
-			"Path: %v\n"+
-			"Size (GiB): %v\n"+
-			"Node: %v\n"+
-			"Device: %v\n\n",
-			b.Id,
-			b.Path,
-			b.Size/(1024*1024),
-			b.NodeId,
-			b.DeviceId)
-	}
+	/*
+		s += "\nBricks:\n"
+		for _, b := range v.Bricks {
+			s += fmt.Sprintf("Id: %v\n"+
+				"Path: %v\n"+
+				"Size (GiB): %v\n"+
+				"Node: %v\n"+
+				"Device: %v\n\n",
+				b.Id,
+				b.Path,
+				b.Size/(1024*1024),
+				b.NodeId,
+				b.DeviceId)
+		}
+	*/
 
 	return s
 }


### PR DESCRIPTION
This change allows the administrator to set the maximum
limit of snapshots in the configuration file.

If no limit has been specified, then Heketi will not set
a limit and GlusterFS will use its default value.

Closes #419

Signed-off-by: Luis Pabón <lpabon@redhat.com>