### PR TITLE
Compress database when storing in a K8S Secret

### DIFF
--- a/extras/docker/fromsource/heketi-start.sh
+++ b/extras/docker/fromsource/heketi-start.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
 
-if [ -f /backupdb/heketi.db ] ; then
-    cp /backupdb/heketi.db /var/lib/heketi/heketi.db
+if [ -f /backupdb/heketi.db.gz ] ; then
+    gunzip -c /backupdb/heketi.db.gz > /var/lib/heketi/heketi.db
+    if [ $? -ne 0 ] ; then
+        echo "Unable to copy database"
+        exit 1
+    fi
+    echo "Copied backup db to /var/lib/heketi/heketi.db"
+elif [ -f /backupdb/heketi.db ] ; then
+    cp /backupdb/heketi.db > /var/lib/heketi/heketi.db
     if [ $? -ne 0 ] ; then
         echo "Unable to copy database"
         exit 1

--- a/extras/docker/rpi/heketi-start.sh
+++ b/extras/docker/rpi/heketi-start.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
 
-if [ -f /backupdb/heketi.db ] ; then
-    cp /backupdb/heketi.db /var/lib/heketi/heketi.db
+if [ -f /backupdb/heketi.db.gz ] ; then
+    gunzip -c /backupdb/heketi.db.gz > /var/lib/heketi/heketi.db
+    if [ $? -ne 0 ] ; then
+        echo "Unable to copy database"
+        exit 1
+    fi
+    echo "Copied backup db to /var/lib/heketi/heketi.db"
+elif [ -f /backupdb/heketi.db ] ; then
+    cp /backupdb/heketi.db > /var/lib/heketi/heketi.db
     if [ $? -ne 0 ] ; then
         echo "Unable to copy database"
         exit 1

--- a/extras/kubernetes/heketi-start.sh
+++ b/extras/kubernetes/heketi-start.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
 
-if [ -f /backupdb/heketi.db ] ; then
-    cp /backupdb/heketi.db /var/lib/heketi/heketi.db
+if [ -f /backupdb/heketi.db.gz ] ; then
+    gunzip -c /backupdb/heketi.db.gz > /var/lib/heketi/heketi.db
+    if [ $? -ne 0 ] ; then
+        echo "Unable to copy database"
+        exit 1
+    fi
+    echo "Copied backup db to /var/lib/heketi/heketi.db"
+elif [ -f /backupdb/heketi.db ] ; then
+    cp /backupdb/heketi.db > /var/lib/heketi/heketi.db
     if [ $? -ne 0 ] ; then
         echo "Unable to copy database"
         exit 1


### PR DESCRIPTION
With this change, the database is compressed before storing in
a Kuberntes Secret, which currently has a maximum size of 1Mi.
Because of this limit, it has been found that the maximum number
of devices allowed is 12000. This creates a db which is around 30Mi,
but is compressed down to around 900Ki.

Closes #697

Signed-off-by: Luis Pabón <luis.pabon@coreos.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/heketi/heketi/740)
<!-- Reviewable:end -->
