### PR TITLE
Gluster Service check and Remove device node selection

### DIFF
--- a/apps/glusterfs/node_entry.go
+++ b/apps/glusterfs/node_entry.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 
 	"github.com/boltdb/bolt"
+	"github.com/heketi/heketi/executors"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/lpabon/godbc"
@@ -66,6 +67,53 @@ func (n *NodeEntry) registerManageKey(host string) string {
 
 func (n *NodeEntry) registerStorageKey(host string) string {
 	return "STORAGE" + host
+}
+
+// Verify gluster process in the node and return the manage hostname of a node in the cluster
+func GetVerifiedManageHostname(db *bolt.DB, e executors.Executor, clusterId string) (string, error) {
+	godbc.Require(clusterId != "")
+	var cluster *ClusterEntry
+	var node *NodeEntry
+	var err error
+	err = db.View(func(tx *bolt.Tx) error {
+		var err error
+		cluster, err = NewClusterEntryFromId(tx, clusterId)
+		return err
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	for _, n := range cluster.Info.Nodes {
+		var newNode *NodeEntry
+		err = db.View(func(tx *bolt.Tx) error {
+			var err error
+			newNode, err = NewNodeEntryFromId(tx, n)
+			return err
+		})
+
+		if err != nil {
+			//pass on to next node
+			continue
+		}
+
+		// Ignore if the node is not online
+		if !newNode.isOnline() {
+			continue
+		}
+		err = e.GlusterdCheck(newNode.ManageHostName())
+		if err != nil {
+			logger.Info("Glusterd not running in %v", newNode.ManageHostName())
+			continue
+		}
+		node = newNode
+		break
+	}
+	if node != nil {
+		return node.ManageHostName(), nil
+	}
+	return "", ErrNotFound
 }
 
 func (n *NodeEntry) Register(tx *bolt.Tx) error {

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -131,8 +131,17 @@ func (v *VolumeEntry) replaceBrickInVolume(db *bolt.DB, executor executors.Execu
 		return err
 	}
 
+	node := oldBrickNodeEntry.ManageHostName()
+	err = executor.GlusterdCheck(node)
+	if err != nil {
+		node, err = GetVerifiedManageHostname(db, executor, oldBrickNodeEntry.Info.ClusterId)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Determine the setlist by getting data from Gluster
-	vinfo, err := executor.VolumeInfo(oldBrickNodeEntry.ManageHostName(), v.Info.Name)
+	vinfo, err := executor.VolumeInfo(node, v.Info.Name)
 	var slicestartindex int
 	var foundbrickset bool
 	var brick executors.Brick
@@ -246,7 +255,7 @@ func (v *VolumeEntry) replaceBrickInVolume(db *bolt.DB, executor executors.Execu
 		newBrick.Path = newBrickEntry.Info.Path
 		newBrick.Host = newBrickNodeEntry.StorageHostName()
 
-		err = executor.VolumeReplaceBrick(oldBrickNodeEntry.ManageHostName(), v.Info.Name, &oldBrick, &newBrick)
+		err = executor.VolumeReplaceBrick(node, v.Info.Name, &oldBrick, &newBrick)
 		if err != nil {
 			return err
 		}

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -12,6 +12,7 @@ package executors
 import "encoding/xml"
 
 type Executor interface {
+	GlusterdCheck(host string) error
 	PeerProbe(exec_host, newnode string) error
 	PeerDetach(exec_host, detachnode string) error
 	DeviceSetup(host, device, vgid string) (*DeviceInfo, error)

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -15,6 +15,7 @@ import (
 
 type MockExecutor struct {
 	// These functions can be overwritten for testing
+	MockGlusterdCheck      func(host string) error
 	MockPeerProbe          func(exec_host, newnode string) error
 	MockPeerDetach         func(exec_host, newnode string) error
 	MockDeviceSetup        func(host, device, vgid string) (*executors.DeviceInfo, error)
@@ -32,6 +33,10 @@ type MockExecutor struct {
 
 func NewMockExecutor() (*MockExecutor, error) {
 	m := &MockExecutor{}
+
+	m.MockGlusterdCheck = func(host string) error {
+		return nil
+	}
 
 	m.MockPeerProbe = func(exec_host, newnode string) error {
 		return nil
@@ -109,6 +114,10 @@ func NewMockExecutor() (*MockExecutor, error) {
 
 func (m *MockExecutor) SetLogLevel(level string) {
 
+}
+
+func (m *MockExecutor) GlusterdCheck(host string) error {
+	return m.MockGlusterdCheck(host)
 }
 
 func (m *MockExecutor) PeerProbe(exec_host, newnode string) error {

--- a/executors/sshexec/peer.go
+++ b/executors/sshexec/peer.go
@@ -11,6 +11,7 @@ package sshexec
 
 import (
 	"fmt"
+
 	"github.com/lpabon/godbc"
 )
 
@@ -58,6 +59,22 @@ func (s *SshExecutor) PeerDetach(host, detachnode string) error {
 	_, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 10)
 	if err != nil {
 		logger.Err(err)
+	}
+
+	return nil
+}
+
+func (s *SshExecutor) GlusterdCheck(host string) error {
+	godbc.Require(host != "")
+
+	logger.Info("Check Glusterd service status in node %v", host)
+	commands := []string{
+		fmt.Sprintf("systemctl status glusterd"),
+	}
+	_, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 10)
+	if err != nil {
+		logger.Err(err)
+		return err
 	}
 
 	return nil

--- a/executors/sshexec/volume.go
+++ b/executors/sshexec/volume.go
@@ -251,60 +251,11 @@ func (s *SshExecutor) VolumeReplaceBrick(host string, volume string, oldBrick *e
 	godbc.Require(oldBrick != nil)
 	godbc.Require(newBrick != nil)
 
-	type CliOutput struct {
-		VolStatus struct {
-			Volumes struct {
-				Volume struct {
-					VolumeName string `xml:"volName"`
-					NodeCount  int    `xml:"nodeCount"`
-					Node       struct {
-						HostName string `xml:"hostname"`
-						Path     string `xml:"path"`
-						PeerId   string `xml:"peerid"`
-						Status   int    `xml:"status"`
-						Port     string `xml:"port"`
-						Ports    struct {
-							TCP  string `xml:"tcp"`
-							RDMA string `xml:"rdma"`
-						} `xml:"ports"`
-						Pid string `xml:"pid"`
-					} `xml:"node"`
-				} `xml:"volume"`
-			} `xml:"volumes"`
-		} `xml:"volStatus"`
-	}
-
-	command := []string{
-		fmt.Sprintf("gluster --mode=script volume status %v %v:%v --xml", volume, oldBrick.Host, oldBrick.Path),
-	}
-
-	//Get the xml output of status of brick
-	output, err := s.RemoteExecutor.RemoteCommandExecute(host, command, 10)
-	if err != nil {
-		return fmt.Errorf("Unable to get volume status of volume name: %v and brick: %v:%v", volume, oldBrick.Host, oldBrick.Path)
-	}
-	var volumeBrickInfo CliOutput
-	err = xml.Unmarshal([]byte(output[0]), &volumeBrickInfo)
-	if err != nil {
-		return fmt.Errorf("Unable to determine volume status of volume name: %v and brick: %v:%v", volume, oldBrick.Host, oldBrick.Path)
-	}
-
-	//Kill the brick process if it is running as it is a requirement of replace brick
-	if volumeBrickInfo.VolStatus.Volumes.Volume.Node.Pid != "N/A" {
-		command = []string{
-			fmt.Sprintf("kill -9 %v", volumeBrickInfo.VolStatus.Volumes.Volume.Node.Pid),
-		}
-		_, err := s.RemoteExecutor.RemoteCommandExecute(host, command, 10)
-		if err != nil {
-			return fmt.Errorf("Unable to kill brick process %v:%v", oldBrick.Host, oldBrick.Path)
-		}
-	}
-
 	// Replace the brick
-	command = []string{
+	command := []string{
 		fmt.Sprintf("gluster --mode=script volume replace-brick %v %v:%v %v:%v commit force", volume, oldBrick.Host, oldBrick.Path, newBrick.Host, newBrick.Path),
 	}
-	_, err = s.RemoteExecutor.RemoteCommandExecute(host, command, 10)
+	_, err := s.RemoteExecutor.RemoteCommandExecute(host, command, 10)
 	if err != nil {
 		return logger.Err(fmt.Errorf("Unable to replace brick %v:%v with %v:%v for volume %v", oldBrick.Host, oldBrick.Path, newBrick.Host, newBrick.Path, volume))
 	}


### PR DESCRIPTION
GetNode will return the node's manage hostname when called for a
clusterID. This hostname is verifed for the glusterd service to be
running.

This enables device remove to verify the node is up or not and then
choose a different node for replace brick command.

Signed-off-by: Mohamed Ashiq Liyazudeen <mliyazud@redhat.com>