### PR TITLE
Make Rebalance() a little easier to read.

### DIFF
--- a/apps/glusterfs/allocator_simple_ring.go
+++ b/apps/glusterfs/allocator_simple_ring.go
@@ -134,20 +134,26 @@ func (s *SimpleAllocatorRing) Rebalance() {
 	var device *SimpleDevice
 	for i := 0; len(zones) != 0; i++ {
 		zone := i % len(zones)
-		node := i % len(zones[zone])
+		nodes := zones[zone]
+		node := i % len(nodes)
+		devices := nodes[node]
 
 		// pop device
-		device, zones[zone][node] = zones[zone][node][len(zones[zone][node])-1], zones[zone][node][:len(zones[zone][node])-1]
+		device = devices[len(devices)-1]
+		devices = devices[:len(devices)-1]
+		nodes[node] = devices
+
 		list = append(list, *device)
 
-		// delete node
-		if len(zones[zone][node]) == 0 {
-			zones[zone] = append(zones[zone][:node], zones[zone][node+1:]...)
+		if len(devices) == 0 {
+			// delete node
+			nodes = append(nodes[:node], nodes[node+1:]...)
+			zones[zone] = nodes
+		}
 
+		if len(nodes) == 0 {
 			// delete zone
-			if len(zones[zone]) == 0 {
-				zones = append(zones[:zone], zones[zone+1:]...)
-			}
+			zones = append(zones[:zone], zones[zone+1:]...)
 		}
 	}
 


### PR DESCRIPTION

Signed-off-by: Michael Adam <obnox@redhat.com>

While studying the ring allocator code, I found Rebalance() a little
difficult to read/understand. I tried to make it more readable by
introducing a few helper variables etc.

What do others think - is this useful?