### PR TITLE
Revert command typos 

### DIFF
--- a/extras/docker/fromsource/heketi-start.sh
+++ b/extras/docker/fromsource/heketi-start.sh
@@ -8,7 +8,7 @@ if [ -f /backupdb/heketi.db.gz ] ; then
     fi
     echo "Copied backup db to /var/lib/heketi/heketi.db"
 elif [ -f /backupdb/heketi.db ] ; then
-    cp /backupdb/heketi.db > /var/lib/heketi/heketi.db
+    cp /backupdb/heketi.db /var/lib/heketi/heketi.db
     if [ $? -ne 0 ] ; then
         echo "Unable to copy database"
         exit 1

--- a/extras/docker/rpi/heketi-start.sh
+++ b/extras/docker/rpi/heketi-start.sh
@@ -8,7 +8,7 @@ if [ -f /backupdb/heketi.db.gz ] ; then
     fi
     echo "Copied backup db to /var/lib/heketi/heketi.db"
 elif [ -f /backupdb/heketi.db ] ; then
-    cp /backupdb/heketi.db > /var/lib/heketi/heketi.db
+    cp /backupdb/heketi.db /var/lib/heketi/heketi.db
     if [ $? -ne 0 ] ; then
         echo "Unable to copy database"
         exit 1

--- a/extras/kubernetes/heketi-start.sh
+++ b/extras/kubernetes/heketi-start.sh
@@ -8,7 +8,7 @@ if [ -f /backupdb/heketi.db.gz ] ; then
     fi
     echo "Copied backup db to /var/lib/heketi/heketi.db"
 elif [ -f /backupdb/heketi.db ] ; then
-    cp /backupdb/heketi.db > /var/lib/heketi/heketi.db
+    cp /backupdb/heketi.db /var/lib/heketi/heketi.db
     if [ $? -ne 0 ] ; then
         echo "Unable to copy database"
         exit 1


### PR DESCRIPTION
Revert cp command typos that were introduced in commit c8cb940c285f2c225d12405870587eeb61916754
The redirect symbol > in the copy command makes the script fail and breaks the dockerimage: heketi/heketi:dev
This pull request fixes this error.