### PR TITLE
Improve error handling and reporting when deleting items.

### DIFF
--- a/apps/glusterfs/app_cluster.go
+++ b/apps/glusterfs/app_cluster.go
@@ -18,10 +18,11 @@ package glusterfs
 
 import (
 	"encoding/json"
+	"net/http"
+
 	"github.com/boltdb/bolt"
 	"github.com/gorilla/mux"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
-	"net/http"
 )
 
 func (a *App) ClusterCreate(w http.ResponseWriter, r *http.Request) {
@@ -143,11 +144,12 @@ func (a *App) ClusterDelete(w http.ResponseWriter, r *http.Request) {
 		}
 
 		err = entry.Delete(tx)
-		if err == ErrConflict {
-			http.Error(w, err.Error(), http.StatusConflict)
-			return err
-		} else if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+		if err != nil {
+			if err == ErrConflict {
+				http.Error(w, entry.ConflictString(), http.StatusConflict)
+			} else {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
 			return err
 		}
 

--- a/apps/glusterfs/app_cluster_test.go
+++ b/apps/glusterfs/app_cluster_test.go
@@ -334,6 +334,7 @@ func TestClusterDelete(t *testing.T) {
 	r, err := http.DefaultClient.Do(req)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, r.StatusCode == http.StatusConflict)
+	tests.Assert(t, utils.GetErrorFromResponse(r).Error() == entries[0].ConflictString())
 
 	// Check that we cannot delete a cluster with volumes
 	req, err = http.NewRequest("DELETE", ts.URL+"/clusters/"+"a2", nil)
@@ -341,6 +342,7 @@ func TestClusterDelete(t *testing.T) {
 	r, err = http.DefaultClient.Do(req)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, r.StatusCode == http.StatusConflict)
+	tests.Assert(t, utils.GetErrorFromResponse(r).Error() == entries[1].ConflictString())
 
 	// Check that we cannot delete a cluster with nodes
 	req, err = http.NewRequest("DELETE", ts.URL+"/clusters/"+"a3", nil)
@@ -348,6 +350,7 @@ func TestClusterDelete(t *testing.T) {
 	r, err = http.DefaultClient.Do(req)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, r.StatusCode == http.StatusConflict)
+	tests.Assert(t, utils.GetErrorFromResponse(r).Error() == entries[2].ConflictString())
 
 	// Delete cluster with no elements
 	req, err = http.NewRequest("DELETE", ts.URL+"/clusters/"+"000", nil)

--- a/apps/glusterfs/app_device.go
+++ b/apps/glusterfs/app_device.go
@@ -225,7 +225,7 @@ func (a *App) DeviceDelete(w http.ResponseWriter, r *http.Request) {
 
 		// Check if we can delete the device
 		if !device.IsDeleteOk() {
-			http.Error(w, ErrConflict.Error(), http.StatusConflict)
+			http.Error(w, device.ConflictString(), http.StatusConflict)
 			return ErrConflict
 		}
 

--- a/apps/glusterfs/app_device_test.go
+++ b/apps/glusterfs/app_device_test.go
@@ -236,6 +236,7 @@ func TestDeviceAddDelete(t *testing.T) {
 	r, err = http.DefaultClient.Do(req)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, r.StatusCode == http.StatusConflict)
+	tests.Assert(t, utils.GetErrorFromResponse(r).Error() == devicemap["/dev/fake1"].ConflictString())
 
 	// Check the db is still intact
 	err = app.db.View(func(tx *bolt.Tx) error {

--- a/apps/glusterfs/app_node.go
+++ b/apps/glusterfs/app_node.go
@@ -227,7 +227,7 @@ func (a *App) NodeDelete(w http.ResponseWriter, r *http.Request) {
 
 		// Check the node can be deleted
 		if !node.IsDeleteOk() {
-			http.Error(w, ErrConflict.Error(), http.StatusConflict)
+			http.Error(w, node.ConflictString(), http.StatusConflict)
 			return ErrConflict
 		}
 

--- a/apps/glusterfs/app_node_test.go
+++ b/apps/glusterfs/app_node_test.go
@@ -397,6 +397,7 @@ func TestNodeAddDelete(t *testing.T) {
 	r, err = http.DefaultClient.Do(req)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, r.StatusCode == http.StatusConflict)
+	tests.Assert(t, utils.GetErrorFromResponse(r).Error() == entry.ConflictString())
 
 	// Check that nothing has changed in the db
 	var cluster *ClusterEntry

--- a/apps/glusterfs/device_entry.go
+++ b/apps/glusterfs/device_entry.go
@@ -148,12 +148,16 @@ func (d *DeviceEntry) IsDeleteOk() bool {
 	return true
 }
 
+func (d *DeviceEntry) ConflictString() string {
+	return fmt.Sprintf("Unable to delete device [%v] because it contains bricks", d.Info.Id)
+}
+
 func (d *DeviceEntry) Delete(tx *bolt.Tx) error {
 	godbc.Require(tx != nil)
 
 	// Check if the devices still has drives
 	if !d.IsDeleteOk() {
-		logger.Warning("Unable to delete device [%v] because it contains bricks", d.Info.Id)
+		logger.Warning(d.ConflictString())
 		return ErrConflict
 	}
 

--- a/apps/glusterfs/errors.go
+++ b/apps/glusterfs/errors.go
@@ -18,13 +18,12 @@ package glusterfs
 
 import (
 	"errors"
-	"net/http"
 )
 
 var (
 	ErrNoSpace          = errors.New("No space")
 	ErrNotFound         = errors.New("Id not found")
-	ErrConflict         = errors.New(http.StatusText(http.StatusConflict))
+	ErrConflict         = errors.New("The target exists, contains other items, or is in use.")
 	ErrMaxBricks        = errors.New("Maximum number of bricks reached.")
 	ErrMinimumBrickSize = errors.New("Minimum brick size limit reached.  Out of space.")
 	ErrDbAccess         = errors.New("Unable to access db")

--- a/apps/glusterfs/node_entry.go
+++ b/apps/glusterfs/node_entry.go
@@ -159,12 +159,16 @@ func (n *NodeEntry) IsDeleteOk() bool {
 	return true
 }
 
+func (n *NodeEntry) ConflictString() string {
+	return fmt.Sprintf("Unable to delete node [%v] because it contains devices", n.Info.Id)
+}
+
 func (n *NodeEntry) Delete(tx *bolt.Tx) error {
 	godbc.Require(tx != nil)
 
 	// Check if the nodes still has drives
 	if !n.IsDeleteOk() {
-		logger.Warning("Unable to delete node [%v] because it contains devices", n.Info.Id)
+		logger.Warning(n.ConflictString())
 		return ErrConflict
 	}
 


### PR DESCRIPTION
Allow more useful error messages to be reported and logged when attempting to
delete clusters, nodes, and devices in the glusterfs app. Minor changes also
to simplify and bring consistency to error reporting within related functions.

Closes #355

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>