### PR TITLE
Introduce switch "backup_db_to_kube_secret", defaulting to false

### DIFF
--- a/etc/heketi.json
+++ b/etc/heketi.json
@@ -17,6 +17,9 @@
     }
   },
 
+  "_backup_db_to_kube_secret": "Backup the heketi database to a Kubernetes secret when running in Kubernetes. Default is off.",
+  "backup_db_to_kube_secret": false,
+
   "_glusterfs_comment": "GlusterFS Configuration",
   "glusterfs": {
     "_executor_comment": [

--- a/main.go
+++ b/main.go
@@ -27,9 +27,10 @@ import (
 )
 
 type Config struct {
-	Port        string                   `json:"port"`
-	AuthEnabled bool                     `json:"use_auth"`
-	JwtConfig   middleware.JwtAuthConfig `json:"jwt"`
+	Port                 string                   `json:"port"`
+	AuthEnabled          bool                     `json:"use_auth"`
+	JwtConfig            middleware.JwtAuthConfig `json:"jwt"`
+	BackupDbToKubeSecret bool                     `json:"backup_db_to_kube_secret"`
 }
 
 var (
@@ -83,6 +84,11 @@ func setWithEnvVariables(options *Config) {
 	env = os.Getenv("HEKETI_HTTP_PORT")
 	if "" != env {
 		options.Port = env
+	}
+
+	env = os.Getenv("HEKETI_BACKUP_DB_TO_KUBE_SECRET")
+	if "" != env {
+		options.BackupDbToKubeSecret = true
 	}
 }
 
@@ -172,11 +178,13 @@ func main() {
 		fmt.Println("Authorization loaded")
 	}
 
-	// Check if running in a Kubernetes environment
-	_, err = restclient.InClusterConfig()
-	if err == nil {
-		// Load middleware to backup database
-		n.UseFunc(glusterfsApp.BackupToKubernetesSecret)
+	if options.BackupDbToKubeSecret {
+		// Check if running in a Kubernetes environment
+		_, err = restclient.InClusterConfig()
+		if err == nil {
+			// Load middleware to backup database
+			n.UseFunc(glusterfsApp.BackupToKubernetesSecret)
+		}
 	}
 
 	// Add all endpoints after the middleware was added


### PR DESCRIPTION
This disables the default activation of the backup-to-kube-secret
feature, because the size of a kubernetes secret is limited to
1MB which is too small at least for an uncompressed db with some
entries.

The feature can now be activated by the config variable
"backup_db_to_kube_secret" or with the corresponding environment
variable "HEKETI_BACKUP_DB_TO_KUBE_SECRET".

Resolves #697

Signed-off-by: Michael Adam <obnox@redhat.com>