### PR TITLE
Use older model for coverage

### DIFF
--- a/.travis-coverage
+++ b/.travis-coverage
@@ -3,13 +3,38 @@
 # We cannot use go test -coverprofile=cover.out ./... because
 # the tool requires that it be used only on one package when
 # capturing the coverage
+# This is why we need this little script here.
+packages="./apps/glusterfs"
+packages="${packages} ./executors/sshexec"
+packages="${packages} ./executors/mockexec"
+packages="${packages} ./executors/kubeexec"
+packages="${packages} ./client/api/go-client"
+packages="${packages} ./middleware"
+packages="${packages} ./pkg/utils"
 COVERFILE=packagecover.out
 
-# For each package with test files, run with full coverage (including other packages)
-go list -f '{{if gt (len .TestGoFiles) 0}}"godep go test -covermode count -coverprofile {{.Name}}_{{len .Imports}}_{{len .Deps}}.coverprofile -coverpkg ./... {{.ImportPath}}"{{end}}' ./... | xargs -I {} bash -c {}
+coverage()
+{
 
-# Merge the generated cover profiles into a single file
-gocovmerge `ls *.coverprofile` > $COVERFILE
+    echo "mode: count" > $COVERFILE
+    for pkg in $packages ; do
+        echo "-- Testing $pkg --"
+
+        # Collect coverage
+        go test -covermode=count -coverprofile=cover.out $pkg || exit 1
+
+        # Show in the command line
+        go tool cover -func=cover.out
+
+        # Append to coverfile
+        grep -v "^mode: count" cover.out >> $COVERFILE
+
+        # Cleanup
+        rm -f cover.out
+    done
+}
+
+coverage
 
 if [ -n "$COVERALLS_TOKEN" ] ; then
     # Send to coveralls.io


### PR DESCRIPTION
Now that the vendor directory is in use, it can confuse
normal utilities.  Use older model to avoide issues.