### PR TITLE
Fix bad quotes around /sys/fs/cgroup

### DIFF
--- a/extras/docker/gluster/Dockerfile
+++ b/extras/docker/gluster/Dockerfile
@@ -67,7 +67,7 @@ RUN echo 'root:password' | chpasswd
 # Set SSH public key
 USER root
 
-VOLUME [ “/sys/fs/cgroup”, "/dev", "/run/lvm" , "/var/lib/heketi" ]
+VOLUME [ "/sys/fs/cgroup", "/dev", "/run/lvm" , "/var/lib/heketi" ]
 
 EXPOSE 111 245 443 24007 2049 8080 6010 6011 6012 38465 38466 38468 38469 49152 49153 49154 49156 49157 49158 49159 49160 49161 49162
 


### PR DESCRIPTION
See issue #745 