### PR TITLE
have "Id:" as prefix for each cluster id

### DIFF
--- a/client/cli/go/cmds/cluster.go
+++ b/client/cli/go/cmds/cluster.go
@@ -157,8 +157,10 @@ var clusterListCommand = &cobra.Command{
 			}
 			fmt.Fprintf(stdout, string(data))
 		} else {
-			output := strings.Join(list.Clusters, "\n")
-			fmt.Fprintf(stdout, "Clusters:\n%v\n", output)
+			fmt.Fprintf(stdout, "Clusters:\n")
+			for _, clusterid := range list.Clusters {
+				fmt.Fprintf(stdout, "Id:%v\n", clusterid)
+			}
 		}
 
 		return nil


### PR DESCRIPTION
We have "Id:" as prefix for Id in most of the cli outputs.
Adding it to cluster list output too for easy parsing.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>