### PR TITLE
Kubernetes DaemonSet Support

### DIFF
--- a/executors/kubeexec/config.go
+++ b/executors/kubeexec/config.go
@@ -25,8 +25,9 @@ type KubeConfig struct {
 	// Use Secrets to get the Bearerkey
 	UseSecrets bool `json:"use_secrets"`
 
-	TokenFile     string `json:"token_file"`
-	NamespaceFile string `json:"namespace_file"`
+	TokenFile        string `json:"token_file"`
+	NamespaceFile    string `json:"namespace_file"`
+	GlusterDaemonSet bool   `json:"gluster_daemonset"`
 
 	// Use POD name instead of using label
 	// to access POD

--- a/executors/kubeexec/kubeexec.go
+++ b/executors/kubeexec/kubeexec.go
@@ -128,6 +128,18 @@ func setWithEnvVariables(config *KubeConfig) {
 		config.NamespaceFile = env
 	}
 
+	// Determine if Heketi should communicate with Gluster
+	// pods deployed by a DaemonSet
+	env = os.Getenv("HEKETI_KUBE_GLUSTER_DAEMONSET")
+	if "" != env {
+		env = strings.ToLower(env)
+		if env[0] == 'y' || env[0] == '1' {
+			config.GlusterDaemonSet = true
+		} else if env[0] == 'n' || env[0] == '0' {
+			config.GlusterDaemonSet = false
+		}
+	}
+
 	// Use POD names
 	env = os.Getenv("HEKETI_KUBE_USE_POD_NAMES")
 	if "" != env {
@@ -240,44 +252,13 @@ func (k *KubeExecutor) ConnectAndExec(host, resource string,
 	var podName string
 	if k.config.UsePodNames {
 		podName = host
+	} else if k.config.GlusterDaemonSet {
+		podName, err = k.getPodNameFromDaemonSet(conn, host)
 	} else {
-		// 'host' is actually the value for the label with a key
-		// of 'glusterid'
-		selector, err := labels.Parse(KubeGlusterFSPodLabelKey + "==" + host)
-		if err != nil {
-			logger.Err(err)
-			return nil, fmt.Errorf("Unable to get pod with a matching label of %v==%v",
-				KubeGlusterFSPodLabelKey, host)
-		}
-
-		// Get a list of pods
-		pods, err := conn.Pods(k.config.Namespace).List(api.ListOptions{
-			LabelSelector: selector,
-			FieldSelector: fields.Everything(),
-		})
-		if err != nil {
-			logger.Err(err)
-			return nil, fmt.Errorf("Failed to get list of pods")
-		}
-
-		numPods := len(pods.Items)
-		if numPods == 0 {
-			// No pods found with that label
-			err := fmt.Errorf("No pods with the label '%v=%v' were found",
-				KubeGlusterFSPodLabelKey, host)
-			logger.Critical(err.Error())
-			return nil, err
-
-		} else if numPods > 1 {
-			// There are more than one pod with the same label
-			err := fmt.Errorf("Found %v pods with the sharing the same label '%v=%v'",
-				numPods, KubeGlusterFSPodLabelKey, host)
-			logger.Critical(err.Error())
-			return nil, err
-		}
-
-		// Get pod name
-		podName = pods.Items[0].ObjectMeta.Name
+		podName, err = k.getPodNameByLabel(conn, host)
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	for index, command := range commands {
@@ -321,7 +302,7 @@ func (k *KubeExecutor) ConnectAndExec(host, resource string,
 				command, podName, err, b.String(), berr.String())
 			return nil, fmt.Errorf("Unable to execute command on %v: %v", podName, berr.String())
 		}
-		logger.Debug("Host: %v Command: %v\nResult: %v", podName, command, b.String())
+		logger.Debug("Host: %v Pod: %v Command: %v\nResult: %v", host, podName, command, b.String())
 		buffers[index] = b.String()
 
 	}
@@ -343,4 +324,81 @@ func (k *KubeExecutor) readAllLinesFromFile(filename string) (string, error) {
 		return "", logger.LogError("Error reading %v file: %v", filename, err.Error())
 	}
 	return string(fileBytes), nil
+}
+
+func (k *KubeExecutor) getPodNameByLabel(conn *client.Client,
+	host string) (string, error) {
+	// 'host' is actually the value for the label with a key
+	// of 'glusterid'
+	selector, err := labels.Parse(KubeGlusterFSPodLabelKey + "==" + host)
+	if err != nil {
+		logger.Err(err)
+		return "", logger.LogError("Unable to get pod with a matching label of %v==%v",
+			KubeGlusterFSPodLabelKey, host)
+	}
+
+	// Get a list of pods
+	pods, err := conn.Pods(k.config.Namespace).List(api.ListOptions{
+		LabelSelector: selector,
+		FieldSelector: fields.Everything(),
+	})
+	if err != nil {
+		logger.Err(err)
+		return "", fmt.Errorf("Failed to get list of pods")
+	}
+
+	numPods := len(pods.Items)
+	if numPods == 0 {
+		// No pods found with that label
+		err := fmt.Errorf("No pods with the label '%v=%v' were found",
+			KubeGlusterFSPodLabelKey, host)
+		logger.Critical(err.Error())
+		return "", err
+
+	} else if numPods > 1 {
+		// There are more than one pod with the same label
+		err := fmt.Errorf("Found %v pods with the sharing the same label '%v=%v'",
+			numPods, KubeGlusterFSPodLabelKey, host)
+		logger.Critical(err.Error())
+		return "", err
+	}
+
+	// Get pod name
+	return pods.Items[0].ObjectMeta.Name, nil
+}
+
+func (k *KubeExecutor) getPodNameFromDaemonSet(conn *client.Client,
+	host string) (string, error) {
+	// 'host' is actually the value for the label with a key
+	// of 'glusterid'
+	selector, err := labels.Parse(KubeGlusterFSPodLabelKey)
+	if err != nil {
+		return "", logger.LogError("Unable to create selector of %v: %v",
+			KubeGlusterFSPodLabelKey, err.Error())
+	}
+
+	// Get a list of pods
+	pods, err := conn.Pods(k.config.Namespace).List(api.ListOptions{
+		LabelSelector: selector,
+		FieldSelector: fields.Everything(),
+	})
+	if err != nil {
+		logger.Err(err)
+		return "", logger.LogError("Failed to get list of pods")
+	}
+
+	// Go through the pods looking for the node
+	var glusterPod string
+	for _, pod := range pods.Items {
+		if pod.Spec.NodeName == host {
+			glusterPod = pod.ObjectMeta.Name
+		}
+	}
+	if glusterPod == "" {
+		return "", logger.LogError("Unable to find a Gluster Pod on host %v"+
+			"with DaemonSet nodeSelector %v", host, KubeGlusterFSPodLabelKey)
+	}
+
+	// Get pod name
+	return glusterPod, nil
 }

--- a/extras/kubernetes/README.md
+++ b/extras/kubernetes/README.md
@@ -13,12 +13,16 @@ documentation, please visit the Heketi wiki page.
 $ kubectl get nodes
 ```
 
-* Deploy gluster container onto specified node:
+* Deploy the GlusterFS DaemonSet
 
 ```
-$ sed -e \
-   's#<GLUSTERFS_NODE>#..type your node name here..#' \
-   glusterfs-deployment.json | kubectl create -f -
+$ kubectl create -f gluster-daemonset.json
+```
+
+* Deploy gluster container onto specified node by setting the label `storagenode=glusterfs` on that node:
+
+```
+$ kubectl label node <...node...> storagenode=glusterfs
 ```
 
 Repeat as needed.

--- a/extras/kubernetes/deploy-heketi-deployment.json
+++ b/extras/kubernetes/deploy-heketi-deployment.json
@@ -83,6 +83,10 @@
                             "value": "y"
                           },
                           {
+                            "name": "HEKETI_KUBE_GLUSTER_DAEMONSET",
+                            "value": "y"
+                          },
+                          {
                             "name": "HEKETI_KUBE_APIHOST",
                             "value": <HEKETI_KUBE_APIHOST>
                           }

--- a/extras/kubernetes/glusterfs-daemonset.json
+++ b/extras/kubernetes/glusterfs-daemonset.json
@@ -1,31 +1,27 @@
 {
-    "kind": "Deployment",
+    "kind": "DaemonSet",
     "apiVersion": "extensions/v1beta1",
     "metadata": {
-        "name": "glusterfs-<GLUSTERFS_NODE>",
+        "name": "glusterfs",
         "labels": {
-            "glusterfs": "deployment",
-            "glusterfs-node": "<GLUSTERFS_NODE>"
+            "glusterfs": "deployment"
         },
         "annotations": {
-            "description": "GlusterFS container deployment template",
+            "description": "GlusterFS Daemon Set",
             "tags": "glusterfs"
         }
     },
     "spec": {
-        "replicas":1,
         "template": {
             "metadata": {
                 "name": "glusterfs",
                 "labels": {
-                    "name": "glusterfs",
-                    "glusterfs": "pod",
-                    "glusterfs-node": "<GLUSTERFS_NODE>"
+                    "glusterfs-node": "daemonset"
                 }
             },
             "spec": {
                 "nodeSelector": {
-                    "kubernetes.io/hostname": "<GLUSTERFS_NODE>"
+                    "storagenode" : "glusterfs"
                 },
                 "hostNetwork": true,
                 "containers": [

--- a/tests/functional/TestKubeSmokeTest/testHeketiRpc.sh
+++ b/tests/functional/TestKubeSmokeTest/testHeketiRpc.sh
@@ -128,7 +128,7 @@ test_peer_probe() {
 
 	echo -e "\nAdd device"
 	nodeid=$(heketi-cli node list | awk '{print $1}' | awk -F: '{print $2}')
-	heketi-cli device add --name=/dev/fakedevice --node=$nodeid # || fail "Unable to add device"
+	heketi-cli device add --name=/dev/fakedevice --node=$nodeid || fail "Unable to add device"
 
 	echo -e "\nShow Topology"
 	heketi-cli topology info


### PR DESCRIPTION
This change allows Heketi to discover and manage GlusterFS containers which
have been deployed by using a DaemonSet.  The GlusterFS deploy object
has been changed to a GlusterFS daemonset which will need to be installed
by the administrator.  When the administrator wants the DaemonSet to
deploy GlusterFS to a specific node, the administrator can then label
that node with `storagenode=glusterfs`.  This is setup in the DaemonSet
as the `nodeSelector`, which will instruct Kubernetes to deploy the
glusterfs container to the specified node.

When a node is added to Heketi to be managed, just as before, the management
host is the name of the node as displayed in `kubectl get nodes`.  When
Heketi needs to execute a command in a GlusterFS container which has been
deployed by a daemonset, it will fetch all pods in the namespace which
match the label `glusterfs-node` (see kubeexec.go:36).  It then receives
a list of all the pods which match this label.  Heketi goes through each
pod spec looking for the one which matches the management host name.  Once
the pod has been found, it uses the pod name to execute commands on that
container.

Signed-off-by: Luis Pabón <luis.pabon@coreos.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heketi/heketi/596)
<!-- Reviewable:end -->
