### PR TITLE
Suggestion - External Gluster from OCP POC [DO NOT MERGE]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,3 +114,12 @@ release: darwin_amd64_dist linux_arm64_dist linux_arm_dist linux_amd64_dist
 
 .PHONY: server client test clean name run version release \
         darwin_amd64_dist linux_arm_dist linux_amd64_dist linux_arm64_dist
+
+custombuild:
+	@cp heketi ./extras/docker/ci/ 
+	@cp ./extras/docker/fromsource/heketi-start.sh ./extras/docker/ci/ 
+	@cp ./extras/docker/fromsource/heketi.json ./extras/docker/ci/ 
+	@cp ./extras/docker/fromsource/adhoc-setup.sh ./extras/docker/ci/ 
+	cd ./extras/docker/ci ;\
+	docker build --rm --tag mangirdas/heketi:dev . ;\
+	docker push mangirdas/heketi:dev

--- a/extras/docker/ci/Dockerfile
+++ b/extras/docker/ci/Dockerfile
@@ -9,10 +9,14 @@ LABEL description="CI Development build"
 ADD ./heketi /usr/bin/heketi
 ADD ./heketi-start.sh /usr/bin/heketi-start.sh
 ADD ./heketi.json /etc/heketi/heketi.json
+ADD ./adhoc-setup.sh /usr/bin/adhoc-setup.sh
 
+#to configure heketi to manage external gluster when running in ocp
+RUN chmod 777 /usr/bin/adhoc-setup.sh ; /usr/bin/adhoc-setup.sh
 RUN mkdir /var/lib/heketi
 VOLUME /var/lib/heketi
 
 # expose port, set user and set entrypoint with config option
 ENTRYPOINT ["/usr/bin/heketi-start.sh"]
+
 EXPOSE 8080

--- a/extras/docker/fromsource/Dockerfile
+++ b/extras/docker/fromsource/Dockerfile
@@ -31,6 +31,9 @@ RUN mkdir $BUILD_HOME $GOPATH && \
 # post install config and volume setup
 ADD ./heketi.json /etc/heketi/heketi.json
 ADD ./heketi-start.sh /usr/bin/heketi-start.sh
+ADD ./adhoc-setup.sh /usr/bin/adhoc-setup.sh
+
+RUN /usr/bin/adhoc-setup.sh
 VOLUME /etc/heketi
 
 RUN mkdir /var/lib/heketi

--- a/extras/docker/fromsource/adhoc-setup.sh
+++ b/extras/docker/fromsource/adhoc-setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#To run heketi in OCP and manage external Gluster we need sshd
+yum -y install openssh-server openssh-clients; yum clean all;
+echo 'root:screencast' | chpasswd
+sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+# SSH login fix. Otherwise user is kicked off after login
+sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+export NOTVISIBLE="in users profile"
+echo "export VISIBLE=now" >> /etc/profile

--- a/extras/docker/fromsource/heketi-start.sh
+++ b/extras/docker/fromsource/heketi-start.sh
@@ -8,5 +8,10 @@ if [ -f /backupdb/heketi.db ] ; then
     fi
     echo "Copied backup db to /var/lib/heketi/heketi.db"
 fi
+#ssh dirtyhack
 
+if [ "$HEKETI_EXECUTOR" == "ssh" ]; then
+    /usr/sbin/sshd -D &
+    chmod 600 /etc/heketi/heketi_key*
+fi
 /usr/bin/heketi --config=/etc/heketi/heketi.json

