### PR TITLE
Allow disperse to be 2+1

### DIFF
--- a/apps/glusterfs/app_volume.go
+++ b/apps/glusterfs/app_volume.go
@@ -83,6 +83,7 @@ func (a *App) VolumeCreate(w http.ResponseWriter, r *http.Request) {
 		d := msg.Durability.Disperse
 		// Place here correct combinations
 		switch {
+		case d.Data == 2 && d.Redundancy == 1:
 		case d.Data == 4 && d.Redundancy == 2:
 		case d.Data == 8 && d.Redundancy == 3:
 		case d.Data == 8 && d.Redundancy == 4:


### PR DESCRIPTION
I was getting `Error: Invalid dispersion combination: 2+1`, but after checking the gluster docs and testing it out, I found out this combination is actually valid and is the one I would like to use in my 3-node cluster.