### PR TITLE
Ignore vendor directory from git status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+vendor
 
 # Architecture specific extensions/prefixes
 *.[56vq]


### PR DESCRIPTION
We can ignore vendor directory as glide install will take care of the directory.

Signed-off-by: Mohamed Ashiq Liyazudeen <mliyazud@redhat.com>