### PR TITLE
[RFC] apps:glusterfs: make it possible to get 1xN volumes (N=#replica)

### DIFF
--- a/apps/glusterfs/app_volume_test.go
+++ b/apps/glusterfs/app_volume_test.go
@@ -491,9 +491,8 @@ func TestVolumeCreate(t *testing.T) {
 	}
 	tests.Assert(t, info.Id != "")
 	tests.Assert(t, info.Cluster != "")
-	tests.Assert(t, len(info.Bricks) == 2) // Only two 50GB bricks needed
-	tests.Assert(t, info.Bricks[0].Size == 50*GB)
-	tests.Assert(t, info.Bricks[1].Size == 50*GB)
+	tests.Assert(t, len(info.Bricks) == 1) // Only one 100GB brick needed
+	tests.Assert(t, info.Bricks[0].Size == 100*GB)
 	tests.Assert(t, info.Name == "vol_"+info.Id)
 	tests.Assert(t, info.Snapshot.Enable == false)
 	tests.Assert(t, info.Snapshot.Factor == 1)

--- a/apps/glusterfs/volume_durability_replica.go
+++ b/apps/glusterfs/volume_durability_replica.go
@@ -44,10 +44,12 @@ func (r *VolumeReplicaDurability) BrickSizeGenerator(size uint64) func() (int, u
 	return func() (int, uint64, error) {
 
 		var brick_size uint64
+		var num_sets int
 
 		for {
+			num_sets = sets
 			sets *= 2
-			brick_size = size / uint64(sets)
+			brick_size = size / uint64(num_sets)
 
 			if brick_size < BrickMinSize {
 				return 0, 0, ErrMinimumBrickSize
@@ -56,7 +58,7 @@ func (r *VolumeReplicaDurability) BrickSizeGenerator(size uint64) func() (int, u
 			}
 		}
 
-		return sets, brick_size, nil
+		return num_sets, brick_size, nil
 	}
 }
 

--- a/apps/glusterfs/volume_durability_test.go
+++ b/apps/glusterfs/volume_durability_test.go
@@ -89,32 +89,39 @@ func TestNoneDurability(t *testing.T) {
 	// Gen 1
 	sets, brick_size, err := gen()
 	tests.Assert(t, err == nil)
+	tests.Assert(t, sets == 1)
+	tests.Assert(t, brick_size == 100*GB)
+	tests.Assert(t, 1 == r.BricksInSet())
+
+	// Gen 2
+	sets, brick_size, err = gen()
+	tests.Assert(t, err == nil)
 	tests.Assert(t, sets == 2)
 	tests.Assert(t, brick_size == 50*GB)
 	tests.Assert(t, 1 == r.BricksInSet())
 
-	// Gen 2
+	// Gen 3
 	sets, brick_size, err = gen()
 	tests.Assert(t, err == nil)
 	tests.Assert(t, sets == 4)
 	tests.Assert(t, brick_size == 25*GB)
 	tests.Assert(t, 1 == r.BricksInSet())
 
-	// Gen 3
+	// Gen 4
 	sets, brick_size, err = gen()
 	tests.Assert(t, err == nil)
 	tests.Assert(t, sets == 8)
 	tests.Assert(t, brick_size == 12800*1024)
 	tests.Assert(t, 1 == r.BricksInSet())
 
-	// Gen 4
+	// Gen 5
 	sets, brick_size, err = gen()
 	tests.Assert(t, err == nil)
 	tests.Assert(t, sets == 16)
 	tests.Assert(t, brick_size == 6400*1024)
 	tests.Assert(t, 1 == r.BricksInSet())
 
-	// Gen 5
+	// Gen 6
 	sets, brick_size, err = gen()
 	tests.Assert(t, err == ErrMinimumBrickSize)
 	tests.Assert(t, sets == 0)
@@ -174,32 +181,39 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	// Gen 1
 	sets, brick_size, err := gen()
 	tests.Assert(t, err == nil)
-	tests.Assert(t, sets == 2)
-	tests.Assert(t, brick_size == 50*GB)
+	tests.Assert(t, sets == 1)
+	tests.Assert(t, brick_size == 100*GB)
 	tests.Assert(t, 2 == r.BricksInSet())
 
 	// Gen 2
+	sets, brick_size, err = gen()
+	tests.Assert(t, err == nil)
+	tests.Assert(t, sets == 2, "sets we got:", sets)
+	tests.Assert(t, brick_size == 50*GB)
+	tests.Assert(t, 2 == r.BricksInSet())
+
+	// Gen 3
 	sets, brick_size, err = gen()
 	tests.Assert(t, err == nil)
 	tests.Assert(t, sets == 4)
 	tests.Assert(t, brick_size == 25*GB)
 	tests.Assert(t, 2 == r.BricksInSet())
 
-	// Gen 3
+	// Gen 4
 	sets, brick_size, err = gen()
 	tests.Assert(t, err == nil)
 	tests.Assert(t, sets == 8)
 	tests.Assert(t, brick_size == 12800*1024)
 	tests.Assert(t, 2 == r.BricksInSet())
 
-	// Gen 4
+	// Gen 5
 	sets, brick_size, err = gen()
 	tests.Assert(t, err == nil)
 	tests.Assert(t, sets == 16)
 	tests.Assert(t, brick_size == 6400*1024)
 	tests.Assert(t, 2 == r.BricksInSet())
 
-	// Gen 5
+	// Gen 6
 	sets, brick_size, err = gen()
 	tests.Assert(t, err == ErrMinimumBrickSize)
 	tests.Assert(t, sets == 0)

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -578,10 +578,8 @@ func TestVolumeEntryCreateFourBricks(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Check that it used only two bricks each with only two replicas
-	tests.Assert(t, len(info.Bricks) == 4)
+	tests.Assert(t, len(info.Bricks) == 2)
 	tests.Assert(t, info.Bricks[0].Size == info.Bricks[1].Size)
-	tests.Assert(t, info.Bricks[0].Size == info.Bricks[2].Size)
-	tests.Assert(t, info.Bricks[0].Size == info.Bricks[3].Size)
 	tests.Assert(t, info.Cluster == v.Info.Cluster)
 
 	// Check information on the bricks
@@ -962,7 +960,7 @@ func TestVolumeEntryCreateWithSnapshot(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Check that it used only two bricks each with only two replicas
-	tests.Assert(t, len(info.Bricks) == 4)
+	tests.Assert(t, len(info.Bricks) == 2)
 	err = app.db.View(func(tx *bolt.Tx) error {
 		for _, b := range info.Bricks {
 			device, err := NewDeviceEntryFromId(tx, b.DeviceId)
@@ -1324,13 +1322,13 @@ func TestVolumeEntryExpand(t *testing.T) {
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, v.Info.Size == 1024)
-	tests.Assert(t, len(v.Bricks) == 4)
+	tests.Assert(t, len(v.Bricks) == 2)
 
 	// Expand volume
 	err = v.Expand(app.db, app.executor, app.allocator, 1234)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, v.Info.Size == 1024+1234)
-	tests.Assert(t, len(v.Bricks) == 8)
+	tests.Assert(t, len(v.Bricks) == 4)
 
 	// Check db
 	var entry *VolumeEntry

--- a/tests/functional/TestSmokeTest/tests/heketi_test.go
+++ b/tests/functional/TestSmokeTest/tests/heketi_test.go
@@ -225,7 +225,7 @@ func TestHeketiVolumes(t *testing.T) {
 	tests.Assert(t, volInfo.Size == 100)
 	tests.Assert(t, volInfo.Mount.GlusterFS.MountPoint != "")
 	tests.Assert(t, volInfo.Name != "")
-	tests.Assert(t, len(volInfo.Bricks) == 3)
+	tests.Assert(t, len(volInfo.Bricks) == 3, len(volInfo.Bricks))
 
 	// Check there are two volumes
 	volumes, err = heketi.VolumeList()

--- a/tests/functional/TestSmokeTest/tests/heketi_test.go
+++ b/tests/functional/TestSmokeTest/tests/heketi_test.go
@@ -225,7 +225,7 @@ func TestHeketiVolumes(t *testing.T) {
 	tests.Assert(t, volInfo.Size == 100)
 	tests.Assert(t, volInfo.Mount.GlusterFS.MountPoint != "")
 	tests.Assert(t, volInfo.Name != "")
-	tests.Assert(t, len(volInfo.Bricks) == 6)
+	tests.Assert(t, len(volInfo.Bricks) == 3)
 
 	// Check there are two volumes
 	volumes, err = heketi.VolumeList()


### PR DESCRIPTION
Start the BrickSizeGenerator with the full volume size.

Signed-off-by: Michael Adam <obnox@redhat.com>