### PR TITLE
make bash behave as login shell

### DIFF
--- a/pkg/utils/ssh/ssh.go
+++ b/pkg/utils/ssh/ssh.go
@@ -135,7 +135,7 @@ func (s *SshExec) ConnectAndExec(host string, commands []string, timeoutMinutes 
 		session.Stderr = &berr
 
 		// Execute command in a shell
-		command = "/bin/bash -c '" + command + "'"
+		command = "/bin/bash -l -c '" + command + "'"
 
 		// Check if we need to use sudo for the entire command
 		if useSudo {


### PR DESCRIPTION
When bash is executed over ssh, if -l is not used it does not behave
like a login shell causing differences in $PATH and ENV variables.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>