### PR TITLE
Revert "implement timeout for kubeexec"

### DIFF
--- a/executors/kubeexec/kubeexec.go
+++ b/executors/kubeexec/kubeexec.go
@@ -129,7 +129,6 @@ func NewKubeExecutor(config *KubeConfig) (*KubeExecutor, error) {
 
 	// Create a Kube client configuration
 	k.kubeConfig, err = inClusterConfig()
-	k.kubeConfig.Timeout = 10
 	if err != nil {
 		return nil, logger.LogError("Unable to create configuration for Kubernetes: %v", err)
 	}


### PR DESCRIPTION
Reverts heketi/heketi#778

This option does not work as expected in all the cases and leads to kubeexec timeouts in some cases.

When heketi uses kubeexec to get the list of nodes with gluster labels it fails with timeout. I increased the value to 10000 from 10 and it failed again. Reading the comments on the PR which introduced this feature in kubernetes[1] tells that it needs a corresponding feature in container run time. I have not investigated exactly what change needs to be in container runtime and if it exists, however it is for sure that with timeout set, heketi is unable to perform a kubeexec operation at all.

[1] kubernetes/kubernetes#33366

