### PR TITLE
sshexec: Environmental variable support for config

### DIFF
--- a/executors/sshexec/sshexec.go
+++ b/executors/sshexec/sshexec.go
@@ -12,6 +12,8 @@ package sshexec
 import (
 	"errors"
 	"fmt"
+	"os"
+	"strconv"
 	"sync"
 
 	"github.com/heketi/heketi/pkg/utils"
@@ -56,8 +58,42 @@ var (
 	}
 )
 
+func setWithEnvVariables(config *SshConfig) {
+	var env string
+
+	env = os.Getenv("HEKETI_SSH_KEYFILE")
+	if "" != env {
+		config.PrivateKeyFile = env
+	}
+
+	env = os.Getenv("HEKETI_SSH_USER")
+	if "" != env {
+		config.User = env
+	}
+
+	env = os.Getenv("HEKETI_SSH_PORT")
+	if "" != env {
+		config.Port = env
+	}
+
+	env = os.Getenv("HEKETI_FSTAB")
+	if "" != env {
+		config.Fstab = env
+	}
+
+	env = os.Getenv("HEKETI_SNAPSHOT_LIMIT")
+	if "" != env {
+		i, err := strconv.Atoi(env)
+		if err == nil {
+			config.SnapShotLimit = i
+		}
+	}
+
+}
+
 func NewSshExecutor(config *SshConfig) (*SshExecutor, error) {
-	godbc.Require(config != nil)
+	// Override configuration
+	setWithEnvVariables(config)
 
 	s := &SshExecutor{}
 	s.RemoteExecutor = s


### PR DESCRIPTION
sshexec config values to support environmental variable inputs.
We have the same for Kubeexec. This patch will enable to same for sshexec. 

Signed-off-by: Mohamed Ashiq Liyazudeen <mliyazud@redhat.com>