### PR TITLE
Device resync API to update free disk space after increasing the size of disk

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -333,6 +333,11 @@ func (a *App) SetRoutes(router *mux.Router) error {
 			Method:      "POST",
 			Pattern:     "/devices/{id:[A-Fa-f0-9]+}/state",
 			HandlerFunc: a.DeviceSetState},
+		rest.Route{
+			Name:        "DeviceResync",
+			Method:      "GET",
+			Pattern:     "/devices/{id:[A-Fa-f0-9]+}/resync",
+			HandlerFunc: a.DeviceResync},
 
 		// Volume
 		rest.Route{

--- a/client/api/go-client/client_test.go
+++ b/client/api/go-client/client_test.go
@@ -434,6 +434,15 @@ func TestClientDevice(t *testing.T) {
 	tests.Assert(t, err == nil)
 	tests.Assert(t, deviceInfo.State == api.EntryStateOnline)
 
+	// Resync
+	err = c.DeviceResync(deviceId)
+	tests.Assert(t, err == nil)
+	deviceInfo, err = c.DeviceInfo(deviceId)
+	tests.Assert(t, err == nil)
+	tests.Assert(t, deviceInfo.Storage.Total == 500*1024*1024)
+	tests.Assert(t, deviceInfo.Storage.Free == 500*1024*1024)
+	tests.Assert(t, deviceInfo.Storage.Used == 0)
+
 	// Try to delete node, and will not until we delete the device
 	err = c.NodeDelete(node.Id)
 	tests.Assert(t, err != nil)

--- a/client/api/go-client/device.go
+++ b/client/api/go-client/device.go
@@ -176,3 +176,38 @@ func (c *Client) DeviceState(id string,
 
 	return nil
 }
+
+func (c *Client) DeviceResync(id string) error {
+
+	// Create a request
+	req, err := http.NewRequest("GET", c.host+"/devices/"+id+"/resync", nil)
+	if err != nil {
+		return err
+	}
+
+	// Set token
+	err = c.setToken(req)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	r, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	if r.StatusCode != http.StatusAccepted {
+		return utils.GetErrorFromResponse(r)
+	}
+
+	// Wait for response
+	r, err = c.waitForResponseWithTimer(r, time.Millisecond*250)
+	if err != nil {
+		return err
+	}
+	if r.StatusCode != http.StatusNoContent {
+		return utils.GetErrorFromResponse(r)
+	}
+
+	return nil
+}

--- a/client/api/python/heketi/heketi.py
+++ b/client/api/python/heketi/heketi.py
@@ -178,6 +178,11 @@ class HeketiClient(object):
         return req.status_code == requests.codes.ok
         '''
 
+    def device_resync(self, device_id):
+        uri = '/devices/' + device_id + '/resync'
+        req = self._make_request('GET', uri)
+        return req.status_code == requests.codes.NO_CONTENT
+
     def volume_create(self, volume_options={}):
         ''' volume_options is a dict with volume creation options:
             https://github.com/heketi/heketi/wiki/API#create-a-volume

--- a/client/api/python/test/unit/test_client.py
+++ b/client/api/python/test/unit/test_client.py
@@ -180,6 +180,10 @@ class test_heketi(unittest.TestCase):
         info = c.device_info(device_id)
         self.assertEqual(info['state'], 'online')
 
+        # Resync device
+        device_resync = c.device_resync(device_id)
+        self.assertEqual(True, device_resync)
+
         # Try to delete node, and will not until we delete the device
         with self.assertRaises(requests.exceptions.HTTPError):
             c.node_delete(node['id'])

--- a/client/cli/go/cmds/device.go
+++ b/client/cli/go/cmds/device.go
@@ -31,6 +31,7 @@ func init() {
 	deviceCommand.AddCommand(deviceInfoCommand)
 	deviceCommand.AddCommand(deviceEnableCommand)
 	deviceCommand.AddCommand(deviceDisableCommand)
+	deviceCommand.AddCommand(deviceResyncCommand)
 	deviceAddCommand.Flags().StringVar(&device, "name", "",
 		"Name of device to add")
 	deviceAddCommand.Flags().StringVar(&nodeId, "node", "",
@@ -39,6 +40,7 @@ func init() {
 	deviceDeleteCommand.SilenceUsage = true
 	deviceRemoveCommand.SilenceUsage = true
 	deviceInfoCommand.SilenceUsage = true
+	deviceResyncCommand.SilenceUsage = true
 }
 
 var deviceCommand = &cobra.Command{
@@ -264,5 +266,33 @@ var deviceDisableCommand = &cobra.Command{
 		}
 
 		return err
+	},
+}
+
+var deviceResyncCommand = &cobra.Command{
+	Use:     "resync [device_id]",
+	Short:   "Resync storage information about the device with operation system",
+	Long:    "Resync storage information about the device with operation system",
+	Example: "  $ heketi-cli device resync 886a86a868711bef83001",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		//ensure proper number of args
+		s := cmd.Flags().Args()
+		if len(s) < 1 {
+			return errors.New("device id missing")
+		}
+
+		// Set node id
+		deviceId := cmd.Flags().Arg(0)
+
+		// Create a client
+		heketi := client.NewClient(options.Url, options.User, options.Key)
+
+		//set url
+		err := heketi.DeviceResync(deviceId)
+		if err == nil {
+			fmt.Fprintf(stdout, "Device %v updated\n", nodeId)
+		}
+
+		return nil
 	},
 }

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -16,6 +16,7 @@ type Executor interface {
 	PeerProbe(exec_host, newnode string) error
 	PeerDetach(exec_host, detachnode string) error
 	DeviceSetup(host, device, vgid string) (*DeviceInfo, error)
+	GetDeviceInfo(host, device, vgid string) (*DeviceInfo, error)
 	DeviceTeardown(host, device, vgid string) error
 	BrickCreate(host string, brick *BrickRequest) (*BrickInfo, error)
 	BrickDestroy(host string, brick *BrickRequest) error

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -132,6 +132,10 @@ func (m *MockExecutor) DeviceSetup(host, device, vgid string) (*executors.Device
 	return m.MockDeviceSetup(host, device, vgid)
 }
 
+func (m *MockExecutor) GetDeviceInfo(host, device, vgid string) (*executors.DeviceInfo, error) {
+	return m.MockDeviceSetup(host, device, vgid)
+}
+
 func (m *MockExecutor) DeviceTeardown(host, device, vgid string) error {
 	return m.MockDeviceTeardown(host, device, vgid)
 }

--- a/executors/sshexec/device.go
+++ b/executors/sshexec/device.go
@@ -12,9 +12,10 @@ package sshexec
 import (
 	"errors"
 	"fmt"
-	"github.com/heketi/heketi/executors"
 	"strconv"
 	"strings"
+
+	"github.com/heketi/heketi/executors"
 )
 
 const (
@@ -50,13 +51,16 @@ func (s *SshExecutor) DeviceSetup(host, device, vgid string) (d *executors.Devic
 		}
 	}()
 
+	return s.GetDeviceInfo(host, device, vgid)
+}
+
+func (s *SshExecutor) GetDeviceInfo(host, device, vgid string) (d *executors.DeviceInfo, e error) {
 	// Vg info
 	d = &executors.DeviceInfo{}
-	err = s.getVgSizeFromNode(d, host, device, vgid)
+	err := s.getVgSizeFromNode(d, host, device, vgid)
 	if err != nil {
 		return nil, err
 	}
-
 	return d, nil
 }
 


### PR DESCRIPTION
Hi. This PR adds a new REST API method `resync` that helps to update free disk space on device after increasing the size of virtual disk. See issue #756

Usage:
```
$ heketi-cli device resync id
```