### PR TITLE
ci: Update OpenShift test to use origin 1.3

### DIFF
--- a/tests/functional/TestOpenShiftSmokeTest/vagrant/roles/client/files/hosts.conf
+++ b/tests/functional/TestOpenShiftSmokeTest/vagrant/roles/client/files/hosts.conf
@@ -4,8 +4,8 @@ nodes
 
 [OSEv3:vars]
 deployment_type=origin
-openshift_pkg_version=v1.2.1
-openshift_image_tag=v1.2.1
+openshift_pkg_version=v1.3.0
+openshift_image_tag=v1.3.0
 ansible_ssh_user=root
 ansible_sudo=true
 containerized=true

--- a/tests/functional/TestOpenShiftSmokeTest/vagrant/roles/client/tasks/main.yml
+++ b/tests/functional/TestOpenShiftSmokeTest/vagrant/roles/client/tasks/main.yml
@@ -18,8 +18,8 @@
     - ansible
     - pyOpenSSL
 
-- name: get openshift-ansible
-  git: repo=https://github.com/openshift/openshift-ansible dest=/home/vagrant/openshift-ansible version=enterprise-3.2
+- name: get openshift-ansible release 1.3
+  git: repo=https://github.com/openshift/openshift-ansible dest=/home/vagrant/openshift-ansible version=3cc5b0562de1b8a2334104542c15a6cce67b68bf
 
 - name: copy hosts.conf
   copy: src=hosts.conf dest=/home/vagrant force=yes mode=0644
@@ -49,10 +49,10 @@
   command: chmod a+x /etc/rc.d/rc.local
 
 - name: get oc client
-  unarchive: src=https://github.com/openshift/origin/releases/download/v1.2.1/openshift-origin-client-tools-v1.2.1-5e723f6-linux-64bit.tar.gz dest=/home/vagrant copy=no
+  unarchive: src=https://github.com/openshift/origin/releases/download/v1.3.0/openshift-origin-client-tools-v1.3.0-3ab7af3d097b57f933eccef684a714f2368804e7-linux-64bit.tar.gz dest=/home/vagrant copy=no
 
 - name: copy oc to /usr/bin
-  command: cp /home/vagrant/openshift-origin-client-tools-v1.2.1-5e723f6-linux-64bit/oc /usr/bin
+  command: cp /home/vagrant/openshift-origin-client-tools-v1.3.0-3ab7af3d097b57f933eccef684a714f2368804e7-linux-64bit/oc /usr/bin
 
 - name: install openshift this can take about 20 mins
   command: ansible-playbook -i hosts.conf openshift-ansible/playbooks/byo/config.yml


### PR DESCRIPTION
Needed to change both the openshift-ansible release to 1.3 and the
version of Origin to 1.3.0.

Closes #502

Signed-off-by: Luis Pabón <lpabon@redhat.com>