### PR TITLE
Fix typo in manpage of heketi-cli

### DIFF
--- a/doc/man/heketi-cli.8
+++ b/doc/man/heketi-cli.8
@@ -230,7 +230,7 @@ Retreives information about the current Topology
 .PP
 .TP
 
-\fBheketi\-cli volume create \-\-cluster=<CLUSTER-ID> \-\-disperse-data=<DISPERSION-VALUE> \-\-durability=<TYPE> \-\-name=<VOLUME-NAME> \-\-redundancy=<REDUNDENCY-VALUE> \-\-replica=<REPLICA-VALUE> \-\-size=<VOLUME-SIZE> \-\-snapshot-factor=<SNAPSHOT-FACTOR-VALUE>\fP
+\fBheketi\-cli volume create \-\-clusters=<CLUSTER-IDS> \-\-disperse-data=<DISPERSION-VALUE> \-\-durability=<TYPE> \-\-name=<VOLUME-NAME> \-\-redundancy=<REDUNDENCY-VALUE> \-\-replica=<REPLICA-VALUE> \-\-size=<VOLUME-SIZE> \-\-snapshot-factor=<SNAPSHOT-FACTOR-VALUE>\fP
 Create a GlusterFS volume
 .TP
 \fB           Options\fP


### PR DESCRIPTION
heketi-cli volume create mentions option "--cluster", but
it must be "--clusters" (plural).

Resolves #823

Signed-off-by: Michael Adam <obnox@redhat.com>