### PR TITLE
heketi-cli: fix panic in topology load if TopologyInfo fails

### DIFF
--- a/client/cli/go/cmds/topology.go
+++ b/client/cli/go/cmds/topology.go
@@ -126,6 +126,10 @@ var topologyLoadCommand = &cobra.Command{
 
 		// Load current topolgy
 		heketiTopology, err := heketi.TopologyInfo()
+		if err != nil {
+			fmt.Fprintf(stdout, "Unable to get topology information\n")
+			return fmt.Errorf("Unable to get topology information: %v", err)
+		}
 
 		// Register topology
 		for _, cluster := range topology.Clusters {


### PR DESCRIPTION
React to error from TopologyInfo function.

Closes #445

Signed-off-by: Michael Adam <obnox@redhat.com>