### PR TITLE
tests: use "become" instead of deprecated "sudo: True" in ansible

### DIFF
--- a/tests/functional/TestManyBricksVolume/vagrant/site.yml
+++ b/tests/functional/TestManyBricksVolume/vagrant/site.yml
@@ -1,9 +1,11 @@
 - hosts: all
-  sudo: True
+  become: yes
+  become_method: sudo
   roles:
     - common
 
 - hosts: gluster
-  sudo: True
+  become: yes
+  become_method: sudo
   roles:
     - gluster

--- a/tests/functional/TestVolumeSnapshotBehavior/vagrant/site.yml
+++ b/tests/functional/TestVolumeSnapshotBehavior/vagrant/site.yml
@@ -1,9 +1,11 @@
 - hosts: all
-  sudo: True
+  become: yes
+  become_method: sudo
   roles:
     - common
 
 - hosts: gluster
-  sudo: True
+  become: yes
+  become_method: sudo
   roles:
     - gluster


### PR DESCRIPTION
Signed-off-by: Michael Adam <obnox@redhat.com>