### PR TITLE
Remove Device: Used to distribute all the bricks from device to other devices

### DIFF
--- a/apps/glusterfs/allocator_simple.go
+++ b/apps/glusterfs/allocator_simple.go
@@ -179,6 +179,10 @@ func (s *SimpleAllocator) GetNodes(clusterId, brickId string) (<-chan string,
 	// Get the list of devices for this brick id
 	devicelist, err := s.getDeviceList(clusterId, brickId)
 
+	for _, tester := range devicelist {
+		logger.Debug("Allocator Device ID: %v, Brick ID: %v", tester.deviceId, brickId)
+	}
+
 	if err != nil {
 		errc <- err
 		close(device)

--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -290,6 +290,11 @@ func (a *App) SetRoutes(router *mux.Router) error {
 			Method:      "POST",
 			Pattern:     "/devices/{id:[A-Fa-f0-9]+}/state",
 			HandlerFunc: a.DeviceSetState},
+		rest.Route{
+			Name:        "DeviceRemove",
+			Method:      "POST",
+			Pattern:     "/devices/{id:[A-Fa-f0-9]+}/remove",
+			HandlerFunc: a.DeviceRemove},
 
 		// Volume
 		rest.Route{

--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -143,6 +143,13 @@ func NewApp(configIo io.Reader) *App {
 				return err
 			}
 
+			// Handle Upgrade Changes
+			err = app.Upgrade(tx)
+			if err != nil {
+				logger.LogError("Unable to Upgrade Changes")
+				return err
+			}
+
 			return nil
 
 		})
@@ -188,6 +195,16 @@ func (a *App) setLogLevel(level string) {
 	case "debug":
 		logger.SetLevel(utils.LEVEL_DEBUG)
 	}
+}
+
+// Upgrade Path to update all the values for new API entries
+func (a *App) Upgrade(tx *bolt.Tx) error {
+	err := AddVolumeIdInBrickEntry(tx)
+	if err != nil {
+		logger.LogError("VolumeId add to BrickEntry failed")
+		return err
+	}
+	return nil
 }
 
 func (a *App) setAdvSettings() {
@@ -372,4 +389,39 @@ func (a *App) Backup(w http.ResponseWriter, r *http.Request) {
 func (a *App) NotFoundHandler(w http.ResponseWriter, r *http.Request) {
 	logger.Warning("Invalid path or request %v", r.URL.Path)
 	http.Error(w, "Invalid path or request", http.StatusNotFound)
+}
+
+func AddVolumeIdInBrickEntry(tx *bolt.Tx) error {
+	clusters, err := ClusterList(tx)
+	if err != nil {
+		return err
+	}
+	for _, cluster := range clusters {
+		clusterEntry, err := NewClusterEntryFromId(tx, cluster)
+		if err != nil {
+			return err
+		}
+		for _, volume := range clusterEntry.Info.Volumes {
+			volumeEntry, err := NewVolumeEntryFromId(tx, volume)
+			if err != nil {
+				return err
+			}
+			for _, brick := range volumeEntry.Bricks {
+				brickEntry, err := NewBrickEntryFromId(tx, brick)
+				if err != nil {
+					return err
+				}
+				if brickEntry.Info.VolumeId == "" {
+					brickEntry.Info.VolumeId = volume
+					err = brickEntry.Save(tx)
+					if err != nil {
+						return err
+					}
+				} else {
+					break
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/apps/glusterfs/app_device.go
+++ b/apps/glusterfs/app_device.go
@@ -154,6 +154,56 @@ func (a *App) DeviceAdd(w http.ResponseWriter, r *http.Request) {
 
 }
 
+func (a *App) DeviceRemove(w http.ResponseWriter, r *http.Request) {
+
+	logger.Info("entered deviceremove")
+
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	// Check request
+	var device *DeviceEntry
+	err := a.db.View(func(tx *bolt.Tx) error {
+		var err error
+		// Access device entry
+		device, err = NewDeviceEntryFromId(tx, id)
+		if err == ErrNotFound {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return err
+		} else if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return logger.Err(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return
+	}
+	// Check and remove all bricks from device
+	logger.Info("Check and remove all bricks from device %v", device.Info.Id)
+	a.asyncManager.AsyncHttpRedirectFunc(w, r, func() (string, error) {
+		var err error
+
+		// Check if we can remove the device
+		if device.IsDeleteOk() {
+			logger.Info("Device is clean to delete or remove")
+			return "", nil
+		}
+
+		err = device.Remove(a.db, a.executor, a.allocator)
+		if err != nil {
+			if err == ErrNoReplacement {
+				http.Error(w, device.NoReplacementDeviceString(), http.StatusInternalServerError)
+				logger.LogError(device.NoReplacementDeviceString())
+			}
+			return "", err
+		}
+		logger.Info("exit async")
+		return "", nil
+
+	})
+}
+
 func (a *App) DeviceInfo(w http.ResponseWriter, r *http.Request) {
 
 	// Get device id from URL

--- a/apps/glusterfs/brick_entry.go
+++ b/apps/glusterfs/brick_entry.go
@@ -12,6 +12,7 @@ package glusterfs
 import (
 	"bytes"
 	"encoding/gob"
+
 	"github.com/boltdb/bolt"
 	"github.com/heketi/heketi/executors"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
@@ -36,7 +37,7 @@ func BrickList(tx *bolt.Tx) ([]string, error) {
 }
 
 func NewBrickEntry(size, tpsize, poolMetadataSize uint64,
-	deviceid, nodeid string, gid int64) *BrickEntry {
+	deviceid, nodeid string, gid int64, volumeid string) *BrickEntry {
 
 	godbc.Require(size > 0)
 	godbc.Require(tpsize > 0)
@@ -51,6 +52,7 @@ func NewBrickEntry(size, tpsize, poolMetadataSize uint64,
 	entry.Info.Size = size
 	entry.Info.NodeId = nodeid
 	entry.Info.DeviceId = deviceid
+	entry.Info.VolumeId = volumeid
 
 	godbc.Ensure(entry.Info.Id != "")
 	godbc.Ensure(entry.TpSize == tpsize)

--- a/apps/glusterfs/brick_entry_test.go
+++ b/apps/glusterfs/brick_entry_test.go
@@ -29,8 +29,9 @@ func TestNewBrickEntry(t *testing.T) {
 	nodeid := "def"
 	ps := size
 	gid := int64(1)
+	volumeid := "ghi"
 
-	b := NewBrickEntry(size, tpsize, ps, deviceid, nodeid, gid)
+	b := NewBrickEntry(size, tpsize, ps, deviceid, nodeid, gid, volumeid)
 	tests.Assert(t, b.Info.Id != "")
 	tests.Assert(t, b.TpSize == tpsize)
 	tests.Assert(t, b.PoolMetadataSize == ps)
@@ -38,6 +39,7 @@ func TestNewBrickEntry(t *testing.T) {
 	tests.Assert(t, b.Info.NodeId == nodeid)
 	tests.Assert(t, b.Info.Size == size)
 	tests.Assert(t, b.gidRequested == gid)
+	tests.Assert(t, b.Info.VolumeId == volumeid)
 }
 
 func TestBrickEntryMarshal(t *testing.T) {
@@ -47,7 +49,8 @@ func TestBrickEntryMarshal(t *testing.T) {
 	nodeid := "def"
 	ps := size
 	gid := int64(0)
-	m := NewBrickEntry(size, tpsize, ps, deviceid, nodeid, gid)
+	volumeid := "ghi"
+	m := NewBrickEntry(size, tpsize, ps, deviceid, nodeid, gid, volumeid)
 
 	buffer, err := m.Marshal()
 	tests.Assert(t, err == nil)
@@ -87,7 +90,7 @@ func TestNewBrickEntryFromId(t *testing.T) {
 	defer app.Close()
 
 	// Create a brick
-	b := NewBrickEntry(10, 20, 5, "abc", "def", 0)
+	b := NewBrickEntry(10, 20, 5, "abc", "def", 0, "ghi")
 
 	// Save element in database
 	err := app.db.Update(func(tx *bolt.Tx) error {
@@ -115,7 +118,7 @@ func TestNewBrickEntrySaveDelete(t *testing.T) {
 	defer app.Close()
 
 	// Create a brick
-	b := NewBrickEntry(10, 20, 5, "abc", "def", 1000)
+	b := NewBrickEntry(10, 20, 5, "abc", "def", 1000, "ghi")
 
 	// Save element in database
 	err := app.db.Update(func(tx *bolt.Tx) error {
@@ -160,7 +163,7 @@ func TestNewBrickEntryNewInfoResponse(t *testing.T) {
 	defer app.Close()
 
 	// Create a brick
-	b := NewBrickEntry(10, 20, 5, "abc", "def", 1000)
+	b := NewBrickEntry(10, 20, 5, "abc", "def", 1000, "ghi")
 
 	// Save element in database
 	err := app.db.Update(func(tx *bolt.Tx) error {
@@ -191,7 +194,7 @@ func TestBrickEntryDestroyCheck(t *testing.T) {
 	defer app.Close()
 
 	// Create a brick
-	b := NewBrickEntry(10, 20, 5, "abc", "node", 1000)
+	b := NewBrickEntry(10, 20, 5, "abc", "node", 1000, "ghi")
 	n := NewNodeEntry()
 	n.Info.Id = "node"
 	n.Info.Hostnames.Manage = []string{"manage"}
@@ -235,10 +238,11 @@ func TestBrickEntryCreate(t *testing.T) {
 	deviceid := "abc"
 	nodeid := "node"
 	gid := int64(1000)
+	volumeid := "ghi"
 
 	// Create a brick
 	b := NewBrickEntry(size, tpsize, poolMetadataSize,
-		deviceid, nodeid, gid)
+		deviceid, nodeid, gid, volumeid)
 	n := NewNodeEntry()
 	n.Info.Id = nodeid
 	n.Info.Hostnames.Manage = []string{"manage"}

--- a/apps/glusterfs/device_entry.go
+++ b/apps/glusterfs/device_entry.go
@@ -343,7 +343,7 @@ func (d *DeviceEntry) SetExtentSize(amount uint64) {
 // the storage amount required from the device's used storage, but it will not add
 // the brick id to the brick list.  The caller is responsabile for adding the brick
 // id to the list.
-func (d *DeviceEntry) NewBrickEntry(amount uint64, snapFactor float64, gid int64) *BrickEntry {
+func (d *DeviceEntry) NewBrickEntry(amount uint64, snapFactor float64, gid int64, volumeid string) *BrickEntry {
 
 	// :TODO: This needs unit test
 
@@ -379,7 +379,7 @@ func (d *DeviceEntry) NewBrickEntry(amount uint64, snapFactor float64, gid int64
 	d.StorageAllocate(total)
 
 	// Create brick
-	return NewBrickEntry(amount, tpsize, metadataSize, d.Info.Id, d.NodeId, gid)
+	return NewBrickEntry(amount, tpsize, metadataSize, d.Info.Id, d.NodeId, gid, volumeid)
 }
 
 // Return poolmetadatasize in KB

--- a/apps/glusterfs/device_entry.go
+++ b/apps/glusterfs/device_entry.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 
 	"github.com/boltdb/bolt"
+	"github.com/heketi/heketi/executors"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/lpabon/godbc"
@@ -156,6 +157,10 @@ func (d *DeviceEntry) IsDeleteOk() bool {
 
 func (d *DeviceEntry) ConflictString() string {
 	return fmt.Sprintf("Unable to delete device [%v] because it contains bricks", d.Info.Id)
+}
+
+func (d *DeviceEntry) NoReplacementDeviceString() string {
+	return fmt.Sprintf("Unable to delete device [%v] as no device was found to replace it", d.Info.Id)
 }
 
 func (d *DeviceEntry) Delete(tx *bolt.Tx) error {
@@ -372,6 +377,7 @@ func (d *DeviceEntry) NewBrickEntry(amount uint64, snapFactor float64, gid int64
 		d.Id(),
 		d.Info.Storage.Free, total)
 	if !d.StorageCheck(total) {
+		logger.Info("Failed Storage Check")
 		return nil
 	}
 
@@ -392,4 +398,47 @@ func (d *DeviceEntry) poolMetadataSize(tpsize uint64) uint64 {
 	}
 
 	return p
+}
+
+// Removes all the bricks from the Device
+func (d *DeviceEntry) Remove(db *bolt.DB,
+	executor executors.Executor,
+	allocator Allocator) (e error) {
+	type brickToReplace struct {
+		brickId  string
+		volumeId *VolumeEntry
+	}
+	var bricksToReplace []brickToReplace
+	err := db.View(func(tx *bolt.Tx) error {
+		for _, bricks := range d.Bricks {
+			brickEntry, err := NewBrickEntryFromId(tx, bricks)
+			if err != nil {
+				return nil
+			}
+			volumeEntry, err := NewVolumeEntryFromId(tx, brickEntry.Info.VolumeId)
+			if err != nil {
+				return nil
+			}
+			brick := brickToReplace{}
+			brick.brickId = bricks
+			brick.volumeId = volumeEntry
+			bricksToReplace = append(bricksToReplace, brick)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, brick := range bricksToReplace {
+		logger.Info("replace the brick %v", brick.brickId)
+		volentry := brick.volumeId
+		err = volentry.replaceBrickInVolume(db, executor, allocator, brick.brickId)
+		if err != nil {
+			logger.Info("Error replace brick")
+			return err
+		}
+		logger.Info("Replace brick success")
+	}
+	return nil
 }

--- a/apps/glusterfs/device_entry_test.go
+++ b/apps/glusterfs/device_entry_test.go
@@ -103,7 +103,7 @@ func TestDeviceEntryNewBrickEntry(t *testing.T) {
 	d.ExtentSize = 8
 
 	// Too large
-	brick := d.NewBrickEntry(1000000000, 1.5, 1000)
+	brick := d.NewBrickEntry(1000000000, 1.5, 1000, "abc")
 	tests.Assert(t, brick == nil)
 
 	// --- Now check with a real value ---
@@ -122,12 +122,13 @@ func TestDeviceEntryNewBrickEntry(t *testing.T) {
 	metadatasize += d.ExtentSize - (metadatasize % d.ExtentSize)
 	total := tpsize + metadatasize
 
-	brick = d.NewBrickEntry(200, 1.5, 1000)
+	brick = d.NewBrickEntry(200, 1.5, 1000, "abc")
 	tests.Assert(t, brick != nil)
 	tests.Assert(t, brick.TpSize == tpsize)
 	tests.Assert(t, brick.PoolMetadataSize == metadatasize, brick.PoolMetadataSize, metadatasize)
 	tests.Assert(t, brick.Info.Size == 200)
 	tests.Assert(t, brick.gidRequested == 1000)
+	tests.Assert(t, brick.Info.VolumeId == "abc")
 
 	// Check it was subtracted from device storage
 	tests.Assert(t, d.Info.Storage.Used == 100+total)

--- a/apps/glusterfs/errors.go
+++ b/apps/glusterfs/errors.go
@@ -22,4 +22,5 @@ var (
 	ErrDbAccess         = errors.New("Unable to access db")
 	ErrAccessList       = errors.New("Unable to access list")
 	ErrKeyExists        = errors.New("Key already exists in the database")
+	ErrNoReplacement    = errors.New("No Replacement was found for resource requested to be removed")
 )

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -10,7 +10,10 @@
 package glusterfs
 
 import (
+	"fmt"
+
 	"github.com/boltdb/bolt"
+	"github.com/heketi/heketi/executors"
 	"github.com/heketi/heketi/pkg/utils"
 )
 
@@ -61,6 +64,209 @@ func (v *VolumeEntry) allocBricksInCluster(db *bolt.DB,
 		// We were able to allocate bricks
 		return brick_entries, nil
 	}
+}
+
+func (v *VolumeEntry) getEntryfromBrickName(tx *bolt.Tx, brickname string) (brickEntry *BrickEntry, e error) {
+	var brickEntries []*BrickEntry
+	brickids := v.BricksIds()
+	for _, brickid := range brickids {
+		brick, err := NewBrickEntryFromId(tx, brickid)
+		if err != nil {
+			return nil, err
+		}
+		brickEntries = append(brickEntries, brick)
+	}
+
+	for _, brickentry := range brickEntries {
+		nodeEntry, err := NewNodeEntryFromId(tx, brickentry.Info.NodeId)
+		if err != nil {
+			return nil, err
+		}
+		if brickname == fmt.Sprintf("%v:%v", nodeEntry.Info.Hostnames.Storage[0], brickentry.Info.Path) {
+			return brickentry, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func (v *VolumeEntry) replaceBrickInVolume(db *bolt.DB, executor executors.Executor,
+	allocator Allocator,
+	oldBrickId string) (e error) {
+
+	logger.Info("Entered replace brick")
+	// Do the work in the database context so that the cluster
+	// data does not change while determining brick location
+	err := db.Update(func(tx *bolt.Tx) error {
+
+		oldBrickEntry, err := NewBrickEntryFromId(tx, oldBrickId)
+		if err != nil {
+			return err
+		}
+
+		oldDeviceEntry, err := NewDeviceEntryFromId(tx, oldBrickEntry.Info.DeviceId)
+		if err != nil {
+			return err
+		}
+		oldBrickNode, err := NewNodeEntryFromId(tx, oldBrickEntry.Info.NodeId)
+		if err != nil {
+			return err
+		}
+
+		// Determine the setlist by getting data from Gluster
+		vinfo, err := executor.VolumeInfo(oldBrickNode.ManageHostName(), v.Info.Name)
+		var slicestartindex int
+		var foundbrickset bool
+		var brick executors.Brick
+		setlist := make([]*BrickEntry, 0)
+		for slicestartindex = 0; slicestartindex <= len(vinfo.Bricks.Bricks)-v.Durability.BricksInSet(); slicestartindex = slicestartindex + v.Durability.BricksInSet() {
+			setlist = make([]*BrickEntry, 0)
+			for _, brick = range vinfo.Bricks.Bricks[slicestartindex : slicestartindex+v.Durability.BricksInSet()] {
+				brickentry, err := v.getEntryfromBrickName(tx, brick.Name)
+				if err != nil {
+					return err
+				}
+				if brickentry.Id() == oldBrickId {
+					foundbrickset = true
+				} else {
+					setlist = append(setlist, brickentry)
+				}
+			}
+			if foundbrickset {
+				break
+			}
+		}
+		if !foundbrickset {
+			return err
+		}
+
+		for _, brickInSet := range setlist {
+			logger.Info("setlist is %v", brickInSet)
+		}
+
+		//Create an Id for new brick
+		var newBrickId string
+		newId := false
+		for !newId {
+			newBrickId = utils.GenUUID()
+			if !utils.SortedStringHas(v.BricksIds(), newBrickId) {
+				newId = true
+			}
+		}
+
+		logger.Info("Ask allocator for the list of devices")
+		// Check the ring for devices to place the brick
+		deviceCh, done, errc := allocator.GetNodes(v.Info.Cluster, newBrickId)
+		defer func() {
+			close(done)
+		}()
+
+		for deviceId := range deviceCh {
+
+			// Get device entry
+			newDeviceEntry, err := NewDeviceEntryFromId(tx, deviceId)
+			if err != nil {
+				return err
+			}
+
+			// Skip same device
+			if oldDeviceEntry.Info.Id == newDeviceEntry.Info.Id {
+				continue
+			}
+
+			// Do not allow a device from the same node to be
+			// in the set
+			deviceOk := true
+			for _, brickInSet := range setlist {
+				if brickInSet.Info.NodeId == newDeviceEntry.NodeId {
+					deviceOk = false
+				}
+			}
+
+			logger.Info("Volume entry: Device ID: %v,Node ID: %v", newDeviceEntry.Id, newDeviceEntry.NodeId)
+			if !deviceOk {
+				continue
+			}
+			logger.Info("Got the device with id %v", newDeviceEntry.Id())
+
+			// Try to allocate a brick on this device
+			newBrickEntry := newDeviceEntry.NewBrickEntry(oldBrickEntry.Info.Size,
+				float64(v.Info.Snapshot.Factor),
+				v.gidRequested, v.Info.Id)
+
+			// Determine if it was successful
+			if newBrickEntry == nil {
+				continue
+			}
+			logger.Info("Got a good BrickEntry now create a brick")
+			newBrickNode, err := NewNodeEntryFromId(tx, newBrickEntry.Info.NodeId)
+			if err != nil {
+				return err
+			}
+			newBrickEntry.SetId(newBrickId)
+			var brickEntries []*BrickEntry
+			brickEntries = append(brickEntries, newBrickEntry)
+			err = CreateBricks(db, executor, brickEntries)
+			if err != nil {
+				return err
+			}
+			logger.Info("Created Bricks")
+
+			defer func() {
+				if e != nil {
+					logger.Info("Entered Destroy Bricks")
+					DestroyBricks(db, executor, brickEntries)
+				}
+			}()
+
+			var oldBrick executors.BrickInfo
+			var newBrick executors.BrickInfo
+
+			oldBrick.Path = oldBrickEntry.Info.Path
+			oldBrick.Host = oldBrickNode.StorageHostName()
+			newBrick.Path = newBrickEntry.Info.Path
+			newBrick.Host = newBrickNode.StorageHostName()
+
+			err = executor.VolumeReplaceBrick(oldBrickNode.ManageHostName(), v.Info.Name, &oldBrick, &newBrick)
+			if err != nil {
+				return err
+			}
+
+			err = newBrickEntry.Save(tx)
+			if err != nil {
+				return err
+			}
+			newDeviceEntry.BrickAdd(newBrickEntry.Id())
+			err = newDeviceEntry.Save(tx)
+			if err != nil {
+				return err
+			}
+			v.BrickAdd(newBrickEntry.Id())
+			v.removeBrickFromDb(tx, oldBrickEntry)
+			err = v.Save(tx)
+			if err != nil {
+				logger.Err(err)
+				return err
+			}
+
+			logger.Info("replacing brick %s %s %s with %s %s %s",
+				oldBrickEntry.Id(), oldBrickEntry.Info.NodeId, oldBrickEntry.Info.Path,
+				newBrickEntry.Id(), newBrickEntry.Info.NodeId, newBrickEntry.Info.Path)
+
+			return nil
+		}
+		// Check if allocator returned an error
+		if err := <-errc; err != nil {
+			return err
+		}
+
+		// No device found
+		return ErrNoReplacement
+
+	})
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (v *VolumeEntry) allocBricks(

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -139,7 +139,7 @@ func (v *VolumeEntry) allocBricks(
 					// Try to allocate a brick on this device
 					brick := device.NewBrickEntry(brick_size,
 						float64(v.Info.Snapshot.Factor),
-						v.gidRequested)
+						v.gidRequested, v.Info.Id)
 
 					// Determine if it was successful
 					if brick != nil {

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -1506,3 +1506,88 @@ func TestVolumeEntryNameConflictMultiCluster(t *testing.T) {
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err != nil, err)
 }
+
+func TestReplaceBrickInVolume(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	// Create a cluster in the database
+	err := setupSampleDbWithTopology(app,
+		1,      // clusters
+		3,      // nodes_per_cluster
+		1,      // devices_per_node,
+		500*GB, // disksize)
+	)
+	tests.Assert(t, err == nil)
+
+	v := createSampleVolumeEntry(100)
+
+	err = v.Create(app.db, app.executor, app.allocator)
+	tests.Assert(t, err == nil, err)
+	var brickNames []string
+	var be *BrickEntry
+	err = app.db.View(func(tx *bolt.Tx) error {
+
+		for _, brick := range v.Bricks {
+			be, err = NewBrickEntryFromId(tx, brick)
+			if err != nil {
+				return err
+			}
+			ne, err := NewNodeEntryFromId(tx, be.Info.NodeId)
+			if err != nil {
+				return err
+			}
+			brickName := fmt.Sprintf("%v:%v", ne.Info.Hostnames.Storage[0], be.Info.Path)
+			brickNames = append(brickNames, brickName)
+		}
+		return nil
+	})
+	app.xo.MockVolumeInfo = func(host string, volume string) (*executors.SingleVolumeInfo, error) {
+		var bricks []executors.Brick
+		brick := executors.Brick{Name: brickNames[0]}
+		bricks = append(bricks, brick)
+		brick = executors.Brick{Name: brickNames[1]}
+		bricks = append(bricks, brick)
+		Bricks := executors.Bricks{
+			Bricks: bricks,
+		}
+		b := &executors.SingleVolumeInfo{
+			Bricks: Bricks,
+		}
+		return b, nil
+	}
+	brickId := be.Id()
+	err = v.replaceBrickInVolume(app.db, app.executor, app.allocator, brickId)
+	tests.Assert(t, err == nil)
+
+	oldNode := be.Info.NodeId
+	brickOnOldNode := false
+	oldBrickIdExists := false
+
+	err = app.db.View(func(tx *bolt.Tx) error {
+
+		for _, brick := range v.Bricks {
+			be, err = NewBrickEntryFromId(tx, brick)
+			if err != nil {
+				return err
+			}
+			ne, err := NewNodeEntryFromId(tx, be.Info.NodeId)
+			if err != nil {
+				return err
+			}
+			if ne.Info.Id == oldNode {
+				brickOnOldNode = true
+			}
+			if be.Info.Id == brickId {
+				oldBrickIdExists = true
+			}
+		}
+		return nil
+	})
+
+	tests.Assert(t, !brickOnOldNode, "brick found on oldNode")
+	tests.Assert(t, !oldBrickIdExists, "old Brick not deleted")
+}

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -1067,7 +1067,7 @@ func TestVolumeEntryCreateVolumeCreationFailure(t *testing.T) {
 
 	// Cause a brick creation failure
 	mockerror := errors.New("MOCK")
-	app.xo.MockVolumeCreate = func(host string, volume *executors.VolumeRequest) (*executors.VolumeInfo, error) {
+	app.xo.MockVolumeCreate = func(host string, volume *executors.VolumeRequest) (*executors.SingleVolumeInfo, error) {
 		return nil, mockerror
 	}
 

--- a/client/api/go-client/device.go
+++ b/client/api/go-client/device.go
@@ -131,6 +131,42 @@ func (c *Client) DeviceDelete(id string) error {
 	return nil
 }
 
+func (c *Client) DeviceRemove(id string) error {
+
+	// Create a request
+	req, err := http.NewRequest("POST",
+		c.host+"/devices/"+id+"/remove",
+		nil)
+	if err != nil {
+		return err
+	}
+
+	// Set token
+	err = c.setToken(req)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	r, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	if r.StatusCode != http.StatusAccepted {
+		return utils.GetErrorFromResponse(r)
+	}
+
+	// Wait for response
+	r, err = c.waitForResponseWithTimer(r, time.Second)
+	if err != nil {
+		return err
+	}
+	if r.StatusCode != http.StatusNoContent {
+		return utils.GetErrorFromResponse(r)
+	}
+
+	return nil
+}
 func (c *Client) DeviceState(id string,
 	request *api.StateRequest) error {
 

--- a/client/api/python/heketi/heketi.py
+++ b/client/api/python/heketi/heketi.py
@@ -170,6 +170,11 @@ class HeketiClient(object):
         req = self._make_request('POST', uri, state_request)
         return req.status_code == requests.codes.ok
 
+    def device_remove(self, device_id):
+        uri = '/devices/' + device_id + "/remove"
+        req = self._make_request('POST', uri)
+        return req.status_code == requests.codes.NO_CONTENT
+
     def volume_create(self, volume_options={}):
         ''' volume_options is a dict with volume creation options:
             https://github.com/heketi/heketi/wiki/API#create-a-volume

--- a/client/cli/go/cmds/device.go
+++ b/client/cli/go/cmds/device.go
@@ -27,6 +27,7 @@ func init() {
 	RootCmd.AddCommand(deviceCommand)
 	deviceCommand.AddCommand(deviceAddCommand)
 	deviceCommand.AddCommand(deviceDeleteCommand)
+	deviceCommand.AddCommand(deviceRemoveCommand)
 	deviceCommand.AddCommand(deviceInfoCommand)
 	deviceCommand.AddCommand(deviceEnableCommand)
 	deviceCommand.AddCommand(deviceDisableCommand)
@@ -36,6 +37,7 @@ func init() {
 		"Id of the node which has this device")
 	deviceAddCommand.SilenceUsage = true
 	deviceDeleteCommand.SilenceUsage = true
+	deviceRemoveCommand.SilenceUsage = true
 	deviceInfoCommand.SilenceUsage = true
 }
 
@@ -104,6 +106,35 @@ var deviceDeleteCommand = &cobra.Command{
 		err := heketi.DeviceDelete(deviceId)
 		if err == nil {
 			fmt.Fprintf(stdout, "Device %v deleted\n", deviceId)
+		}
+
+		return err
+	},
+}
+
+var deviceRemoveCommand = &cobra.Command{
+	Use:     "remove [device_id]",
+	Short:   "Removes a device from Heketi node",
+	Long:    "Removes a device from Heketi node",
+	Example: "  $ heketi-cli device remove 886a86a868711bef83001",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		s := cmd.Flags().Args()
+
+		//ensure proper number of args
+		if len(s) < 1 {
+			return errors.New("Device id missing")
+		}
+
+		//set clusterId
+		deviceId := cmd.Flags().Arg(0)
+
+		// Create a client
+		heketi := client.NewClient(options.Url, options.User, options.Key)
+
+		//set url
+		err := heketi.DeviceRemove(deviceId)
+		if err == nil {
+			fmt.Fprintf(stdout, "Device %v Removed\n", deviceId)
 		}
 
 		return err

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -9,6 +9,8 @@
 
 package executors
 
+import "encoding/xml"
+
 type Executor interface {
 	PeerProbe(exec_host, newnode string) error
 	PeerDetach(exec_host, detachnode string) error
@@ -17,11 +19,12 @@ type Executor interface {
 	BrickCreate(host string, brick *BrickRequest) (*BrickInfo, error)
 	BrickDestroy(host string, brick *BrickRequest) error
 	BrickDestroyCheck(host string, brick *BrickRequest) error
-	VolumeCreate(host string, volume *VolumeRequest) (*VolumeInfo, error)
+	VolumeCreate(host string, volume *VolumeRequest) (*SingleVolumeInfo, error)
 	VolumeDestroy(host string, volume string) error
 	VolumeDestroyCheck(host, volume string) error
-	VolumeExpand(host string, volume *VolumeRequest) (*VolumeInfo, error)
+	VolumeExpand(host string, volume *VolumeRequest) (*SingleVolumeInfo, error)
 	VolumeReplaceBrick(host string, volume string, oldBrick *BrickInfo, newBrick *BrickInfo) error
+	VolumeInfo(host string, volume string) (*SingleVolumeInfo, error)
 	SetLogLevel(level string)
 }
 
@@ -70,5 +73,56 @@ type VolumeRequest struct {
 	Replica int
 }
 
-type VolumeInfo struct {
+type Brick struct {
+	UUID      string `xml:"uuid,attr"`
+	Name      string `xml:"name"`
+	HostUUID  string `xml:"hostUuid"`
+	IsArbiter int    `xml:"isArbiter"`
+}
+
+type Bricks struct {
+	XMLName xml.Name `xml:"bricks"`
+	Bricks  []Brick  `xml:"brick"`
+}
+
+type Option struct {
+	Name  string `xml:"name"`
+	Value string `xml:"value"`
+}
+
+type Options struct {
+	XMLName xml.Name `xml:"options"`
+	Options []Option `xml:"option"`
+}
+
+type SingleVolumeInfo struct {
+	XMLName         xml.Name `xml:"volume"`
+	VolumeName      string   `xml:"name"`
+	ID              string   `xml:"id"`
+	Status          int      `xml:"status"`
+	StatusStr       string   `xml:"statusStr"`
+	BrickCount      int      `xml:"brickCount"`
+	DistCount       int      `xml:"distCount"`
+	StripeCount     int      `xml:"stripeCount"`
+	ReplicaCount    int      `xml:"replicaCount"`
+	ArbiterCount    int      `xml:"arbiterCount"`
+	DisperseCount   int      `xml:"disperseCount"`
+	RedundancyCount int      `xml:"redundancyCount"`
+	Type            int      `xml:"type"`
+	TypeStr         string   `xml:"typeStr"`
+	Transport       int      `xml:"transport"`
+	Bricks          Bricks
+	OptCount        int `xml:"optCount"`
+	Options         Options
+}
+
+type Volumes struct {
+	XMLName xml.Name           `xml:"volumes"`
+	Count   int                `xml:"count"`
+	Volumes []SingleVolumeInfo `xml:"volume"`
+}
+
+type VolInfo struct {
+	XMLName xml.Name `xml:"volInfo"`
+	Volumes Volumes  `xml:"volumes"`
 }

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -21,6 +21,7 @@ type Executor interface {
 	VolumeDestroy(host string, volume string) error
 	VolumeDestroyCheck(host, volume string) error
 	VolumeExpand(host string, volume *VolumeRequest) (*VolumeInfo, error)
+	VolumeReplaceBrick(host string, volume string, oldBrick *BrickInfo, newBrick *BrickInfo) error
 	SetLogLevel(level string)
 }
 

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -22,11 +22,12 @@ type MockExecutor struct {
 	MockBrickCreate        func(host string, brick *executors.BrickRequest) (*executors.BrickInfo, error)
 	MockBrickDestroy       func(host string, brick *executors.BrickRequest) error
 	MockBrickDestroyCheck  func(host string, brick *executors.BrickRequest) error
-	MockVolumeCreate       func(host string, volume *executors.VolumeRequest) (*executors.VolumeInfo, error)
-	MockVolumeExpand       func(host string, volume *executors.VolumeRequest) (*executors.VolumeInfo, error)
+	MockVolumeCreate       func(host string, volume *executors.VolumeRequest) (*executors.SingleVolumeInfo, error)
+	MockVolumeExpand       func(host string, volume *executors.VolumeRequest) (*executors.SingleVolumeInfo, error)
 	MockVolumeDestroy      func(host string, volume string) error
 	MockVolumeDestroyCheck func(host, volume string) error
 	MockVolumeReplaceBrick func(host string, volume string, oldBrick *executors.BrickInfo, newBrick *executors.BrickInfo) error
+	MockVolumeInfo         func(host string, volume string) (*executors.SingleVolumeInfo, error)
 }
 
 func NewMockExecutor() (*MockExecutor, error) {
@@ -66,12 +67,12 @@ func NewMockExecutor() (*MockExecutor, error) {
 		return nil
 	}
 
-	m.MockVolumeCreate = func(host string, volume *executors.VolumeRequest) (*executors.VolumeInfo, error) {
-		return &executors.VolumeInfo{}, nil
+	m.MockVolumeCreate = func(host string, volume *executors.VolumeRequest) (*executors.SingleVolumeInfo, error) {
+		return &executors.SingleVolumeInfo{}, nil
 	}
 
-	m.MockVolumeExpand = func(host string, volume *executors.VolumeRequest) (*executors.VolumeInfo, error) {
-		return &executors.VolumeInfo{}, nil
+	m.MockVolumeExpand = func(host string, volume *executors.VolumeRequest) (*executors.SingleVolumeInfo, error) {
+		return &executors.SingleVolumeInfo{}, nil
 	}
 
 	m.MockVolumeDestroy = func(host string, volume string) error {
@@ -84,6 +85,10 @@ func NewMockExecutor() (*MockExecutor, error) {
 
 	m.MockVolumeReplaceBrick = func(host string, volume string, oldBrick *executors.BrickInfo, newBrick *executors.BrickInfo) error {
 		return nil
+	}
+
+	m.MockVolumeInfo = func(host string, volume string) (*executors.SingleVolumeInfo, error) {
+		return &executors.SingleVolumeInfo{}, nil
 	}
 
 	return m, nil
@@ -121,11 +126,11 @@ func (m *MockExecutor) BrickDestroyCheck(host string, brick *executors.BrickRequ
 	return m.MockBrickDestroyCheck(host, brick)
 }
 
-func (m *MockExecutor) VolumeCreate(host string, volume *executors.VolumeRequest) (*executors.VolumeInfo, error) {
+func (m *MockExecutor) VolumeCreate(host string, volume *executors.VolumeRequest) (*executors.SingleVolumeInfo, error) {
 	return m.MockVolumeCreate(host, volume)
 }
 
-func (m *MockExecutor) VolumeExpand(host string, volume *executors.VolumeRequest) (*executors.VolumeInfo, error) {
+func (m *MockExecutor) VolumeExpand(host string, volume *executors.VolumeRequest) (*executors.SingleVolumeInfo, error) {
 	return m.MockVolumeExpand(host, volume)
 }
 
@@ -139,4 +144,8 @@ func (m *MockExecutor) VolumeDestroyCheck(host string, volume string) error {
 
 func (m *MockExecutor) VolumeReplaceBrick(host string, volume string, oldBrick *executors.BrickInfo, newBrick *executors.BrickInfo) error {
 	return m.MockVolumeReplaceBrick(host, volume, oldBrick, newBrick)
+}
+
+func (m *MockExecutor) VolumeInfo(host string, volume string) (*executors.SingleVolumeInfo, error) {
+	return m.MockVolumeInfo(host, volume)
 }

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -26,6 +26,7 @@ type MockExecutor struct {
 	MockVolumeExpand       func(host string, volume *executors.VolumeRequest) (*executors.VolumeInfo, error)
 	MockVolumeDestroy      func(host string, volume string) error
 	MockVolumeDestroyCheck func(host, volume string) error
+	MockVolumeReplaceBrick func(host string, volume string, oldBrick *executors.BrickInfo, newBrick *executors.BrickInfo) error
 }
 
 func NewMockExecutor() (*MockExecutor, error) {
@@ -81,6 +82,10 @@ func NewMockExecutor() (*MockExecutor, error) {
 		return nil
 	}
 
+	m.MockVolumeReplaceBrick = func(host string, volume string, oldBrick *executors.BrickInfo, newBrick *executors.BrickInfo) error {
+		return nil
+	}
+
 	return m, nil
 }
 
@@ -130,4 +135,8 @@ func (m *MockExecutor) VolumeDestroy(host string, volume string) error {
 
 func (m *MockExecutor) VolumeDestroyCheck(host string, volume string) error {
 	return m.MockVolumeDestroyCheck(host, volume)
+}
+
+func (m *MockExecutor) VolumeReplaceBrick(host string, volume string, oldBrick *executors.BrickInfo, newBrick *executors.BrickInfo) error {
+	return m.MockVolumeReplaceBrick(host, volume, oldBrick, newBrick)
 }

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -62,6 +62,7 @@ type BrickInfo struct {
 	Path     string `json:"path"`
 	DeviceId string `json:"device"`
 	NodeId   string `json:"node"`
+	VolumeId string `json:"volume"`
 
 	// Size in KB
 	Size uint64 `json:"size"`


### PR DESCRIPTION
Important:
We only support this feature for Replicate and Distribute Replicate Volume.
Refer: https://gluster.readthedocs.io/en/latest/Administrator%20Guide/Managing%20Volumes/#replace-brick

Removes all the brick from the device and start these bricks on other
devices based on allocator. Heal is triggered automatially for replicate volumes
on replace brick.

Allocate and create new brick to replace.
It stops the brick to be replaced, If it is not already down(kill the brick process).
Then gluster replace brick which will replace the brick with new one and also starts the heals.

If other nodes does not have sufficient storage then this command should fail.

Pair-Programmed-With: Mohamed Ashiq Liyazudeen mliyazud@redhat.com

Signed-off-by: Mohamed Ashiq Liyazudeen mliyazud@redhat.com
Signed-off-by: Raghavendra Talur rtalur@redhat.com