### PR TITLE
Remove the VG directory on Device remove

### DIFF
--- a/executors/sshexec/device.go
+++ b/executors/sshexec/device.go
@@ -75,6 +75,24 @@ func (s *SshExecutor) DeviceTeardown(host, device, vgid string) error {
 			device, host, vgid)
 	}
 
+	commands = []string{
+		fmt.Sprintf("ls %v/%v", rootMountPoint, s.vgName(vgid)),
+	}
+	_, err = s.RemoteExecutor.RemoteCommandExecute(host, commands, 5)
+	if err != nil {
+		return nil
+	}
+
+	commands = []string{
+		fmt.Sprintf("rmdir %v/%v", rootMountPoint, s.vgName(vgid)),
+	}
+
+	_, err = s.RemoteExecutor.RemoteCommandExecute(host, commands, 5)
+	if err != nil {
+		logger.LogError("Error while removing the VG directory")
+		return nil
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Device Delete should check if the vg directory present or not and if present then remove the directory.

Closes: #402 

Signed-off-by: Mohamed Ashiq Liyazudeen <mliyazud@redhat.com>