### PR TITLE
Topology Info, Node Info: "ID not found" error when running concurrently with volume creation.

### DIFF
--- a/apps/glusterfs/device_entry.go
+++ b/apps/glusterfs/device_entry.go
@@ -282,6 +282,20 @@ func (d *DeviceEntry) NewInfoResponse(tx *bolt.Tx) (*api.DeviceInfoResponse, err
 	return info, nil
 }
 
+func (d *DeviceEntry) NewInfoResponseNode(tx *bolt.Tx) (*api.DeviceInfoResponse, error) {
+
+	godbc.Require(tx != nil)
+
+	info := &api.DeviceInfoResponse{}
+	info.Id = d.Info.Id
+	info.Name = d.Info.Name
+	info.Storage = d.Info.Storage
+	info.State = d.State
+	info.Bricks = make([]api.BrickInfo, 0)
+
+	return info, nil
+}
+
 func (d *DeviceEntry) Marshal() ([]byte, error) {
 	var buffer bytes.Buffer
 	enc := gob.NewEncoder(&buffer)

--- a/apps/glusterfs/node_entry.go
+++ b/apps/glusterfs/node_entry.go
@@ -316,7 +316,7 @@ func (n *NodeEntry) NewInfoReponse(tx *bolt.Tx) (*api.NodeInfoResponse, error) {
 			return nil, err
 		}
 
-		driveinfo, err := device.NewInfoResponse(tx)
+		driveinfo, err := device.NewInfoResponseNode(tx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The brick entries which is being updated during `volume create` causes inconsistent state ( until the transaction is over ). In this state, It returns `Err:Id not found` for bricks when issuing  `node info` | `topology info`. This fix will make `node info` and `topology info` not to depend on the bricks information. In actual scenario `node info` and `topology info` is not using the bricks anyways.

Closes:#382

Signed-off-by: Mohamed Ashiq Liyazudeen <mliyazud@redhat.com>