### PR TITLE
Opt out of crash analysis in minikube

### DIFF
--- a/tests/functional/TestKubeSmokeTest/run.sh
+++ b/tests/functional/TestKubeSmokeTest/run.sh
@@ -101,6 +101,8 @@ setup_minikube() {
     chmod +x kubectl
     _sudo mv kubectl /usr/local/bin
 
+    echo -e "\nOpt-out of errors"
+    minikube config set WantReportErrorPrompt false
 }
 
 start_minikube() {


### PR DESCRIPTION
New minikube versions pause on errors asking
if the user would mind sending a crash analysis.
This slows down testing.  Instead the tests can
opt out and not block.

Signed-off-by: Luis Pabón <lpabon@redhat.com>