### PR TITLE
build: Support full RELRO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GO=go
 # Sources and Targets
 EXECUTABLES :=$(APP_NAME)
 # Build Binaries setting main.version and main.build vars
-LDFLAGS :=-ldflags "-X main.HEKETI_VERSION=$(VERSION)"
+LDFLAGS :=-ldflags "-X main.HEKETI_VERSION=$(VERSION) -extldflags '-z relro -z now'"
 # Package target
 PACKAGE :=$(DIR)/dist/$(APP_NAME)-$(VERSION).$(GOOS).$(ARCH).tar.gz
 CLIENT_PACKAGE :=$(DIR)/dist/$(APP_NAME)-client-$(VERSION).$(GOOS).$(ARCH).tar.gz

--- a/client/cli/go/Makefile
+++ b/client/cli/go/Makefile
@@ -29,7 +29,7 @@ TEST="go test"
 # Sources and Targets
 EXECUTABLES :=$(APP_NAME)
 # Build Binaries setting main.version and main.build vars
-LDFLAGS :=-ldflags "-X main.HEKETI_CLI_VERSION=$(VERSION)"
+LDFLAGS :=-ldflags "-X main.HEKETI_CLI_VERSION=$(VERSION) -extldflags '-z relro -z now'"
 # Package target
 PACKAGE :=$(DIR)/dist/$(APP_NAME)-$(VERSION).$(GOOS).$(ARCH).tar.gz
 


### PR DESCRIPTION
Currently, the go build tool passes -z relro to the linker, which
creates a 'partial' RELRO executable.  Maybe it is a bug in the
GNU linker, but '-z relro' only creates a partial RELRO.  For
a full RELRO to be created the switch '-z now' must also be
passed.

See http://tk-blog.blogspot.com/2009/02/relro-not-so-well-known-memory.html
for more information.

Signed-off-by: Luis Pabón <lpabon@redhat.com>