### PR TITLE
Set Gluster Volume options based on user input.

### DIFF
--- a/apps/glusterfs/app_volume_test.go
+++ b/apps/glusterfs/app_volume_test.go
@@ -1211,3 +1211,71 @@ func TestVolumeCreateVsTopologyInfo(t *testing.T) {
 	err = sg.Result()
 	tests.Assert(t, err == nil, err)
 }
+func TestVolumeCreateWithOptions(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+	router := mux.NewRouter()
+	app.SetRoutes(router)
+
+	// Setup the server
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	// Setup database
+	err := setupSampleDbWithTopology(app,
+		1,    // clusters
+		10,   // nodes_per_cluster
+		10,   // devices_per_node,
+		5*TB, // disksize)
+	)
+	tests.Assert(t, err == nil)
+
+	// VolumeCreate using a test option called "test-option"
+	request := []byte(`{
+        "size" : 100,
+		"glustervolumeoptions" : [
+			"test-option"
+			]
+    }`)
+
+	// Send request
+	r, err := http.Post(ts.URL+"/volumes", "application/json", bytes.NewBuffer(request))
+	tests.Assert(t, err == nil)
+	tests.Assert(t, r.StatusCode == http.StatusAccepted)
+	location, err := r.Location()
+	tests.Assert(t, err == nil)
+
+	// Query queue until finished
+	var info api.VolumeInfoResponse
+	for {
+		r, err = http.Get(location.String())
+		tests.Assert(t, err == nil)
+		tests.Assert(t, r.StatusCode == http.StatusOK)
+		if r.ContentLength <= 0 {
+			time.Sleep(time.Millisecond * 10)
+			continue
+		} else {
+			// Should have node information here
+			tests.Assert(t, r.Header.Get("Content-Type") == "application/json; charset=UTF-8")
+			err = utils.GetJsonFromResponse(r, &info)
+			tests.Assert(t, err == nil)
+			break
+		}
+	}
+
+	tests.Assert(t, info.Id != "")
+	tests.Assert(t, info.Cluster != "")
+	tests.Assert(t, len(info.Bricks) == 1) // Only one 100GB brick needed
+	tests.Assert(t, info.Bricks[0].Size == 100*GB)
+	tests.Assert(t, info.Name == "vol_"+info.Id)
+	tests.Assert(t, info.Snapshot.Enable == false)
+	tests.Assert(t, info.Snapshot.Factor == 1)
+	tests.Assert(t, info.Durability.Type == api.DurabilityDistributeOnly)
+	// GlusterVolumeOption should have the "test-option"
+	tests.Assert(t, info.GlusterVolumeOptions[0] == "test-option")
+
+}

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -38,9 +38,10 @@ const (
 )
 
 type VolumeEntry struct {
-	Info       api.VolumeInfo
-	Bricks     sort.StringSlice
-	Durability VolumeDurability
+	Info                 api.VolumeInfo
+	Bricks               sort.StringSlice
+	Durability           VolumeDurability
+	GlusterVolumeOptions []string
 }
 
 func VolumeList(tx *bolt.Tx) ([]string, error) {
@@ -114,6 +115,9 @@ func NewVolumeEntryFromRequest(req *api.VolumeCreateRequest) *VolumeEntry {
 	} else if !vol.Info.Snapshot.Enable {
 		vol.Info.Snapshot.Factor = 1
 	}
+
+	// If it is zero, then no volume options are set.
+	vol.GlusterVolumeOptions = req.GlusterVolumeOptions
 
 	// If it is zero, then it will be assigned during volume creation
 	vol.Info.Clusters = req.Clusters

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -163,6 +163,7 @@ func (v *VolumeEntry) NewInfoResponse(tx *bolt.Tx) (*api.VolumeInfoResponse, err
 	info.Size = v.Info.Size
 	info.Durability = v.Info.Durability
 	info.Name = v.Info.Name
+	info.GlusterVolumeOptions = v.GlusterVolumeOptions
 
 	for _, brickid := range v.BricksIds() {
 		brick, err := NewBrickEntryFromId(tx, brickid)

--- a/apps/glusterfs/volume_entry_create.go
+++ b/apps/glusterfs/volume_entry_create.go
@@ -97,6 +97,7 @@ func (v *VolumeEntry) createVolumeRequest(db *bolt.DB,
 	// Setup volume information in the request
 	vr.Name = v.Info.Name
 	v.Durability.SetExecutorVolumeRequest(vr)
+	vr.GlusterVolumeOptions = v.GlusterVolumeOptions
 
 	return vr, sshhost, nil
 }

--- a/apps/glusterfs/volume_entry_create.go
+++ b/apps/glusterfs/volume_entry_create.go
@@ -11,11 +11,12 @@ package glusterfs
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/boltdb/bolt"
 	"github.com/heketi/heketi/executors"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/lpabon/godbc"
-	"strings"
 )
 
 func (v *VolumeEntry) createVolume(db *bolt.DB,

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -1675,3 +1675,47 @@ func TestReplaceBrickInVolume(t *testing.T) {
 	tests.Assert(t, !brickOnOldNode, "brick found on oldNode")
 	tests.Assert(t, !oldBrickIdExists, "old Brick not deleted")
 }
+
+func TestNewVolumeEntryWithVolumeOptions(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	// Create a cluster in the database
+	err := setupSampleDbWithTopology(app,
+		1,      // clusters
+		3,      // nodes_per_cluster
+		1,      // devices_per_node,
+		500*GB, // disksize)
+	)
+	tests.Assert(t, err == nil)
+	req := &api.VolumeCreateRequest{}
+	req.Size = 1024
+	req.GlusterVolumeOptions = []string{"test-option"}
+
+	v := NewVolumeEntryFromRequest(req)
+	tests.Assert(t, v.Info.Name == "vol_"+v.Info.Id)
+	tests.Assert(t, v.Info.Snapshot.Enable == false)
+	tests.Assert(t, v.Info.Snapshot.Factor == 1)
+	tests.Assert(t, v.Info.Size == 1024)
+	tests.Assert(t, len(v.Info.Id) != 0)
+	tests.Assert(t, len(v.Bricks) == 0)
+	tests.Assert(t, v.GlusterVolumeOptions[0] == "test-option")
+
+	err = v.Create(app.db, app.executor, app.allocator)
+	logger.Info("%v", v.Info.Cluster)
+	tests.Assert(t, err == nil, err)
+
+	// Check that the data on the database is recorded correctly
+	var entry VolumeEntry
+	err = app.db.View(func(tx *bolt.Tx) error {
+		return entry.Unmarshal(
+			tx.Bucket([]byte(BOLTDB_BUCKET_VOLUME)).
+				Get([]byte(v.Info.Id)))
+	})
+	tests.Assert(t, err == nil)
+	tests.Assert(t, entry.GlusterVolumeOptions[0] == "test-option")
+
+}

--- a/client/cli/go/cmds/volume.go
+++ b/client/cli/go/cmds/volume.go
@@ -23,20 +23,21 @@ import (
 )
 
 var (
-	size           int
-	volname        string
-	durability     string
-	replica        int
-	disperseData   int
-	redundancy     int
-	gid            int64
-	snapshotFactor float64
-	clusters       string
-	expandSize     int
-	id             string
-	kubePvFile     string
-	kubePvEndpoint string
-	kubePv         bool
+	size                 int
+	volname              string
+	durability           string
+	replica              int
+	disperseData         int
+	redundancy           int
+	gid                  int64
+	snapshotFactor       float64
+	clusters             string
+	expandSize           int
+	id                   string
+	kubePvFile           string
+	kubePvEndpoint       string
+	kubePv               bool
+	glusterVolumeOptions string
 )
 
 func init() {
@@ -78,6 +79,9 @@ func init() {
 			"\n\ton any of the configured clusters which have the available space."+
 			"\n\tProviding a set of clusters will ensure Heketi allocates storage"+
 			"\n\tfor this volume only in the clusters specified.")
+	volumeCreateCommand.Flags().StringVar(&glusterVolumeOptions, "gluster-volume-options", "",
+		"\n\tOptional: Comma separated list of volume options which can be set on the volume."+
+			"\n\tIf omitted, Heketi will set no volume option for the volume.")
 	volumeCreateCommand.Flags().BoolVar(&kubePv, "persistent-volume", false,
 		"\n\tOptional: Output to standard out a persistent volume JSON file for OpenShift or"+
 			"\n\tKubernetes with the name provided.")
@@ -126,6 +130,9 @@ var volumeCreateCommand = &cobra.Command{
   * Create a 100GB erasure coded 8+3 volume with 25GB snapshot storage:
       $ heketi-cli volume create --size=100 --durability=disperse --snapshot-factor=1.25 \
         --disperse-data=8 --redundancy=3
+
+  * Create a 100GB distributed volume which supports performance related volume options.
+      $ heketi-cli volume create --size=100 --durability=none --gluster-volume-options="performance.rda-cache-limit 10MB","performance.nl-cache-positive-entry no"
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Check volume size
@@ -153,6 +160,12 @@ var volumeCreateCommand = &cobra.Command{
 		req.Durability.Replicate.Replica = replica
 		req.Durability.Disperse.Data = disperseData
 		req.Durability.Disperse.Redundancy = redundancy
+
+
+		// Check volume options
+		if glusterVolumeOptions != "" {
+			req.GlusterVolumeOptions = strings.Split(glusterVolumeOptions, ",")
+		}
 
 		// Set group id if specified
 		if gid != 0 {

--- a/client/cli/go/cmds/volume.go
+++ b/client/cli/go/cmds/volume.go
@@ -146,21 +146,18 @@ var volumeCreateCommand = &cobra.Command{
 			return fmt.Errorf("Missing endpoint")
 		}
 
-		// Check clusters
-		var clusters_ []string
-		if clusters != "" {
-			clusters_ = strings.Split(clusters, ",")
-		}
-
 		// Create request blob
 		req := &api.VolumeCreateRequest{}
 		req.Size = size
-		req.Clusters = clusters_
 		req.Durability.Type = api.DurabilityType(durability)
 		req.Durability.Replicate.Replica = replica
 		req.Durability.Disperse.Data = disperseData
 		req.Durability.Disperse.Redundancy = redundancy
 
+		// Check clusters
+		if clusters != "" {
+			req.Clusters = strings.Split(clusters, ",")
+		}
 
 		// Check volume options
 		if glusterVolumeOptions != "" {

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -62,9 +62,10 @@ type BrickInfo struct {
 }
 
 type VolumeRequest struct {
-	Bricks []BrickInfo
-	Name   string
-	Type   DurabilityType
+	Bricks               []BrickInfo
+	Name                 string
+	Type                 DurabilityType
+	GlusterVolumeOptions []string
 
 	// Dispersion
 	Data       int

--- a/executors/sshexec/volume.go
+++ b/executors/sshexec/volume.go
@@ -62,6 +62,8 @@ func (s *SshExecutor) VolumeCreate(host string,
 
 	commands = append(commands, s.createAddBrickCommands(volume, inSet, inSet, maxPerSet)...)
 
+	commands = append(commands, s.createVolumeOptionsCommand(volume)...)
+
 	commands = append(commands, fmt.Sprintf("gluster --mode=script volume start %v", volume.Name))
 
 	_, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 10)
@@ -153,6 +155,23 @@ func (s *SshExecutor) VolumeDestroyCheck(host, volume string) error {
 	}
 
 	return nil
+}
+
+func (s *SshExecutor) createVolumeOptionsCommand(volume *executors.VolumeRequest) []string {
+	godbc.Require(len(volume.GlusterVolumeOptions) > 0)
+
+	commands := []string{}
+	var cmd string
+
+	// Go through all the Options and create volume set command
+	for _, volOption := range volume.GlusterVolumeOptions {
+		if volOption != "" {
+			cmd = fmt.Sprintf("gluster --mode=script volume set %v %v", volume.Name, volOption)
+			commands = append(commands, cmd)
+		}
+
+	}
+	return commands
 }
 
 func (s *SshExecutor) createAddBrickCommands(volume *executors.VolumeRequest,

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -148,12 +148,13 @@ type VolumeDurabilityInfo struct {
 
 type VolumeCreateRequest struct {
 	// Size in GB
-	Size       int                  `json:"size"`
-	Clusters   []string             `json:"clusters,omitempty"`
-	Name       string               `json:"name"`
-	Durability VolumeDurabilityInfo `json:"durability,omitempty"`
-	Gid        int64                `json:"gid,omitempty"`
-	Snapshot   struct {
+	Size                 int                  `json:"size"`
+	Clusters             []string             `json:"clusters,omitempty"`
+	Name                 string               `json:"name"`
+	Durability           VolumeDurabilityInfo `json:"durability,omitempty"`
+	Gid                  int64                `json:"gid,omitempty"`
+	GlusterVolumeOptions []string             `json:"glustervolumeoptions,omitempty"`
+	Snapshot             struct {
 		Enable bool    `json:"enable"`
 		Factor float32 `json:"factor"`
 	} `json:"snapshot"`


### PR DESCRIPTION
    At present there is no method to provide volume options via
    heketi commandline or via api client. With this patch we provide
    an option to user for specifying various volume options.
    
    For eg#:
    
    '
    $ heketi-cli volume create --size=100 --durability=none --options="performance.rda-cache-limit 10MB","performance.nl-cache-positive-entry no"
    '
    
    Issue ##711
    
    Signed-off-by: Mohammed Ashiq mliyazud@redhat.com
    Signed-off-by: Humble Chirammal hchiramm@redhat.com

