### PR TITLE
fix/go-cli: set default HEKETI_CLI_SERVER

### DIFF
--- a/client/cli/go/cmds/root.go
+++ b/client/cli/go/cmds/root.go
@@ -36,11 +36,10 @@ type Options struct {
 }
 
 var RootCmd = &cobra.Command{
-	Use:   "heketi-cli",
-	Short: "Command line program for Heketi",
-	Long:  "Command line program for Heketi",
-	Example: `  $ export HEKETI_CLI_SERVER=http://localhost:8080
-  $ heketi-cli volume list`,
+	Use:     "heketi-cli",
+	Short:   "Command line program for Heketi",
+	Long:    "Command line program for Heketi",
+	Example: `  $ heketi-cli volume list`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if version {
 			fmt.Printf("heketi-cli %v\n", HEKETI_CLI_VERSION)
@@ -54,7 +53,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	RootCmd.PersistentFlags().StringVarP(&options.Url, "server", "s", "",
 		"\n\tHeketi server. Can also be set using the"+
-			"\n\tenvironment variable HEKETI_CLI_SERVER")
+			"\n\tenvironment variable HEKETI_CLI_SERVER (the default one is http://localhost:8080)")
 	RootCmd.PersistentFlags().StringVar(&options.Key, "secret", "",
 		"\n\tSecret key for specified user.  Can also be"+
 			"\n\tset using the environment variable HEKETI_CLI_KEY")

--- a/client/cli/go/cmds/root.go
+++ b/client/cli/go/cmds/root.go
@@ -25,6 +25,10 @@ var (
 	version            bool
 )
 
+const (
+	defaultCliServer = "http://localhost:8080"
+)
+
 // Main arguments
 type Options struct {
 	Url, Key, User string
@@ -68,10 +72,8 @@ func initConfig() {
 	// Check server
 	if options.Url == "" {
 		options.Url = os.Getenv("HEKETI_CLI_SERVER")
-		args := os.Args[1:]
-		if options.Url == "" && !version && len(args) > 0 {
-			fmt.Fprintf(stderr, "Server must be provided\n")
-			os.Exit(3)
+		if options.Url == "" {
+			options.Url = defaultCliServer
 		}
 	}
 


### PR DESCRIPTION
if `HEKETI_CLI_SERVER` is not set, make `http://localhost:8080` as the default one