### PR TITLE
return if unable to retrieve entry from db

### DIFF
--- a/apps/glusterfs/app_node.go
+++ b/apps/glusterfs/app_node.go
@@ -354,6 +354,9 @@ func (a *App) NodeSetState(w http.ResponseWriter, r *http.Request) {
 
 		return nil
 	})
+	if err != nil {
+		return
+	}
 
 	// Set state
 	a.asyncManager.AsyncHttpRedirectFunc(w, r, func() (string, error) {


### PR DESCRIPTION
This is fix for a crash in SetState when a null node entry is passed.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>