### PR TITLE
check for self heal before replaceBrick

### DIFF
--- a/apps/glusterfs/app_volume_test.go
+++ b/apps/glusterfs/app_volume_test.go
@@ -720,7 +720,7 @@ func TestVolumeList(t *testing.T) {
 	err := app.db.Update(func(tx *bolt.Tx) error {
 
 		for i := 0; i < numvolumes; i++ {
-			v := createSampleVolumeEntry(100)
+			v := createSampleReplicaVolumeEntry(100, 2)
 			err := v.Save(tx)
 			if err != nil {
 				return err
@@ -771,7 +771,7 @@ func TestVolumeListReadOnlyDb(t *testing.T) {
 	err := app.db.Update(func(tx *bolt.Tx) error {
 
 		for i := 0; i < numvolumes; i++ {
-			v := createSampleVolumeEntry(100)
+			v := createSampleReplicaVolumeEntry(100, 2)
 			err := v.Save(tx)
 			if err != nil {
 				return err
@@ -875,7 +875,7 @@ func TestVolumeDelete(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Create a volume
-	v := createSampleVolumeEntry(100)
+	v := createSampleReplicaVolumeEntry(100, 2)
 	tests.Assert(t, v != nil)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil)
@@ -1020,7 +1020,7 @@ func TestVolumeExpand(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Create a volume
-	v := createSampleVolumeEntry(100)
+	v := createSampleReplicaVolumeEntry(100, 2)
 	tests.Assert(t, v != nil)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil)
@@ -1087,13 +1087,13 @@ func TestVolumeClusterResizeByAddingDevices(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Create a volume which uses the entire storage
-	v := createSampleVolumeEntry(495)
+	v := createSampleReplicaVolumeEntry(495, 2)
 	tests.Assert(t, v != nil)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil)
 
 	// Try to create another volume, but this should fail
-	v = createSampleVolumeEntry(495)
+	v = createSampleReplicaVolumeEntry(495, 2)
 	tests.Assert(t, v != nil)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == ErrNoSpace)
@@ -1121,13 +1121,13 @@ func TestVolumeClusterResizeByAddingDevices(t *testing.T) {
 	}
 
 	// Now add a volume, and it should work
-	v = createSampleVolumeEntry(495)
+	v = createSampleReplicaVolumeEntry(495, 2)
 	tests.Assert(t, v != nil)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == nil)
 
 	// Try to create another volume, but this should fail
-	v = createSampleVolumeEntry(495)
+	v = createSampleReplicaVolumeEntry(495, 2)
 	tests.Assert(t, v != nil)
 	err = v.Create(app.db, app.executor, app.allocator)
 	tests.Assert(t, err == ErrNoSpace)

--- a/apps/glusterfs/volume_durability.go
+++ b/apps/glusterfs/volume_durability.go
@@ -19,4 +19,5 @@ type VolumeDurability interface {
 	BricksInSet() int
 	SetDurability()
 	SetExecutorVolumeRequest(v *executors.VolumeRequest)
+	QuorumBrickCount() int
 }

--- a/apps/glusterfs/volume_durability_ec.go
+++ b/apps/glusterfs/volume_durability_ec.go
@@ -71,6 +71,10 @@ func (d *VolumeDisperseDurability) BricksInSet() int {
 	return d.Data + d.Redundancy
 }
 
+func (d *VolumeDisperseDurability) QuorumBrickCount() int {
+	return d.Data
+}
+
 func (d *VolumeDisperseDurability) SetExecutorVolumeRequest(v *executors.VolumeRequest) {
 	v.Type = executors.DurabilityDispersion
 	v.Data = d.Data

--- a/apps/glusterfs/volume_durability_none.go
+++ b/apps/glusterfs/volume_durability_none.go
@@ -32,6 +32,10 @@ func (n *NoneDurability) BricksInSet() int {
 	return 1
 }
 
+func (n *NoneDurability) QuorumBrickCount() int {
+	return n.BricksInSet()
+}
+
 func (n *NoneDurability) SetExecutorVolumeRequest(v *executors.VolumeRequest) {
 	v.Type = executors.DurabilityNone
 	v.Replica = n.Replica

--- a/apps/glusterfs/volume_durability_replica.go
+++ b/apps/glusterfs/volume_durability_replica.go
@@ -63,6 +63,10 @@ func (r *VolumeReplicaDurability) BricksInSet() int {
 	return r.Replica
 }
 
+func (r *VolumeReplicaDurability) QuorumBrickCount() int {
+	return r.BricksInSet()/2 + 1
+}
+
 func (r *VolumeReplicaDurability) SetExecutorVolumeRequest(v *executors.VolumeRequest) {
 	v.Type = executors.DurabilityReplica
 	v.Replica = r.Replica

--- a/apps/glusterfs/volume_durability_test.go
+++ b/apps/glusterfs/volume_durability_test.go
@@ -85,6 +85,7 @@ func TestNoneDurability(t *testing.T) {
 	tests.Assert(t, sets == 1)
 	tests.Assert(t, brick_size == 100*GB)
 	tests.Assert(t, 1 == r.BricksInSet())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 2
 	sets, brick_size, err = gen()
@@ -92,6 +93,7 @@ func TestNoneDurability(t *testing.T) {
 	tests.Assert(t, sets == 2)
 	tests.Assert(t, brick_size == 50*GB)
 	tests.Assert(t, 1 == r.BricksInSet())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 3
 	sets, brick_size, err = gen()
@@ -99,6 +101,7 @@ func TestNoneDurability(t *testing.T) {
 	tests.Assert(t, sets == 4)
 	tests.Assert(t, brick_size == 25*GB)
 	tests.Assert(t, 1 == r.BricksInSet())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 4
 	sets, brick_size, err = gen()
@@ -106,6 +109,7 @@ func TestNoneDurability(t *testing.T) {
 	tests.Assert(t, sets == 8)
 	tests.Assert(t, brick_size == 12800*1024)
 	tests.Assert(t, 1 == r.BricksInSet())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 5
 	sets, brick_size, err = gen()
@@ -113,6 +117,7 @@ func TestNoneDurability(t *testing.T) {
 	tests.Assert(t, sets == 16)
 	tests.Assert(t, brick_size == 6400*1024)
 	tests.Assert(t, 1 == r.BricksInSet())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 6
 	sets, brick_size, err = gen()
@@ -120,6 +125,7 @@ func TestNoneDurability(t *testing.T) {
 	tests.Assert(t, sets == 32)
 	tests.Assert(t, brick_size == 3200*1024)
 	tests.Assert(t, 1 == r.BricksInSet())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 7
 	sets, brick_size, err = gen()
@@ -127,6 +133,7 @@ func TestNoneDurability(t *testing.T) {
 	tests.Assert(t, sets == 64)
 	tests.Assert(t, brick_size == 1600*1024)
 	tests.Assert(t, 1 == r.BricksInSet())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 8
 	sets, brick_size, err = gen()
@@ -134,6 +141,7 @@ func TestNoneDurability(t *testing.T) {
 	tests.Assert(t, sets == 0)
 	tests.Assert(t, brick_size == 0)
 	tests.Assert(t, 1 == r.BricksInSet())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 }
 
 func TestDisperseDurability(t *testing.T) {
@@ -150,6 +158,7 @@ func TestDisperseDurability(t *testing.T) {
 	tests.Assert(t, sets == 1)
 	tests.Assert(t, brick_size == uint64(200*GB/8))
 	tests.Assert(t, 8+3 == r.BricksInSet())
+	tests.Assert(t, 8 == r.QuorumBrickCount())
 
 	// Gen 2
 	sets, brick_size, err = gen()
@@ -157,6 +166,7 @@ func TestDisperseDurability(t *testing.T) {
 	tests.Assert(t, sets == 2)
 	tests.Assert(t, brick_size == uint64(100*GB/8))
 	tests.Assert(t, 8+3 == r.BricksInSet())
+	tests.Assert(t, 8 == r.QuorumBrickCount())
 
 	// Gen 3
 	sets, brick_size, err = gen()
@@ -164,6 +174,7 @@ func TestDisperseDurability(t *testing.T) {
 	tests.Assert(t, sets == 4)
 	tests.Assert(t, brick_size == uint64(50*GB/8))
 	tests.Assert(t, 8+3 == r.BricksInSet())
+	tests.Assert(t, 8 == r.QuorumBrickCount())
 
 	// Gen 4
 	sets, brick_size, err = gen()
@@ -171,6 +182,7 @@ func TestDisperseDurability(t *testing.T) {
 	tests.Assert(t, sets == 8)
 	tests.Assert(t, brick_size == uint64(25*GB/8))
 	tests.Assert(t, 8+3 == r.BricksInSet())
+	tests.Assert(t, 8 == r.QuorumBrickCount())
 
 	// Gen 5
 	sets, brick_size, err = gen()
@@ -178,11 +190,13 @@ func TestDisperseDurability(t *testing.T) {
 	tests.Assert(t, sets == 16)
 	tests.Assert(t, brick_size == uint64(12800*1024/8))
 	tests.Assert(t, 8+3 == r.BricksInSet())
+	tests.Assert(t, 8 == r.QuorumBrickCount())
 
 	// Gen 6
 	sets, brick_size, err = gen()
 	tests.Assert(t, err == ErrMinimumBrickSize)
 	tests.Assert(t, 8+3 == r.BricksInSet())
+	tests.Assert(t, 8 == r.QuorumBrickCount())
 }
 
 func TestDisperseDurabilityLargeBrickGenerator(t *testing.T) {
@@ -198,6 +212,7 @@ func TestDisperseDurabilityLargeBrickGenerator(t *testing.T) {
 	tests.Assert(t, sets == 32)
 	tests.Assert(t, brick_size == 3200*GB)
 	tests.Assert(t, 8+3 == r.BricksInSet())
+	tests.Assert(t, 8 == r.QuorumBrickCount())
 }
 
 func TestReplicaDurabilityGenerator(t *testing.T) {
@@ -212,6 +227,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 1)
 	tests.Assert(t, brick_size == 100*GB)
 	tests.Assert(t, 2 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
 
 	// Gen 2
 	sets, brick_size, err = gen()
@@ -219,6 +235,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 2, "sets we got:", sets)
 	tests.Assert(t, brick_size == 50*GB)
 	tests.Assert(t, 2 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
 
 	// Gen 3
 	sets, brick_size, err = gen()
@@ -226,6 +243,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 4)
 	tests.Assert(t, brick_size == 25*GB)
 	tests.Assert(t, 2 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
 
 	// Gen 4
 	sets, brick_size, err = gen()
@@ -233,6 +251,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 8)
 	tests.Assert(t, brick_size == 12800*1024)
 	tests.Assert(t, 2 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
 
 	// Gen 5
 	sets, brick_size, err = gen()
@@ -240,6 +259,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 16)
 	tests.Assert(t, brick_size == 6400*1024)
 	tests.Assert(t, 2 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
 
 	// Gen 6
 	sets, brick_size, err = gen()
@@ -247,6 +267,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 32, sets)
 	tests.Assert(t, brick_size == 3200*1024)
 	tests.Assert(t, 2 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
 
 	// Gen 7
 	sets, brick_size, err = gen()
@@ -254,6 +275,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 64, sets)
 	tests.Assert(t, brick_size == 1600*1024)
 	tests.Assert(t, 2 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
 
 	// Gen 8
 	sets, brick_size, err = gen()
@@ -261,6 +283,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 0)
 	tests.Assert(t, brick_size == 0)
 	tests.Assert(t, 2 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
 }
 
 func TestReplicaDurabilityLargeBrickGenerator(t *testing.T) {
@@ -275,6 +298,22 @@ func TestReplicaDurabilityLargeBrickGenerator(t *testing.T) {
 	tests.Assert(t, sets == 32)
 	tests.Assert(t, brick_size == 3200*GB)
 	tests.Assert(t, 2 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
+}
+
+func TestReplicaDurabilityQuorumBrickCount3(t *testing.T) {
+	r := &VolumeReplicaDurability{}
+	r.Replica = 3
+
+	gen := r.BrickSizeGenerator(100 * TB)
+
+	// Gen 1
+	sets, brick_size, err := gen()
+	tests.Assert(t, err == nil)
+	tests.Assert(t, sets == 32)
+	tests.Assert(t, brick_size == 3200*GB)
+	tests.Assert(t, 3 == r.BricksInSet())
+	tests.Assert(t, 2 == r.QuorumBrickCount())
 }
 
 func TestNoneDurabilityMinVolumeSize(t *testing.T) {

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -27,6 +27,7 @@ type Executor interface {
 	VolumeExpand(host string, volume *VolumeRequest) (*Volume, error)
 	VolumeReplaceBrick(host string, volume string, oldBrick *BrickInfo, newBrick *BrickInfo) error
 	VolumeInfo(host string, volume string) (*Volume, error)
+	HealInfo(host string, volume string) (*HealInfo, error)
 	SetLogLevel(level string)
 }
 
@@ -88,6 +89,13 @@ type Bricks struct {
 	BrickList []Brick  `xml:"brick"`
 }
 
+type BrickHealStatus struct {
+	HostUUID        string `xml:"hostUuid,attr"`
+	Name            string `xml:"name"`
+	Status          string `xml:"status"`
+	NumberOfEntries string `xml:"numberOfEntries"`
+}
+
 type Option struct {
 	Name  string `xml:"name"`
 	Value string `xml:"value"`
@@ -128,4 +136,13 @@ type Volumes struct {
 type VolInfo struct {
 	XMLName xml.Name `xml:"volInfo"`
 	Volumes Volumes  `xml:"volumes"`
+}
+
+type HealInfoBricks struct {
+	BrickList []BrickHealStatus `xml:"brick"`
+}
+
+type HealInfo struct {
+	XMLName xml.Name       `xml:"healInfo"`
+	Bricks  HealInfoBricks `xml:"bricks"`
 }

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -29,6 +29,7 @@ type MockExecutor struct {
 	MockVolumeDestroyCheck func(host, volume string) error
 	MockVolumeReplaceBrick func(host string, volume string, oldBrick *executors.BrickInfo, newBrick *executors.BrickInfo) error
 	MockVolumeInfo         func(host string, volume string) (*executors.Volume, error)
+	MockHealInfo           func(host string, volume string) (*executors.HealInfo, error)
 }
 
 func NewMockExecutor() (*MockExecutor, error) {
@@ -109,6 +110,10 @@ func NewMockExecutor() (*MockExecutor, error) {
 		return vinfo, nil
 	}
 
+	m.MockHealInfo = func(host string, volume string) (*executors.HealInfo, error) {
+		return &executors.HealInfo{}, nil
+	}
+
 	return m, nil
 }
 
@@ -174,4 +179,8 @@ func (m *MockExecutor) VolumeReplaceBrick(host string, volume string, oldBrick *
 
 func (m *MockExecutor) VolumeInfo(host string, volume string) (*executors.Volume, error) {
 	return m.MockVolumeInfo(host, volume)
+}
+
+func (m *MockExecutor) HealInfo(host string, volume string) (*executors.HealInfo, error) {
+	return m.MockHealInfo(host, volume)
 }


### PR DESCRIPTION
The conditions to be considered are
1. If the brick to be replaced is source for some files, don't proceed
2. We kill the brick to be replaced, if that would make the replica set
lose quorum, don't proceed.

This has a side effect that remove device won't work on volumes which
have replica count 2. Choosing data safety over migration features.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>