### PR TITLE
functional/TestSmokeTest: use 'become' instead of deprecated 'sudo'

### DIFF
--- a/tests/functional/TestSmokeTest/vagrant/site.yml
+++ b/tests/functional/TestSmokeTest/vagrant/site.yml
@@ -1,9 +1,11 @@
 - hosts: all
-  sudo: True
+  become: yes
+  become_method: sudo
   roles:
     - common
 
 - hosts: gluster
-  sudo: True
+  become: yes
+  become_method: sudo
   roles:
     - gluster


### PR DESCRIPTION
Signed-off-by: Michael Adam <obnox@redhat.com>