### PR TITLE
save and reuse volume gid in volume entry

### DIFF
--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -38,10 +38,9 @@ const (
 )
 
 type VolumeEntry struct {
-	Info         api.VolumeInfo
-	Bricks       sort.StringSlice
-	Durability   VolumeDurability
-	gidRequested int64
+	Info       api.VolumeInfo
+	Bricks     sort.StringSlice
+	Durability VolumeDurability
 }
 
 func VolumeList(tx *bolt.Tx) ([]string, error) {
@@ -68,7 +67,7 @@ func NewVolumeEntryFromRequest(req *api.VolumeCreateRequest) *VolumeEntry {
 	godbc.Require(req != nil)
 
 	vol := NewVolumeEntry()
-	vol.gidRequested = req.Gid
+	vol.Info.Gid = req.Gid
 	vol.Info.Id = utils.GenUUID()
 	vol.Info.Durability = req.Durability
 	vol.Info.Snapshot = req.Snapshot

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -225,7 +225,7 @@ func (v *VolumeEntry) replaceBrickInVolume(db *bolt.DB, executor executors.Execu
 			}
 			newBrickEntry = newDeviceEntry.NewBrickEntry(oldBrickEntry.Info.Size,
 				float64(v.Info.Snapshot.Factor),
-				v.gidRequested, v.Info.Id)
+				v.Info.Gid, v.Info.Id)
 			err = newDeviceEntry.Save(tx)
 			if err != nil {
 				return err
@@ -426,7 +426,7 @@ func (v *VolumeEntry) allocBricks(
 					// Try to allocate a brick on this device
 					brick := device.NewBrickEntry(brick_size,
 						float64(v.Info.Snapshot.Factor),
-						v.gidRequested, v.Info.Id)
+						v.Info.Gid, v.Info.Id)
 
 					// Determine if it was successful
 					if brick != nil {

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -555,7 +555,7 @@ func TestVolumeEntryCreateTwoBricks(t *testing.T) {
 	v := createSampleVolumeEntry(250)
 
 	// Set a GID
-	v.gidRequested = gid
+	v.Info.Gid = gid
 
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil, err)


### PR DESCRIPTION
Earlier, VolumeEntry.gidRequested wasn't being stored in db because
Marshal/UnMarshal methods rely on reflection to get members of a struct
to be stored in db. gidRequested being a unexported member, it wasn't
being stored. VolumeEntry.Info.Gid was not being set to gidRequested,
hence it was always found to be zero.

This patch deletes gidRequested from VolumeEntry(as it was never
exported, it is safe to do so) and uses VolumeEntry.Info.Gid in all the
further operations.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>