### PR TITLE
api: New GID support in VolumeCreate API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ LDFLAGS :=-ldflags "-X main.HEKETI_VERSION=$(VERSION)"
 # Package target
 PACKAGE :=$(DIR)/dist/$(APP_NAME)-$(VERSION).$(GOOS).$(ARCH).tar.gz
 CLIENT_PACKAGE :=$(DIR)/dist/$(APP_NAME)-client-$(VERSION).$(GOOS).$(ARCH).tar.gz
+GOFILES=$(shell go list ./... | grep -v vendor)
 
 .DEFAULT: all
 
@@ -60,7 +61,7 @@ run: server
 	./$(APP_NAME)
 
 test: 
-	godep go test ./...
+	godep go test $(GOFILES)
 
 clean:
 	@echo Cleaning Workspace...

--- a/apps/glusterfs/app_volume.go
+++ b/apps/glusterfs/app_volume.go
@@ -19,6 +19,7 @@ package glusterfs
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 
 	"github.com/boltdb/bolt"
@@ -38,6 +39,16 @@ func (a *App) VolumeCreate(w http.ResponseWriter, r *http.Request) {
 	err := utils.GetJsonFromRequest(r, &msg)
 	if err != nil {
 		http.Error(w, "request unable to be parsed", 422)
+		return
+	}
+
+	// Check group id
+	switch {
+	case msg.Gid < 0:
+		http.Error(w, "Bad group id less than zero", http.StatusBadRequest)
+		return
+	case msg.Gid >= math.MaxInt32:
+		http.Error(w, "Bad group id equal or greater than 2**32", http.StatusBadRequest)
 		return
 	}
 

--- a/apps/glusterfs/brick_entry.go
+++ b/apps/glusterfs/brick_entry.go
@@ -30,6 +30,7 @@ type BrickEntry struct {
 	Info             api.BrickInfo
 	TpSize           uint64
 	PoolMetadataSize uint64
+	gidRequested     int64
 }
 
 func BrickList(tx *bolt.Tx) ([]string, error) {
@@ -41,13 +42,16 @@ func BrickList(tx *bolt.Tx) ([]string, error) {
 	return list, nil
 }
 
-func NewBrickEntry(size, tpsize, poolMetadataSize uint64, deviceid, nodeid string) *BrickEntry {
+func NewBrickEntry(size, tpsize, poolMetadataSize uint64,
+	deviceid, nodeid string, gid int64) *BrickEntry {
+
 	godbc.Require(size > 0)
 	godbc.Require(tpsize > 0)
 	godbc.Require(deviceid != "")
 	godbc.Require(nodeid != "")
 
 	entry := &BrickEntry{}
+	entry.gidRequested = gid
 	entry.TpSize = tpsize
 	entry.PoolMetadataSize = poolMetadataSize
 	entry.Info.Id = utils.GenUUID()
@@ -147,6 +151,7 @@ func (b *BrickEntry) Create(db *bolt.DB, executor executors.Executor) error {
 
 	// Create request
 	req := &executors.BrickRequest{}
+	req.Gid = b.gidRequested
 	req.Name = b.Info.Id
 	req.Size = b.Info.Size
 	req.TpSize = b.TpSize

--- a/apps/glusterfs/brick_entry_test.go
+++ b/apps/glusterfs/brick_entry_test.go
@@ -35,14 +35,16 @@ func TestNewBrickEntry(t *testing.T) {
 	deviceid := "abc"
 	nodeid := "def"
 	ps := size
+	gid := int64(1)
 
-	b := NewBrickEntry(size, tpsize, ps, deviceid, nodeid)
+	b := NewBrickEntry(size, tpsize, ps, deviceid, nodeid, gid)
 	tests.Assert(t, b.Info.Id != "")
 	tests.Assert(t, b.TpSize == tpsize)
 	tests.Assert(t, b.PoolMetadataSize == ps)
 	tests.Assert(t, b.Info.DeviceId == deviceid)
 	tests.Assert(t, b.Info.NodeId == nodeid)
 	tests.Assert(t, b.Info.Size == size)
+	tests.Assert(t, b.gidRequested == gid)
 }
 
 func TestBrickEntryMarshal(t *testing.T) {
@@ -51,7 +53,8 @@ func TestBrickEntryMarshal(t *testing.T) {
 	deviceid := "abc"
 	nodeid := "def"
 	ps := size
-	m := NewBrickEntry(size, tpsize, ps, deviceid, nodeid)
+	gid := int64(0)
+	m := NewBrickEntry(size, tpsize, ps, deviceid, nodeid, gid)
 
 	buffer, err := m.Marshal()
 	tests.Assert(t, err == nil)
@@ -91,7 +94,7 @@ func TestNewBrickEntryFromId(t *testing.T) {
 	defer app.Close()
 
 	// Create a brick
-	b := NewBrickEntry(10, 20, 5, "abc", "def")
+	b := NewBrickEntry(10, 20, 5, "abc", "def", 0)
 
 	// Save element in database
 	err := app.db.Update(func(tx *bolt.Tx) error {
@@ -119,7 +122,7 @@ func TestNewBrickEntrySaveDelete(t *testing.T) {
 	defer app.Close()
 
 	// Create a brick
-	b := NewBrickEntry(10, 20, 5, "abc", "def")
+	b := NewBrickEntry(10, 20, 5, "abc", "def", 1000)
 
 	// Save element in database
 	err := app.db.Update(func(tx *bolt.Tx) error {
@@ -164,7 +167,7 @@ func TestNewBrickEntryNewInfoResponse(t *testing.T) {
 	defer app.Close()
 
 	// Create a brick
-	b := NewBrickEntry(10, 20, 5, "abc", "def")
+	b := NewBrickEntry(10, 20, 5, "abc", "def", 1000)
 
 	// Save element in database
 	err := app.db.Update(func(tx *bolt.Tx) error {
@@ -195,7 +198,7 @@ func TestBrickEntryDestroyCheck(t *testing.T) {
 	defer app.Close()
 
 	// Create a brick
-	b := NewBrickEntry(10, 20, 5, "abc", "node")
+	b := NewBrickEntry(10, 20, 5, "abc", "node", 1000)
 	n := NewNodeEntry()
 	n.Info.Id = "node"
 	n.Info.Hostnames.Manage = []string{"manage"}
@@ -222,4 +225,55 @@ func TestBrickEntryDestroyCheck(t *testing.T) {
 
 	err = b.DestroyCheck(app.db, app.executor)
 	tests.Assert(t, err == nil, err)
+}
+
+func TestBrickEntryCreate(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	// Set test values
+	size := uint64(10)
+	tpsize := uint64(20)
+	poolMetadataSize := uint64(5)
+	deviceid := "abc"
+	nodeid := "node"
+	gid := int64(1000)
+
+	// Create a brick
+	b := NewBrickEntry(size, tpsize, poolMetadataSize,
+		deviceid, nodeid, gid)
+	n := NewNodeEntry()
+	n.Info.Id = nodeid
+	n.Info.Hostnames.Manage = []string{"manage"}
+	n.Info.Hostnames.Storage = []string{"storage"}
+
+	// Save element in database
+	err := app.db.Update(func(tx *bolt.Tx) error {
+		err := n.Save(tx)
+		tests.Assert(t, err == nil)
+		return b.Save(tx)
+	})
+	tests.Assert(t, err == nil)
+
+	app.xo.MockBrickCreate = func(host string,
+		brick *executors.BrickRequest) (*executors.BrickInfo, error) {
+		bInfo := &executors.BrickInfo{
+			Path: "/mockpath",
+		}
+
+		tests.Assert(t, brick.Gid == gid)
+		tests.Assert(t, brick.Name == b.Info.Id)
+		tests.Assert(t, brick.PoolMetadataSize == poolMetadataSize)
+		tests.Assert(t, brick.Size == size)
+		tests.Assert(t, brick.TpSize == tpsize)
+		tests.Assert(t, brick.VgId == deviceid)
+
+		return bInfo, nil
+	}
+	err = b.Create(app.db, app.executor)
+	tests.Assert(t, err == nil)
 }

--- a/apps/glusterfs/device_entry.go
+++ b/apps/glusterfs/device_entry.go
@@ -350,7 +350,7 @@ func (d *DeviceEntry) SetExtentSize(amount uint64) {
 // the storage amount required from the device's used storage, but it will not add
 // the brick id to the brick list.  The caller is responsabile for adding the brick
 // id to the list.
-func (d *DeviceEntry) NewBrickEntry(amount uint64, snapFactor float64) *BrickEntry {
+func (d *DeviceEntry) NewBrickEntry(amount uint64, snapFactor float64, gid int64) *BrickEntry {
 
 	// :TODO: This needs unit test
 
@@ -386,7 +386,7 @@ func (d *DeviceEntry) NewBrickEntry(amount uint64, snapFactor float64) *BrickEnt
 	d.StorageAllocate(total)
 
 	// Create brick
-	return NewBrickEntry(amount, tpsize, metadataSize, d.Info.Id, d.NodeId)
+	return NewBrickEntry(amount, tpsize, metadataSize, d.Info.Id, d.NodeId, gid)
 }
 
 // Return poolmetadatasize in KB

--- a/apps/glusterfs/device_entry_test.go
+++ b/apps/glusterfs/device_entry_test.go
@@ -110,7 +110,7 @@ func TestDeviceEntryNewBrickEntry(t *testing.T) {
 	d.ExtentSize = 8
 
 	// Too large
-	brick := d.NewBrickEntry(1000000000, 1.5)
+	brick := d.NewBrickEntry(1000000000, 1.5, 1000)
 	tests.Assert(t, brick == nil)
 
 	// --- Now check with a real value ---
@@ -129,11 +129,12 @@ func TestDeviceEntryNewBrickEntry(t *testing.T) {
 	metadatasize += d.ExtentSize - (metadatasize % d.ExtentSize)
 	total := tpsize + metadatasize
 
-	brick = d.NewBrickEntry(200, 1.5)
+	brick = d.NewBrickEntry(200, 1.5, 1000)
 	tests.Assert(t, brick != nil)
 	tests.Assert(t, brick.TpSize == tpsize)
 	tests.Assert(t, brick.PoolMetadataSize == metadatasize, brick.PoolMetadataSize, metadatasize)
 	tests.Assert(t, brick.Info.Size == 200)
+	tests.Assert(t, brick.gidRequested == 1000)
 
 	// Check it was subtracted from device storage
 	tests.Assert(t, d.Info.Storage.Used == 100+total)

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -45,9 +45,10 @@ const (
 )
 
 type VolumeEntry struct {
-	Info       api.VolumeInfo
-	Bricks     sort.StringSlice
-	Durability VolumeDurability
+	Info         api.VolumeInfo
+	Bricks       sort.StringSlice
+	Durability   VolumeDurability
+	gidRequested int64
 }
 
 func VolumeList(tx *bolt.Tx) ([]string, error) {
@@ -74,6 +75,7 @@ func NewVolumeEntryFromRequest(req *api.VolumeCreateRequest) *VolumeEntry {
 	godbc.Require(req != nil)
 
 	vol := NewVolumeEntry()
+	vol.gidRequested = req.Gid
 	vol.Info.Id = utils.GenUUID()
 	vol.Info.Durability = req.Durability
 	vol.Info.Snapshot = req.Snapshot

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -144,7 +144,9 @@ func (v *VolumeEntry) allocBricks(
 					}
 
 					// Try to allocate a brick on this device
-					brick := device.NewBrickEntry(brick_size, float64(v.Info.Snapshot.Factor))
+					brick := device.NewBrickEntry(brick_size,
+						float64(v.Info.Snapshot.Factor),
+						v.gidRequested)
 
 					// Determine if it was successful
 					if brick != nil {

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/boltdb/bolt"
@@ -541,10 +542,13 @@ func TestVolumeEntryCreateTwoBricks(t *testing.T) {
 	// Mock Brick creation and check it was called
 	brickCreateCount := 0
 	gid := int64(1000)
+	var mutex sync.Mutex
 	app.xo.MockBrickCreate = func(host string,
 		brick *executors.BrickRequest) (*executors.BrickInfo, error) {
 
+		mutex.Lock()
 		brickCreateCount++
+		mutex.Unlock()
 
 		bInfo := &executors.BrickInfo{
 			Path: "/mockpath",

--- a/client/cli/go/cmds/volume.go
+++ b/client/cli/go/cmds/volume.go
@@ -36,6 +36,7 @@ var (
 	replica        int
 	disperseData   int
 	redundancy     int
+	gid            int64
 	snapshotFactor float64
 	clusters       string
 	expandSize     int
@@ -55,6 +56,8 @@ func init() {
 
 	volumeCreateCommand.Flags().IntVar(&size, "size", -1,
 		"\n\tSize of volume in GB")
+	volumeCreateCommand.Flags().Int64Var(&gid, "gid", 0,
+		"\n\tOptional: Initialize volume with the specified group id")
 	volumeCreateCommand.Flags().StringVar(&volname, "name", "",
 		"\n\tOptional: Name of volume. Only set if really necessary")
 	volumeCreateCommand.Flags().StringVar(&durability, "durability", "replicate",
@@ -157,6 +160,11 @@ var volumeCreateCommand = &cobra.Command{
 		req.Durability.Replicate.Replica = replica
 		req.Durability.Disperse.Data = disperseData
 		req.Durability.Disperse.Redundancy = redundancy
+
+		// Set group id if specified
+		if gid != 0 {
+			req.Gid = gid
+		}
 
 		if volname != "" {
 			req.Name = volname

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -54,6 +54,7 @@ type BrickRequest struct {
 	TpSize           uint64
 	Size             uint64
 	PoolMetadataSize uint64
+	Gid              int64
 }
 
 // Returns information about the location of the brick

--- a/executors/sshexec/brick.go
+++ b/executors/sshexec/brick.go
@@ -97,6 +97,18 @@ func (s *SshExecutor) BrickCreate(host string,
 		fmt.Sprintf("mkdir %v/brick", mountpoint),
 	}
 
+	// Only set the GID if the value is other than root(gid 0).
+	// When no gid is set, root is the only one that can write to the volume
+	if 0 != brick.Gid {
+		commands = append(commands, []string{
+			// Set GID on brick
+			fmt.Sprintf("chown :%v %v/brick", brick.Gid, mountpoint),
+
+			// Set writable by GID and UID
+			fmt.Sprintf("chmod 775 %v/brick", mountpoint),
+		}...)
+	}
+
 	// Execute commands
 	_, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 10)
 	if err != nil {

--- a/executors/sshexec/brick_test.go
+++ b/executors/sshexec/brick_test.go
@@ -110,6 +110,102 @@ func TestSshExecBrickCreate(t *testing.T) {
 
 }
 
+func TestSshExecBrickCreateWithGid(t *testing.T) {
+
+	f := NewFakeSsh()
+	defer tests.Patch(&sshNew,
+		func(logger *utils.Logger, user string, file string) (Ssher, error) {
+			return f, nil
+		}).Restore()
+
+	config := &SshConfig{
+		PrivateKeyFile: "xkeyfile",
+		User:           "xuser",
+		Port:           "100",
+		CLICommandConfig: CLICommandConfig{
+			Fstab: "/my/fstab",
+		},
+	}
+
+	s, err := NewSshExecutor(config)
+	tests.Assert(t, err == nil)
+	tests.Assert(t, s != nil)
+
+	// Create a Brick
+	b := &executors.BrickRequest{
+		VgId:             "xvgid",
+		Name:             "id",
+		TpSize:           100,
+		Size:             10,
+		PoolMetadataSize: 5,
+		Gid:              1234,
+	}
+
+	// Mock ssh function
+	f.FakeConnectAndExec = func(host string,
+		commands []string,
+		timeoutMinutes int,
+		useSudo bool) ([]string, error) {
+
+		tests.Assert(t, host == "myhost:100", host)
+		tests.Assert(t, len(commands) == 8)
+
+		for i, cmd := range commands {
+			cmd = strings.Trim(cmd, " ")
+			switch i {
+			case 0:
+				tests.Assert(t,
+					cmd == "mkdir -p /var/lib/heketi/mounts/vg_xvgid/brick_id", cmd)
+
+			case 1:
+				tests.Assert(t,
+					cmd == "lvcreate --poolmetadatasize 5K "+
+						"-c 256K -L 100K -T vg_xvgid/tp_id -V 10K -n brick_id", cmd)
+
+			case 2:
+				tests.Assert(t,
+					cmd == "mkfs.xfs -i size=512 "+
+						"-n size=8192 /dev/mapper/vg_xvgid-brick_id", cmd)
+
+			case 3:
+				tests.Assert(t,
+					cmd == "echo \"/dev/mapper/vg_xvgid-brick_id "+
+						"/var/lib/heketi/mounts/vg_xvgid/brick_id "+
+						"xfs rw,inode64,noatime,nouuid 1 2\" | "+
+						"tee -a /my/fstab > /dev/null", cmd)
+
+			case 4:
+				tests.Assert(t,
+					cmd == "mount -o rw,inode64,noatime,nouuid "+
+						"/dev/mapper/vg_xvgid-brick_id "+
+						"/var/lib/heketi/mounts/vg_xvgid/brick_id", cmd)
+
+			case 5:
+				tests.Assert(t,
+					cmd == "mkdir "+
+						"/var/lib/heketi/mounts/vg_xvgid/brick_id/brick", cmd)
+
+			case 6:
+				tests.Assert(t,
+					cmd == "chown :1234 "+
+						"/var/lib/heketi/mounts/vg_xvgid/brick_id/brick", cmd)
+
+			case 7:
+				tests.Assert(t,
+					cmd == "chmod 775 "+
+						"/var/lib/heketi/mounts/vg_xvgid/brick_id/brick", cmd)
+			}
+		}
+
+		return nil, nil
+	}
+
+	// Create Brick
+	_, err = s.BrickCreate("myhost", b)
+	tests.Assert(t, err == nil, err)
+
+}
+
 func TestSshExecBrickCreateSudo(t *testing.T) {
 
 	f := NewFakeSsh()

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -155,6 +155,7 @@ type VolumeCreateRequest struct {
 	Clusters   []string             `json:"clusters,omitempty"`
 	Name       string               `json:"name"`
 	Durability VolumeDurabilityInfo `json:"durability,omitempty"`
+	Gid        int64                `json:"gid"`
 	Snapshot   struct {
 		Enable bool    `json:"enable"`
 		Factor float32 `json:"factor"`

--- a/tests/functional/TestSmokeTest/vagrant/roles/gluster/tasks/main.yml
+++ b/tests/functional/TestSmokeTest/vagrant/roles/gluster/tasks/main.yml
@@ -2,6 +2,7 @@
   yum: name={{ item }} state=present
   with_items:
     - glusterfs-server
+    - glusterfs-client
 
 - name: start glusterd
   service: name=glusterd state=started enabled=yes


### PR DESCRIPTION
When a volume is created, it is necessary for the provisioner to
request that the volume has a certain group id.  This group id
would allow the owner of the volume to be able to write to the
GlusterFS volume as long as the user belongs to the requested
group id.

The problem was seen during the access of GlusterFS volumes
from OpenShift containerized applications.  When the volume
was created, it would have a default GID of 0 (root). The
non-privileged containerized application would then be denied
permission to write to the volume due to the fact that it had
a GID other than 0 (root).

With this change, the provisioner can request that the volume
be initialized to a certain GID which matches that of the
containerized application.

Closes #512

Signed-off-by: Luis Pabón <lpabon@redhat.com>