### PR TITLE
executors: chmod with 2775 to inherit group permission

### DIFF
--- a/executors/sshexec/brick.go
+++ b/executors/sshexec/brick.go
@@ -98,7 +98,7 @@ func (s *SshExecutor) BrickCreate(host string,
 			fmt.Sprintf("chown :%v %v/brick", brick.Gid, mountpoint),
 
 			// Set writable by GID and UID
-			fmt.Sprintf("chmod 775 %v/brick", mountpoint),
+			fmt.Sprintf("chmod 2775 %v/brick", mountpoint),
 		}...)
 	}
 

--- a/executors/sshexec/brick_test.go
+++ b/executors/sshexec/brick_test.go
@@ -185,7 +185,7 @@ func TestSshExecBrickCreateWithGid(t *testing.T) {
 
 			case 7:
 				tests.Assert(t,
-					cmd == "chmod 775 "+
+					cmd == "chmod 2775 "+
 						"/var/lib/heketi/mounts/vg_xvgid/brick_id/brick", cmd)
 			}
 		}

--- a/tests/functional/TestSmokeTest/tests/heketi_test.go
+++ b/tests/functional/TestSmokeTest/tests/heketi_test.go
@@ -264,7 +264,7 @@ func TestHeketiCreateVolumeWithGid(t *testing.T) {
 	volInfo, err := heketi.VolumeCreate(volReq)
 	tests.Assert(t, err == nil)
 
-	// SSH into system and execute gluster command to create a snapshot
+	// SSH into system and try creating files from user belonging to gid
 	exec := ssh.NewSshExecWithKeyFile(logger, "vagrant", "../config/insecure_private_key")
 	cmd := []string{
 		fmt.Sprintf("sudo mount -t glusterfs %v /mnt", volInfo.Mount.GlusterFS.MountPoint),


### PR DESCRIPTION
With b56a5e8 we added a feature where one could add a gid to the volume
to enable all users belonging to that group to be able to write into the
volume.

However, it does so by changing the mode bits on the brick dirs to 775.
This is not sufficient for the cause. Here is a test case which fails:

* create a group writegroup
* add rtalur and vagrant to it
* create a volume by providing writegroup's gid to heketi
* as rtalur, create files and dirs in the volume, it works
* as vagrant, creates files and dirs in the root of the volume, it works
* as vagrant, creates files and dirs in the dirs created by rtalur in step
4, it fails with permission denied although it should succeed.

This patch fixes the above test.

Closes #611

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>