### PR TITLE
api: Better invalid path error handler

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -346,8 +346,10 @@ func (a *App) SetRoutes(router *mux.Router) error {
 
 	}
 
-	return nil
+	// Set default error handler
+	router.NotFoundHandler = http.HandlerFunc(a.NotFoundHandler)
 
+	return nil
 }
 
 func (a *App) Close() {
@@ -388,4 +390,9 @@ func (a *App) Backup(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
+}
+
+func (a *App) NotFoundHandler(w http.ResponseWriter, r *http.Request) {
+	logger.Warning("Invalid path or request %v", r.URL.Path)
+	http.Error(w, "Invalid path or request", http.StatusNotFound)
 }


### PR DESCRIPTION
When a path with an illegal id is provided by the caller (something
that does not match the regexp), the Gorilla Mux Router automatically
routed the call to http.NotFoundHandler().  This would be ok for
an API to handle, but the heketi-cli would output information which
was not very human friendly.

Instead, we now provide our own error handler which returns a nicer
error than just "404: Not found".

Closes #539

Signed-off-by: Luis Pabón <lpabon@redhat.com>