### PR TITLE
correctly report when a requested volume is smaller than min volume size

### DIFF
--- a/apps/glusterfs/app_volume.go
+++ b/apps/glusterfs/app_volume.go
@@ -133,6 +133,14 @@ func (a *App) VolumeCreate(w http.ResponseWriter, r *http.Request) {
 	// Create a volume entry
 	vol := NewVolumeEntryFromRequest(&msg)
 
+	if uint64(msg.Size)*GB < vol.Durability.MinVolumeSize() {
+		http.Error(w, fmt.Sprintf("Requested volume size (%v GB) is "+
+			"smaller than the minimum supported volume size (%v)",
+			msg.Size, vol.Durability.MinVolumeSize()),
+			http.StatusBadRequest)
+		return
+	}
+
 	// Add device in an asynchronous function
 	a.asyncManager.AsyncHttpRedirectFunc(w, r, func() (string, error) {
 

--- a/apps/glusterfs/app_volume_test.go
+++ b/apps/glusterfs/app_volume_test.go
@@ -142,7 +142,7 @@ func TestVolumeCreateNoTopology(t *testing.T) {
 	tests.Assert(t, r.StatusCode == http.StatusBadRequest)
 }
 
-func TestVolumeCreateSmallSize(t *testing.T) {
+func TestVolumeCreateInvalidSize(t *testing.T) {
 	tmpfile := tests.Tempfile()
 	defer os.Remove(tmpfile)
 

--- a/apps/glusterfs/volume_durability.go
+++ b/apps/glusterfs/volume_durability.go
@@ -22,6 +22,7 @@ import (
 
 type VolumeDurability interface {
 	BrickSizeGenerator(size uint64) func() (int, uint64, error)
+	MinVolumeSize() uint64
 	BricksInSet() int
 	SetDurability()
 	SetExecutorVolumeRequest(v *executors.VolumeRequest)

--- a/apps/glusterfs/volume_durability_ec.go
+++ b/apps/glusterfs/volume_durability_ec.go
@@ -70,6 +70,10 @@ func (d *VolumeDisperseDurability) BrickSizeGenerator(size uint64) func() (int, 
 	}
 }
 
+func (d *VolumeDisperseDurability) MinVolumeSize() uint64 {
+	return BrickMinSize * uint64(d.Data)
+}
+
 func (d *VolumeDisperseDurability) BricksInSet() int {
 	return d.Data + d.Redundancy
 }

--- a/apps/glusterfs/volume_durability_replica.go
+++ b/apps/glusterfs/volume_durability_replica.go
@@ -62,6 +62,10 @@ func (r *VolumeReplicaDurability) BrickSizeGenerator(size uint64) func() (int, u
 	}
 }
 
+func (r *VolumeReplicaDurability) MinVolumeSize() uint64 {
+	return BrickMinSize
+}
+
 func (r *VolumeReplicaDurability) BricksInSet() int {
 	return r.Replica
 }

--- a/apps/glusterfs/volume_durability_test.go
+++ b/apps/glusterfs/volume_durability_test.go
@@ -241,3 +241,31 @@ func TestReplicaDurabilityLargeBrickGenerator(t *testing.T) {
 	tests.Assert(t, brick_size == 3200*GB)
 	tests.Assert(t, 2 == r.BricksInSet())
 }
+
+func TestNoneDurabilityMinVolumeSize(t *testing.T) {
+	r := &NoneDurability{}
+	r.SetDurability()
+
+	minvolsize := r.MinVolumeSize()
+
+	tests.Assert(t, minvolsize == BrickMinSize)
+}
+
+func TestReplicaDurabilityMinVolumeSize(t *testing.T) {
+	r := &VolumeReplicaDurability{}
+	r.Replica = 3
+
+	minvolsize := r.MinVolumeSize()
+
+	tests.Assert(t, minvolsize == BrickMinSize)
+}
+
+func TestDisperseDurabilityMinVolumeSize(t *testing.T) {
+	r := &VolumeDisperseDurability{}
+	r.Data = 8
+	r.Redundancy = 3
+
+	minvolsize := r.MinVolumeSize()
+
+	tests.Assert(t, minvolsize == BrickMinSize*8)
+}


### PR DESCRIPTION
This is a global error, not specific to the cluster asked for bricks.
Hence this should be checked globally.
The minimum volume size only depends on the durability type and the minimum configured brick size.

This patchset implements MinVolumeSize() functions in the Durability interface and checks the size of the create request centrally in the sync rest api server code.

@lpabon This is an example where I think the several patches make sense as a patchset.
I could agree to squashing the test additions into the matching code changes.

closes #505 
closes #506 