### PR TITLE
Add timeout to functional tests

### DIFF
--- a/tests/functional/run.sh
+++ b/tests/functional/run.sh
@@ -34,8 +34,10 @@ for testDir in * ; do
     if [ -x $testDir/run.sh ] ; then
         println "TEST $testDir"
         cd $testDir
-        run.sh
-        result=$?
+
+        # Run the command with a large timeout.
+        # Just large enough so that it doesn't run forever.
+        timeout 1h run.sh ; result=$?
 
         if [ $result -ne 0 ] ; then
             println "FAILED $testDir"


### PR DESCRIPTION
Add a default timeout of 1hr for each of the functional
tests.  That way, they will not get stuck running forever
in the CI environment.

Signed-off-by: Luis Pabón <lpabon@redhat.com>