### PR TITLE
Fix/create without volume options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ tags
 log
 *.sw?
 *~
+
+.coverage
+.tox
+*.log
+

--- a/executors/sshexec/volume.go
+++ b/executors/sshexec/volume.go
@@ -158,8 +158,6 @@ func (s *SshExecutor) VolumeDestroyCheck(host, volume string) error {
 }
 
 func (s *SshExecutor) createVolumeOptionsCommand(volume *executors.VolumeRequest) []string {
-	godbc.Require(len(volume.GlusterVolumeOptions) > 0)
-
 	commands := []string{}
 	var cmd string
 


### PR DESCRIPTION
`GlusterVolumeOptions` is an optional argument, if this assert is acquired, the default volume create manner will lead the heketi server to crash.