--- a/extras/openshift/templates/deploy-heketi-template-external-gluster.json
+++ b/extras/openshift/templates/deploy-heketi-template-external-gluster.json
@@ -1,0 +1,248 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "deploy-heketi",
+    "labels": {
+      "glusterfs": "heketi-template",
+      "deploy-heketi": "support"
+    },
+    "annotations": {
+      "description": "Bootstrap Heketi installation for EXTERNAL Gluster",
+      "tags": "glusterfs,heketi,installation"
+    }
+  },
+  "labels": {
+    "template": "deploy-heketi"
+  },
+  "objects": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "deploy-heketi",
+        "labels": {
+          "glusterfs": "heketi-service",
+          "deploy-heketi": "support"
+        },
+        "annotations": {
+          "description": "Exposes Heketi service"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "deploy-heketi",
+            "port": 8080,
+            "targetPort": 8080
+          }
+        ],
+        "selector": {
+          "name": "deploy-heketi"
+        }
+      }
+    },
+    {
+      "kind": "Route",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "deploy-heketi",
+        "labels": {
+          "glusterfs": "heketi-route",
+          "deploy-heketi": "support"
+        }
+      },
+      "spec": {
+        "to": {
+          "kind": "Service",
+          "name": "deploy-heketi"
+        }
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "deploy-heketi",
+        "labels": {
+          "glusterfs": "heketi-dc",
+          "deploy-heketi": "support"
+        },
+        "annotations": {
+          "description": "Defines how to deploy Heketi"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "name": "deploy-heketi"
+        },
+        "triggers": [
+           {
+             "type": "ConfigChange"
+           }
+        ],
+        "strategy": {
+          "type": "Recreate"
+        },
+        "template": {
+          "metadata": {
+            "name": "deploy-heketi",
+            "labels": {
+              "name": "deploy-heketi",
+              "glusterfs": "heketi-pod",
+              "deploy-heketi": "support"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "deploy-heketi",
+                "image": "mangirdas/heketi:dev",
+                "env": [
+                  {
+                    "name": "HEKETI_USER_KEY",
+                    "value": "${HEKETI_USER_KEY}"
+                  },
+                  {
+                    "name": "HEKETI_ADMIN_KEY",
+                    "value": "${HEKETI_ADMIN_KEY}"
+                  },
+                  {
+                    "name": "HEKETI_EXECUTOR",
+                    "value": "ssh"
+                  },
+                  {
+                    "name": "HEKETI_FSTAB",
+                    "value": "/var/lib/heketi/fstab"
+                  },
+                  {
+                    "name": "HEKETI_SNAPSHOT_LIMIT",
+                    "value": "14"
+                  },
+                  {
+                    "name": "HEKETI_KUBE_CERTFILE",
+                    "value": "${HEKETI_KUBE_CERTFILE}"
+                  },
+                  {
+                    "name": "HEKETI_KUBE_INSECURE",
+                    "value": "${HEKETI_KUBE_INSECURE}"
+                  },
+                  {
+                    "name": "HEKETI_KUBE_USER",
+                    "value": "${HEKETI_KUBE_USER}"
+                  },
+                  {
+                    "name": "HEKETI_KUBE_PASSWORD",
+                    "value": "${HEKETI_KUBE_PASSWORD}"
+                  },
+                  {
+                    "name": "HEKETI_KUBE_NAMESPACE",
+                    "value": "${HEKETI_KUBE_NAMESPACE}"
+                  },
+                  {
+                    "name": "HEKETI_KUBE_APIHOST",
+                    "value": "${HEKETI_KUBE_APIHOST}"
+                  }
+                ],
+                "ports": [
+                  {
+                    "containerPort": 8080
+                  }
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "db",
+                    "mountPath": "/var/lib/heketi"
+                  },
+                  {
+                    "name": "heketi-config",
+                    "mountPath": "/etc/heketi"
+                  }
+                ],
+                "readinessProbe": {
+                  "timeoutSeconds": 3,
+                  "initialDelaySeconds": 3,
+                  "httpGet": {
+                    "path": "/hello",
+                    "port": 8080
+                  }
+                },
+                "livenessProbe": {
+                  "timeoutSeconds": 3,
+                  "initialDelaySeconds": 30,
+                  "httpGet": {
+                    "path": "/hello",
+                    "port": 8080
+                  }
+                }
+              }
+            ],
+            "volumes": [
+              {
+                "name": "db",
+                 "glusterfs": {
+                    "endpoints": "heketi-storage-endpoints",
+                    "path": "heketidbstorage"
+                  }
+              },
+              {
+               "name": "heketi-config",
+               "configMap": {
+                 "name": "heketiconfig"
+                }
+               }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "HEKETI_USER_KEY",
+      "displayName": "Heketi User Secret",
+      "description": "Set secret for those creating volumes as type _user_"
+    },
+    {
+      "name": "HEKETI_ADMIN_KEY",
+      "displayName": "Heketi Administrator Secret",
+      "description": "Set secret for administration of the Heketi service as user _admin_"
+    },
+    {
+      "name": "HEKETI_KUBE_CERTFILE",
+      "displayName": "Certificate file",
+      "description": "Container path to Kubernetes certificate file"
+    },
+    {
+      "name": "HEKETI_KUBE_INSECURE",
+      "displayName": "Insecure access",
+      "description": "Allow insecure SSL/HTTPS access",
+      "value": "n"
+    },
+    {
+      "name": "HEKETI_KUBE_USER",
+      "displayName": "User",
+      "description": "OpenShift/Kubernetes username to access Kubernetes API",
+      "required": true
+    },
+    {
+      "name": "HEKETI_KUBE_PASSWORD",
+      "displayName": "Password",
+      "description": "Password for OpenShift user",
+      "required": true
+    },
+    {
+      "name": "HEKETI_KUBE_NAMESPACE",
+      "displayName": "Project/Namespace",
+      "description": "OpenShift project or Kubernetes namespace containing GlusterFS",
+      "required": true
+    },
+    {
+      "name": "HEKETI_KUBE_APIHOST",
+      "displayName": "API Host Address",
+      "description": "Kubernetes API host, for example: https://ip:port",
+      "required": true
+    }
+  ]
+}


### PR DESCRIPTION
Opening this just to start the discussion about the validity of this solution and if we can agree on something will rebase and do it properly as per agreement. 

I can see a big need to have heketi running in OCP/Origin and manage external/already existing Gluster installation. 

Did POC where SSH keys are mounted as a secret together with a configuration file. 
Modified Image to have SSHD running in the image.
Tested with external gluster and storageclasses and all things works. 

I would like to see this kind of configuration as a separate image with sshd installed, as to have it the main one would increase possible attack vector for this image if user does not use ssh executor. 

Any ideas how this could fit to wider Heketi + Gluster = CNC storage roadmap?


