### PR TITLE
Build: make sure heketi is always built.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,4 +134,5 @@ darwin_amd64_dist:
 release: darwin_amd64_dist linux_arm64_dist linux_arm_dist linux_amd64_dist
 
 .PHONY: server client test clean name run version release \
-        darwin_amd64_dist linux_arm_dist linux_amd64_dist linux_arm64_dist
+        darwin_amd64_dist linux_arm_dist linux_amd64_dist linux_arm64_dist \
+        heketi


### PR DESCRIPTION
The heketi sources are not tracked in the Makefile's
dependencies. So only by making the heketi target
phony we can ensure that heketi gets rebuilt when
any sources have changed.

Signed-off-by: Michael Adam <obnox@redhat.com>