### PR TITLE
error out replace brick if self heal is in progress

### DIFF
--- a/apps/glusterfs/app_volume_test.go
+++ b/apps/glusterfs/app_volume_test.go
@@ -720,7 +720,7 @@ func TestVolumeList(t *testing.T) {
 	err := app.db.Update(func(tx *bolt.Tx) error {
 
 		for i := 0; i < numvolumes; i++ {
-			v := createSampleVolumeEntry(100)
+			v := createSampleReplicaVolumeEntry(100, 2)
 			err := v.Save(tx)
 			if err != nil {
 				return err
@@ -771,7 +771,7 @@ func TestVolumeListReadOnlyDb(t *testing.T) {
 	err := app.db.Update(func(tx *bolt.Tx) error {
 
 		for i := 0; i < numvolumes; i++ {
-			v := createSampleVolumeEntry(100)
+			v := createSampleReplicaVolumeEntry(100, 2)
 			err := v.Save(tx)
 			if err != nil {
 				return err
@@ -875,7 +875,7 @@ func TestVolumeDelete(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Create a volume
-	v := createSampleVolumeEntry(100)
+	v := createSampleReplicaVolumeEntry(100, 2)
 	tests.Assert(t, v != nil)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil)
@@ -1020,7 +1020,7 @@ func TestVolumeExpand(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Create a volume
-	v := createSampleVolumeEntry(100)
+	v := createSampleReplicaVolumeEntry(100, 2)
 	tests.Assert(t, v != nil)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil)
@@ -1087,13 +1087,13 @@ func TestVolumeClusterResizeByAddingDevices(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Create a volume which uses the entire storage
-	v := createSampleVolumeEntry(495)
+	v := createSampleReplicaVolumeEntry(495, 2)
 	tests.Assert(t, v != nil)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil)
 
 	// Try to create another volume, but this should fail
-	v = createSampleVolumeEntry(495)
+	v = createSampleReplicaVolumeEntry(495, 2)
 	tests.Assert(t, v != nil)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == ErrNoSpace)
@@ -1121,13 +1121,13 @@ func TestVolumeClusterResizeByAddingDevices(t *testing.T) {
 	}
 
 	// Now add a volume, and it should work
-	v = createSampleVolumeEntry(495)
+	v = createSampleReplicaVolumeEntry(495, 2)
 	tests.Assert(t, v != nil)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil)
 
 	// Try to create another volume, but this should fail
-	v = createSampleVolumeEntry(495)
+	v = createSampleReplicaVolumeEntry(495, 2)
 	tests.Assert(t, v != nil)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == ErrNoSpace)

--- a/apps/glusterfs/volume_durability.go
+++ b/apps/glusterfs/volume_durability.go
@@ -19,4 +19,5 @@ type VolumeDurability interface {
 	BricksInSet() int
 	SetDurability()
 	SetExecutorVolumeRequest(v *executors.VolumeRequest)
+	QuorumBrickCount() int
 }

--- a/apps/glusterfs/volume_durability_ec.go
+++ b/apps/glusterfs/volume_durability_ec.go
@@ -71,6 +71,10 @@ func (d *VolumeDisperseDurability) BricksInSet() int {
 	return d.Data + d.Redundancy
 }
 
+func (d *VolumeDisperseDurability) QuorumBrickCount() int {
+	return d.Data
+}
+
 func (d *VolumeDisperseDurability) SetExecutorVolumeRequest(v *executors.VolumeRequest) {
 	v.Type = executors.DurabilityDispersion
 	v.Data = d.Data

--- a/apps/glusterfs/volume_durability_none.go
+++ b/apps/glusterfs/volume_durability_none.go
@@ -32,6 +32,10 @@ func (n *NoneDurability) BricksInSet() int {
 	return 1
 }
 
+func (n *NoneDurability) QuorumBrickCount() int {
+	return n.BricksInSet()
+}
+
 func (n *NoneDurability) SetExecutorVolumeRequest(v *executors.VolumeRequest) {
 	v.Type = executors.DurabilityNone
 	v.Replica = n.Replica

--- a/apps/glusterfs/volume_durability_replica.go
+++ b/apps/glusterfs/volume_durability_replica.go
@@ -63,6 +63,10 @@ func (r *VolumeReplicaDurability) BricksInSet() int {
 	return r.Replica
 }
 
+func (r *VolumeReplicaDurability) QuorumBrickCount() int {
+	return r.BricksInSet()/2 + 1
+}
+
 func (r *VolumeReplicaDurability) SetExecutorVolumeRequest(v *executors.VolumeRequest) {
 	v.Type = executors.DurabilityReplica
 	v.Replica = r.Replica

--- a/apps/glusterfs/volume_durability_test.go
+++ b/apps/glusterfs/volume_durability_test.go
@@ -85,6 +85,7 @@ func TestNoneDurability(t *testing.T) {
 	tests.Assert(t, sets == 1)
 	tests.Assert(t, brick_size == 100*GB)
 	tests.Assert(t, 1 == r.BricksInSet())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 2
 	sets, brick_size, err = gen()
@@ -92,6 +93,7 @@ func TestNoneDurability(t *testing.T) {
 	tests.Assert(t, sets == 2)
 	tests.Assert(t, brick_size == 50*GB)
 	tests.Assert(t, 1 == r.BricksInSet())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 3
 	sets, brick_size, err = gen()
@@ -99,6 +101,7 @@ func TestNoneDurability(t *testing.T) {
 	tests.Assert(t, sets == 4)
 	tests.Assert(t, brick_size == 25*GB)
 	tests.Assert(t, 1 == r.BricksInSet())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 4
 	sets, brick_size, err = gen()
@@ -106,6 +109,7 @@ func TestNoneDurability(t *testing.T) {
 	tests.Assert(t, sets == 8)
 	tests.Assert(t, brick_size == 12800*1024)
 	tests.Assert(t, 1 == r.BricksInSet())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 5
 	sets, brick_size, err = gen()
@@ -113,6 +117,7 @@ func TestNoneDurability(t *testing.T) {
 	tests.Assert(t, sets == 16)
 	tests.Assert(t, brick_size == 6400*1024)
 	tests.Assert(t, 1 == r.BricksInSet())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 6
 	sets, brick_size, err = gen()
@@ -120,6 +125,7 @@ func TestNoneDurability(t *testing.T) {
 	tests.Assert(t, sets == 32)
 	tests.Assert(t, brick_size == 3200*1024)
 	tests.Assert(t, 1 == r.BricksInSet())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 7
 	sets, brick_size, err = gen()
@@ -127,6 +133,7 @@ func TestNoneDurability(t *testing.T) {
 	tests.Assert(t, sets == 64)
 	tests.Assert(t, brick_size == 1600*1024)
 	tests.Assert(t, 1 == r.BricksInSet())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 8
 	sets, brick_size, err = gen()
@@ -134,6 +141,7 @@ func TestNoneDurability(t *testing.T) {
 	tests.Assert(t, sets == 0)
 	tests.Assert(t, brick_size == 0)
 	tests.Assert(t, 1 == r.BricksInSet())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 }
 
 func TestDisperseDurability(t *testing.T) {
@@ -150,6 +158,7 @@ func TestDisperseDurability(t *testing.T) {
 	tests.Assert(t, sets == 1)
 	tests.Assert(t, brick_size == uint64(200*GB/8))
 	tests.Assert(t, 8+3 == r.BricksInSet())
+	tests.Assert(t, 8 == r.QuorumBrickCount())
 
 	// Gen 2
 	sets, brick_size, err = gen()
@@ -157,6 +166,7 @@ func TestDisperseDurability(t *testing.T) {
 	tests.Assert(t, sets == 2)
 	tests.Assert(t, brick_size == uint64(100*GB/8))
 	tests.Assert(t, 8+3 == r.BricksInSet())
+	tests.Assert(t, 8 == r.QuorumBrickCount())
 
 	// Gen 3
 	sets, brick_size, err = gen()
@@ -164,6 +174,7 @@ func TestDisperseDurability(t *testing.T) {
 	tests.Assert(t, sets == 4)
 	tests.Assert(t, brick_size == uint64(50*GB/8))
 	tests.Assert(t, 8+3 == r.BricksInSet())
+	tests.Assert(t, 8 == r.QuorumBrickCount())
 
 	// Gen 4
 	sets, brick_size, err = gen()
@@ -171,6 +182,7 @@ func TestDisperseDurability(t *testing.T) {
 	tests.Assert(t, sets == 8)
 	tests.Assert(t, brick_size == uint64(25*GB/8))
 	tests.Assert(t, 8+3 == r.BricksInSet())
+	tests.Assert(t, 8 == r.QuorumBrickCount())
 
 	// Gen 5
 	sets, brick_size, err = gen()
@@ -178,11 +190,13 @@ func TestDisperseDurability(t *testing.T) {
 	tests.Assert(t, sets == 16)
 	tests.Assert(t, brick_size == uint64(12800*1024/8))
 	tests.Assert(t, 8+3 == r.BricksInSet())
+	tests.Assert(t, 8 == r.QuorumBrickCount())
 
 	// Gen 6
 	sets, brick_size, err = gen()
 	tests.Assert(t, err == ErrMinimumBrickSize)
 	tests.Assert(t, 8+3 == r.BricksInSet())
+	tests.Assert(t, 8 == r.QuorumBrickCount())
 }
 
 func TestDisperseDurabilityLargeBrickGenerator(t *testing.T) {
@@ -198,6 +212,7 @@ func TestDisperseDurabilityLargeBrickGenerator(t *testing.T) {
 	tests.Assert(t, sets == 32)
 	tests.Assert(t, brick_size == 3200*GB)
 	tests.Assert(t, 8+3 == r.BricksInSet())
+	tests.Assert(t, 8 == r.QuorumBrickCount())
 }
 
 func TestReplicaDurabilityGenerator(t *testing.T) {
@@ -212,6 +227,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 1)
 	tests.Assert(t, brick_size == 100*GB)
 	tests.Assert(t, 2 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
 
 	// Gen 2
 	sets, brick_size, err = gen()
@@ -219,6 +235,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 2, "sets we got:", sets)
 	tests.Assert(t, brick_size == 50*GB)
 	tests.Assert(t, 2 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
 
 	// Gen 3
 	sets, brick_size, err = gen()
@@ -226,6 +243,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 4)
 	tests.Assert(t, brick_size == 25*GB)
 	tests.Assert(t, 2 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
 
 	// Gen 4
 	sets, brick_size, err = gen()
@@ -233,6 +251,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 8)
 	tests.Assert(t, brick_size == 12800*1024)
 	tests.Assert(t, 2 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
 
 	// Gen 5
 	sets, brick_size, err = gen()
@@ -240,6 +259,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 16)
 	tests.Assert(t, brick_size == 6400*1024)
 	tests.Assert(t, 2 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
 
 	// Gen 6
 	sets, brick_size, err = gen()
@@ -247,6 +267,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 32, sets)
 	tests.Assert(t, brick_size == 3200*1024)
 	tests.Assert(t, 2 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
 
 	// Gen 7
 	sets, brick_size, err = gen()
@@ -254,6 +275,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 64, sets)
 	tests.Assert(t, brick_size == 1600*1024)
 	tests.Assert(t, 2 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
 
 	// Gen 8
 	sets, brick_size, err = gen()
@@ -261,6 +283,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 0)
 	tests.Assert(t, brick_size == 0)
 	tests.Assert(t, 2 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
 }
 
 func TestReplicaDurabilityLargeBrickGenerator(t *testing.T) {
@@ -275,6 +298,22 @@ func TestReplicaDurabilityLargeBrickGenerator(t *testing.T) {
 	tests.Assert(t, sets == 32)
 	tests.Assert(t, brick_size == 3200*GB)
 	tests.Assert(t, 2 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
+}
+
+func TestReplicaDurabilityQuorumBrickCount3(t *testing.T) {
+	r := &VolumeReplicaDurability{}
+	r.Replica = 3
+
+	gen := r.BrickSizeGenerator(100 * TB)
+
+	// Gen 1
+	sets, brick_size, err := gen()
+	tests.Assert(t, err == nil)
+	tests.Assert(t, sets == 32)
+	tests.Assert(t, brick_size == 3200*GB)
+	tests.Assert(t, 3 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
 }
 
 func TestNoneDurabilityMinVolumeSize(t *testing.T) {

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -26,11 +26,11 @@ import (
 	"github.com/heketi/tests"
 )
 
-func createSampleVolumeEntry(size int) *VolumeEntry {
+func createSampleReplicaVolumeEntry(size int, replica int) *VolumeEntry {
 	req := &api.VolumeCreateRequest{}
 	req.Size = size
 	req.Durability.Type = api.DurabilityReplicate
-	req.Durability.Replicate.Replica = 2
+	req.Durability.Replicate.Replica = replica
 
 	v := NewVolumeEntryFromRequest(req)
 
@@ -363,7 +363,7 @@ func TestVolumeEntryFromId(t *testing.T) {
 	defer app.Close()
 
 	// Create a volume entry
-	v := createSampleVolumeEntry(1024)
+	v := createSampleReplicaVolumeEntry(1024, 2)
 
 	// Save in database
 	err := app.db.Update(func(tx *bolt.Tx) error {
@@ -392,7 +392,7 @@ func TestVolumeEntrySaveDelete(t *testing.T) {
 	defer app.Close()
 
 	// Create a volume entry
-	v := createSampleVolumeEntry(1024)
+	v := createSampleReplicaVolumeEntry(1024, 2)
 
 	// Save in database
 	err := app.db.Update(func(tx *bolt.Tx) error {
@@ -441,7 +441,7 @@ func TestNewVolumeEntryNewInfoResponse(t *testing.T) {
 	defer app.Close()
 
 	// Create a volume entry
-	v := createSampleVolumeEntry(1024)
+	v := createSampleReplicaVolumeEntry(1024, 2)
 
 	// Save in database
 	err := app.db.Update(func(tx *bolt.Tx) error {
@@ -484,7 +484,7 @@ func TestVolumeEntryCreateMissingCluster(t *testing.T) {
 	defer app.Close()
 
 	// Create a volume entry
-	v := createSampleVolumeEntry(1024)
+	v := createSampleReplicaVolumeEntry(1024, 2)
 	v.Info.Clusters = []string{}
 
 	// Save in database
@@ -517,7 +517,7 @@ func TestVolumeEntryCreateRunOutOfSpaceMinBrickSizeLimit(t *testing.T) {
 
 	// Create a 100 GB volume
 	// Shouldn't be able to break it down enough to allocate volume
-	v := createSampleVolumeEntry(100)
+	v := createSampleReplicaVolumeEntry(100, 2)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == ErrNoSpace)
 	tests.Assert(t, v.Info.Cluster == "")
@@ -565,7 +565,7 @@ func TestVolumeEntryCreateRunOutOfSpaceMaxBrickLimit(t *testing.T) {
 
 	// Create a volume who will be broken down to
 	// Shouldn't be able to break it down enough to allocate volume
-	v := createSampleVolumeEntry(BrickMaxNum * 2 * int(BrickMinSize/GB))
+	v := createSampleReplicaVolumeEntry(BrickMaxNum*2*int(BrickMinSize/GB), 2)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == ErrNoSpace)
 
@@ -627,7 +627,7 @@ func TestVolumeEntryCreateTwoBricks(t *testing.T) {
 	}
 
 	// Create a volume who will be broken down to
-	v := createSampleVolumeEntry(250)
+	v := createSampleReplicaVolumeEntry(250, 2)
 
 	// Set a GID
 	v.Info.Gid = gid
@@ -737,7 +737,7 @@ func TestVolumeEntryCreateBrickDivision(t *testing.T) {
 
 	// Create a volume which is so big that it does
 	// not fit into a single replica set
-	v := createSampleVolumeEntry(2000)
+	v := createSampleReplicaVolumeEntry(2000, 2)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil)
 
@@ -818,7 +818,7 @@ func TestVolumeEntryCreateMaxBrickSize(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Create a volume whose bricks must be at most BrickMaxSize
-	v := createSampleVolumeEntry(int(BrickMaxSize / GB * 4))
+	v := createSampleReplicaVolumeEntry(int(BrickMaxSize/GB*4), 2)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil)
 
@@ -877,7 +877,7 @@ func TestVolumeEntryCreateOnClustersRequested(t *testing.T) {
 	clusters.Sort()
 
 	// Create a 1TB volume
-	v := createSampleVolumeEntry(1024)
+	v := createSampleReplicaVolumeEntry(1024, 2)
 
 	// Set the clusters to the first two cluster ids
 	v.Info.Clusters = []string{clusters[0]}
@@ -907,7 +907,7 @@ func TestVolumeEntryCreateOnClustersRequested(t *testing.T) {
 
 	// Create a new volume on either of three clusters
 	clusterset := clusters[2:5]
-	v = createSampleVolumeEntry(1024)
+	v = createSampleReplicaVolumeEntry(1024, 2)
 	v.Info.Clusters = clusterset
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil)
@@ -989,7 +989,7 @@ func TestVolumeEntryCreateCheckingClustersForSpace(t *testing.T) {
 	})
 
 	// Create a 1TB volume
-	v := createSampleVolumeEntry(1024)
+	v := createSampleReplicaVolumeEntry(1024, 2)
 
 	// Create volume
 	err = v.Create(app.db, app.executor, app.allocator)
@@ -1035,7 +1035,7 @@ func TestVolumeEntryCreateWithSnapshot(t *testing.T) {
 	// Create a volume with a snapshot factor of 1.5
 	// For a 200G vol, it would get a brick size of 100G, with a thin pool
 	// size of 100G * 1.5 = 150GB.
-	v := createSampleVolumeEntry(200)
+	v := createSampleReplicaVolumeEntry(200, 2)
 	v.Info.Snapshot.Enable = true
 	v.Info.Snapshot.Factor = 1.5
 
@@ -1103,7 +1103,7 @@ func TestVolumeEntryCreateBrickCreationFailure(t *testing.T) {
 	// Create a volume with a snapshot factor of 1.5
 	// For a 200G vol, it would get a brick size of 100G, with a thin pool
 	// size of 100G * 1.5 = 150GB.
-	v := createSampleVolumeEntry(200)
+	v := createSampleReplicaVolumeEntry(200, 2)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == mockerror, err, mockerror)
 
@@ -1157,7 +1157,7 @@ func TestVolumeEntryCreateVolumeCreationFailure(t *testing.T) {
 	// Create a volume with a snapshot factor of 1.5
 	// For a 200G vol, it would get a brick size of 100G, with a thin pool
 	// size of 100G * 1.5 = 150GB.
-	v := createSampleVolumeEntry(200)
+	v := createSampleReplicaVolumeEntry(200, 2)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == mockerror)
 
@@ -1205,7 +1205,7 @@ func TestVolumeEntryDestroy(t *testing.T) {
 	// Create a volume with a snapshot factor of 1.5
 	// For a 200G vol, it would get a brick size of 100G, with a thin pool
 	// size of 100G * 1.5 = 150GB.
-	v := createSampleVolumeEntry(200)
+	v := createSampleReplicaVolumeEntry(200, 2)
 	v.Info.Snapshot.Enable = true
 	v.Info.Snapshot.Factor = 1.5
 
@@ -1293,7 +1293,7 @@ func TestVolumeEntryExpandNoSpace(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Create large volume
-	v := createSampleVolumeEntry(1190)
+	v := createSampleReplicaVolumeEntry(1190, 2)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil)
 
@@ -1339,7 +1339,7 @@ func TestVolumeEntryExpandMaxBrickLimit(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Create large volume
-	v := createSampleVolumeEntry(100)
+	v := createSampleReplicaVolumeEntry(100, 2)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil)
 
@@ -1371,7 +1371,7 @@ func TestVolumeEntryExpandCreateBricksFailure(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Create volume
-	v := createSampleVolumeEntry(100)
+	v := createSampleReplicaVolumeEntry(100, 2)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil)
 
@@ -1419,7 +1419,7 @@ func TestVolumeEntryExpand(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Create volume
-	v := createSampleVolumeEntry(1024)
+	v := createSampleReplicaVolumeEntry(1024, 2)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, v.Info.Size == 1024)
@@ -1462,12 +1462,12 @@ func TestVolumeEntryDoNotAllowDeviceOnSameNode(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Create volume
-	v := createSampleVolumeEntry(100)
+	v := createSampleReplicaVolumeEntry(100, 2)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err != nil, err)
 	tests.Assert(t, err == ErrNoSpace)
 
-	v = createSampleVolumeEntry(10000)
+	v = createSampleReplicaVolumeEntry(10000, 2)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err != nil, err)
 	tests.Assert(t, err == ErrNoSpace)
@@ -1493,7 +1493,7 @@ func TestVolumeEntryDestroyCheck(t *testing.T) {
 	// Create a volume with a snapshot factor of 1.5
 	// For a 200G vol, it would get a brick size of 100G, with a thin pool
 	// size of 100G * 1.5 = 150GB.
-	v := createSampleVolumeEntry(200)
+	v := createSampleReplicaVolumeEntry(200, 2)
 	v.Info.Snapshot.Enable = true
 	v.Info.Snapshot.Factor = 1.5
 
@@ -1546,13 +1546,13 @@ func TestVolumeEntryNameConflictSingleCluster(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Create volume
-	v := createSampleVolumeEntry(1024)
+	v := createSampleReplicaVolumeEntry(1024, 2)
 	v.Info.Name = "myvol"
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil)
 
 	// Create another volume same name
-	v = createSampleVolumeEntry(10000)
+	v = createSampleReplicaVolumeEntry(10000, 2)
 	v.Info.Name = "myvol"
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err != nil, err)
@@ -1577,7 +1577,7 @@ func TestVolumeEntryNameConflictMultiCluster(t *testing.T) {
 
 	// Create 10 volumes
 	for i := 0; i < 10; i++ {
-		v := createSampleVolumeEntry(1024)
+		v := createSampleReplicaVolumeEntry(1024, 2)
 		v.Info.Name = "myvol"
 		err = v.Create(app.db, app.executor, app.allocator)
 		logger.Info("%v", v.Info.Cluster)
@@ -1585,7 +1585,7 @@ func TestVolumeEntryNameConflictMultiCluster(t *testing.T) {
 	}
 
 	// Create another volume same name
-	v := createSampleVolumeEntry(10000)
+	v := createSampleReplicaVolumeEntry(10000, 2)
 	v.Info.Name = "myvol"
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err != nil, err)
@@ -1601,13 +1601,13 @@ func TestReplaceBrickInVolume(t *testing.T) {
 	// Create a cluster in the database
 	err := setupSampleDbWithTopology(app,
 		1,      // clusters
-		3,      // nodes_per_cluster
+		4,      // nodes_per_cluster
 		1,      // devices_per_node,
 		500*GB, // disksize)
 	)
 	tests.Assert(t, err == nil)
 
-	v := createSampleVolumeEntry(100)
+	v := createSampleReplicaVolumeEntry(100, 3)
 
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil, err)
@@ -1635,6 +1635,8 @@ func TestReplaceBrickInVolume(t *testing.T) {
 		bricks = append(bricks, brick)
 		brick = executors.Brick{Name: brickNames[1]}
 		bricks = append(bricks, brick)
+		brick = executors.Brick{Name: brickNames[2]}
+		bricks = append(bricks, brick)
 		Bricks := executors.Bricks{
 			BrickList: bricks,
 		}
@@ -1643,9 +1645,25 @@ func TestReplaceBrickInVolume(t *testing.T) {
 		}
 		return b, nil
 	}
+	app.xo.MockHealInfo = func(host string, volume string) (*executors.HealInfo, error) {
+		var bricks executors.HealInfoBricks
+		brick := executors.BrickHealStatus{Name: brickNames[0],
+			NumberOfEntries: "0"}
+		bricks.BrickList = append(bricks.BrickList, brick)
+		brick = executors.BrickHealStatus{Name: brickNames[1],
+			NumberOfEntries: "0"}
+		bricks.BrickList = append(bricks.BrickList, brick)
+		brick = executors.BrickHealStatus{Name: brickNames[2],
+			NumberOfEntries: "0"}
+		bricks.BrickList = append(bricks.BrickList, brick)
+		h := &executors.HealInfo{
+			Bricks: bricks,
+		}
+		return h, nil
+	}
 	brickId := be.Id()
 	err = v.replaceBrickInVolume(app.db, app.executor, app.allocator, brickId)
-	tests.Assert(t, err == nil)
+	tests.Assert(t, err == nil, err)
 
 	oldNode := be.Info.NodeId
 	brickOnOldNode := false
@@ -1718,4 +1736,310 @@ func TestNewVolumeEntryWithVolumeOptions(t *testing.T) {
 	tests.Assert(t, err == nil)
 	tests.Assert(t, entry.GlusterVolumeOptions[0] == "test-option")
 
+}
+
+func TestReplaceBrickInVolumeSelfHeal1(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	// Create a cluster in the database
+	err := setupSampleDbWithTopology(app,
+		1,      // clusters
+		4,      // nodes_per_cluster
+		1,      // devices_per_node,
+		500*GB, // disksize)
+	)
+	tests.Assert(t, err == nil)
+
+	v := createSampleReplicaVolumeEntry(100, 3)
+
+	err = v.Create(app.db, app.executor, app.allocator)
+	tests.Assert(t, err == nil, err)
+	var brickNames []string
+	var be *BrickEntry
+	err = app.db.View(func(tx *bolt.Tx) error {
+
+		for _, brick := range v.Bricks {
+			be, err = NewBrickEntryFromId(tx, brick)
+			if err != nil {
+				return err
+			}
+			ne, err := NewNodeEntryFromId(tx, be.Info.NodeId)
+			if err != nil {
+				return err
+			}
+			brickName := fmt.Sprintf("%v:%v", ne.Info.Hostnames.Storage[0], be.Info.Path)
+			brickNames = append(brickNames, brickName)
+		}
+		return nil
+	})
+	app.xo.MockVolumeInfo = func(host string, volume string) (*executors.Volume, error) {
+		var bricks []executors.Brick
+		brick := executors.Brick{Name: brickNames[0]}
+		bricks = append(bricks, brick)
+		brick = executors.Brick{Name: brickNames[1]}
+		bricks = append(bricks, brick)
+		brick = executors.Brick{Name: brickNames[2]}
+		bricks = append(bricks, brick)
+		Bricks := executors.Bricks{
+			BrickList: bricks,
+		}
+		b := &executors.Volume{
+			Bricks: Bricks,
+		}
+		return b, nil
+	}
+	app.xo.MockHealInfo = func(host string, volume string) (*executors.HealInfo, error) {
+		var bricks executors.HealInfoBricks
+		brick := executors.BrickHealStatus{Name: brickNames[0],
+			NumberOfEntries: "0"}
+		bricks.BrickList = append(bricks.BrickList, brick)
+		brick = executors.BrickHealStatus{Name: brickNames[1],
+			NumberOfEntries: "0"}
+		bricks.BrickList = append(bricks.BrickList, brick)
+		// Skip entry for brick to be replaced, should pass
+		h := &executors.HealInfo{
+			Bricks: bricks,
+		}
+		return h, nil
+	}
+	brickId := be.Id()
+	err = v.replaceBrickInVolume(app.db, app.executor, app.allocator, brickId)
+	tests.Assert(t, err == nil, err)
+
+	oldNode := be.Info.NodeId
+	brickOnOldNode := false
+	oldBrickIdExists := false
+
+	err = app.db.View(func(tx *bolt.Tx) error {
+
+		for _, brick := range v.Bricks {
+			be, err = NewBrickEntryFromId(tx, brick)
+			if err != nil {
+				return err
+			}
+			ne, err := NewNodeEntryFromId(tx, be.Info.NodeId)
+			if err != nil {
+				return err
+			}
+			if ne.Info.Id == oldNode {
+				brickOnOldNode = true
+			}
+			if be.Info.Id == brickId {
+				oldBrickIdExists = true
+			}
+		}
+		return nil
+	})
+
+	tests.Assert(t, !brickOnOldNode, "brick found on oldNode")
+	tests.Assert(t, !oldBrickIdExists, "old Brick not deleted")
+}
+
+func TestReplaceBrickInVolumeSelfHeal2(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	// Create a cluster in the database
+	err := setupSampleDbWithTopology(app,
+		1,      // clusters
+		4,      // nodes_per_cluster
+		1,      // devices_per_node,
+		500*GB, // disksize)
+	)
+	tests.Assert(t, err == nil)
+
+	v := createSampleReplicaVolumeEntry(100, 3)
+
+	err = v.Create(app.db, app.executor, app.allocator)
+	tests.Assert(t, err == nil, err)
+	var brickNames []string
+	var be *BrickEntry
+	err = app.db.View(func(tx *bolt.Tx) error {
+
+		for _, brick := range v.Bricks {
+			be, err = NewBrickEntryFromId(tx, brick)
+			if err != nil {
+				return err
+			}
+			ne, err := NewNodeEntryFromId(tx, be.Info.NodeId)
+			if err != nil {
+				return err
+			}
+			brickName := fmt.Sprintf("%v:%v", ne.Info.Hostnames.Storage[0], be.Info.Path)
+			brickNames = append(brickNames, brickName)
+		}
+		return nil
+	})
+	app.xo.MockVolumeInfo = func(host string, volume string) (*executors.Volume, error) {
+		var bricks []executors.Brick
+		brick := executors.Brick{Name: brickNames[0]}
+		bricks = append(bricks, brick)
+		brick = executors.Brick{Name: brickNames[1]}
+		bricks = append(bricks, brick)
+		brick = executors.Brick{Name: brickNames[2]}
+		bricks = append(bricks, brick)
+		Bricks := executors.Bricks{
+			BrickList: bricks,
+		}
+		b := &executors.Volume{
+			Bricks: Bricks,
+		}
+		return b, nil
+	}
+	app.xo.MockHealInfo = func(host string, volume string) (*executors.HealInfo, error) {
+		var bricks executors.HealInfoBricks
+		brick := executors.BrickHealStatus{Name: brickNames[0],
+			NumberOfEntries: "0"}
+		bricks.BrickList = append(bricks.BrickList, brick)
+		brick = executors.BrickHealStatus{Name: brickNames[1],
+			NumberOfEntries: "0"}
+		bricks.BrickList = append(bricks.BrickList, brick)
+		// Brick to be replaced is source, should fail
+		brick = executors.BrickHealStatus{Name: brickNames[2],
+			NumberOfEntries: "100"}
+		bricks.BrickList = append(bricks.BrickList, brick)
+		h := &executors.HealInfo{
+			Bricks: bricks,
+		}
+		return h, nil
+	}
+	brickId := be.Id()
+	err = v.replaceBrickInVolume(app.db, app.executor, app.allocator, brickId)
+	tests.Assert(t, err != nil, err)
+
+	oldNode := be.Info.NodeId
+	brickOnOldNode := false
+	oldBrickIdExists := false
+
+	err = app.db.View(func(tx *bolt.Tx) error {
+
+		for _, brick := range v.Bricks {
+			be, err = NewBrickEntryFromId(tx, brick)
+			if err != nil {
+				return err
+			}
+			ne, err := NewNodeEntryFromId(tx, be.Info.NodeId)
+			if err != nil {
+				return err
+			}
+			if ne.Info.Id == oldNode {
+				brickOnOldNode = true
+			}
+			if be.Info.Id == brickId {
+				oldBrickIdExists = true
+			}
+		}
+		return nil
+	})
+
+	tests.Assert(t, brickOnOldNode, "brick found on oldNode")
+	tests.Assert(t, oldBrickIdExists, "old Brick not deleted")
+}
+
+func TestReplaceBrickInVolumeSelfHealQuorumNotMet(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	// Create a cluster in the database
+	err := setupSampleDbWithTopology(app,
+		1,      // clusters
+		4,      // nodes_per_cluster
+		1,      // devices_per_node,
+		500*GB, // disksize)
+	)
+	tests.Assert(t, err == nil)
+
+	v := createSampleReplicaVolumeEntry(100, 3)
+
+	err = v.Create(app.db, app.executor, app.allocator)
+	tests.Assert(t, err == nil, err)
+	var brickNames []string
+	var be *BrickEntry
+	err = app.db.View(func(tx *bolt.Tx) error {
+
+		for _, brick := range v.Bricks {
+			be, err = NewBrickEntryFromId(tx, brick)
+			if err != nil {
+				return err
+			}
+			ne, err := NewNodeEntryFromId(tx, be.Info.NodeId)
+			if err != nil {
+				return err
+			}
+			brickName := fmt.Sprintf("%v:%v", ne.Info.Hostnames.Storage[0], be.Info.Path)
+			brickNames = append(brickNames, brickName)
+		}
+		return nil
+	})
+	app.xo.MockVolumeInfo = func(host string, volume string) (*executors.Volume, error) {
+		var bricks []executors.Brick
+		brick := executors.Brick{Name: brickNames[0]}
+		bricks = append(bricks, brick)
+		brick = executors.Brick{Name: brickNames[1]}
+		bricks = append(bricks, brick)
+		brick = executors.Brick{Name: brickNames[2]}
+		bricks = append(bricks, brick)
+		Bricks := executors.Bricks{
+			BrickList: bricks,
+		}
+		b := &executors.Volume{
+			Bricks: Bricks,
+		}
+		return b, nil
+	}
+	app.xo.MockHealInfo = func(host string, volume string) (*executors.HealInfo, error) {
+		var bricks executors.HealInfoBricks
+		brick := executors.BrickHealStatus{Name: brickNames[0],
+			NumberOfEntries: "0"}
+		bricks.BrickList = append(bricks.BrickList, brick)
+		// Quorum not met, should fail
+		brick = executors.BrickHealStatus{Name: brickNames[2],
+			NumberOfEntries: "0"}
+		bricks.BrickList = append(bricks.BrickList, brick)
+		h := &executors.HealInfo{
+			Bricks: bricks,
+		}
+		return h, nil
+	}
+	brickId := be.Id()
+	err = v.replaceBrickInVolume(app.db, app.executor, app.allocator, brickId)
+	tests.Assert(t, err != nil, err)
+
+	oldNode := be.Info.NodeId
+	brickOnOldNode := false
+	oldBrickIdExists := false
+
+	err = app.db.View(func(tx *bolt.Tx) error {
+
+		for _, brick := range v.Bricks {
+			be, err = NewBrickEntryFromId(tx, brick)
+			if err != nil {
+				return err
+			}
+			ne, err := NewNodeEntryFromId(tx, be.Info.NodeId)
+			if err != nil {
+				return err
+			}
+			if ne.Info.Id == oldNode {
+				brickOnOldNode = true
+			}
+			if be.Info.Id == brickId {
+				oldBrickIdExists = true
+			}
+		}
+		return nil
+	})
+
+	tests.Assert(t, brickOnOldNode, "brick found on oldNode")
+	tests.Assert(t, oldBrickIdExists, "old Brick not deleted")
 }

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -26,6 +26,7 @@ type Executor interface {
 	VolumeExpand(host string, volume *VolumeRequest) (*Volume, error)
 	VolumeReplaceBrick(host string, volume string, oldBrick *BrickInfo, newBrick *BrickInfo) error
 	VolumeInfo(host string, volume string) (*Volume, error)
+	HealInfo(host string, volume string) (*HealInfo, error)
 	SetLogLevel(level string)
 }
 
@@ -87,6 +88,13 @@ type Bricks struct {
 	BrickList []Brick  `xml:"brick"`
 }
 
+type BrickHealStatus struct {
+	HostUUID        string `xml:"hostUuid,attr"`
+	Name            string `xml:"name"`
+	Status          string `xml:"status"`
+	NumberOfEntries string `xml:"numberOfEntries"`
+}
+
 type Option struct {
 	Name  string `xml:"name"`
 	Value string `xml:"value"`
@@ -127,4 +135,13 @@ type Volumes struct {
 type VolInfo struct {
 	XMLName xml.Name `xml:"volInfo"`
 	Volumes Volumes  `xml:"volumes"`
+}
+
+type HealInfoBricks struct {
+	BrickList []BrickHealStatus `xml:"brick"`
+}
+
+type HealInfo struct {
+	XMLName xml.Name       `xml:"healInfo"`
+	Bricks  HealInfoBricks `xml:"bricks"`
 }

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -29,6 +29,7 @@ type MockExecutor struct {
 	MockVolumeDestroyCheck func(host, volume string) error
 	MockVolumeReplaceBrick func(host string, volume string, oldBrick *executors.BrickInfo, newBrick *executors.BrickInfo) error
 	MockVolumeInfo         func(host string, volume string) (*executors.Volume, error)
+	MockHealInfo           func(host string, volume string) (*executors.HealInfo, error)
 }
 
 func NewMockExecutor() (*MockExecutor, error) {
@@ -109,6 +110,10 @@ func NewMockExecutor() (*MockExecutor, error) {
 		return vinfo, nil
 	}
 
+	m.MockHealInfo = func(host string, volume string) (*executors.HealInfo, error) {
+		return &executors.HealInfo{}, nil
+	}
+
 	return m, nil
 }
 
@@ -170,4 +175,8 @@ func (m *MockExecutor) VolumeReplaceBrick(host string, volume string, oldBrick *
 
 func (m *MockExecutor) VolumeInfo(host string, volume string) (*executors.Volume, error) {
 	return m.MockVolumeInfo(host, volume)
+}
+
+func (m *MockExecutor) HealInfo(host string, volume string) (*executors.HealInfo, error) {
+	return m.MockHealInfo(host, volume)
 }


### PR DESCRIPTION
When the brick to be replaced is a "source" brick in a replicate or disperse volume, we should fail the replace brick. This should be ideally handled in Gluster but no harm in having extra check in Heketi.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>