### PR TITLE
api: Do not add gid information on volume info

### DIFF
--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -155,7 +155,7 @@ type VolumeCreateRequest struct {
 	Clusters   []string             `json:"clusters,omitempty"`
 	Name       string               `json:"name"`
 	Durability VolumeDurabilityInfo `json:"durability,omitempty"`
-	Gid        int64                `json:"gid"`
+	Gid        int64                `json:"gid,omitempty"`
 	Snapshot   struct {
 		Enable bool    `json:"enable"`
 		Factor float32 `json:"factor"`


### PR DESCRIPTION
GID cannot be reliably returned since the user could have changed the value
to something else.  Instead, omit the gid value in the JSON message
returned to a volume information request.

Signed-off-by: Luis Pabón <lpabon@redhat.com>