### PR TITLE
Gluster Template: make /sys/fs/cgroup readonly

### DIFF
--- a/extras/openshift/templates/glusterfs-template.json
+++ b/extras/openshift/templates/glusterfs-template.json
@@ -95,7 +95,8 @@
                                     },
                                     {
                                         "name": "glusterfs-cgroup",
-                                        "mountPath": "/sys/fs/cgroup"
+                                        "mountPath": "/sys/fs/cgroup",
+                                        "readOnly": "true"
                                     }
                                 ],
                                 "securityContext": {


### PR DESCRIPTION
Make the /sys/fs/cgroup in template as readOnly. 

Closes : #604 