### PR TITLE
Support geo-replication functionality

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -365,7 +365,22 @@ func (a *App) SetRoutes(router *mux.Router) error {
 			Method:      "GET",
 			Pattern:     "/volumes",
 			HandlerFunc: a.VolumeList},
-
+		// Geo-replication
+		rest.Route{
+			Name:        "GeoReplicationStatus",
+			Method:      "GET",
+			Pattern:     "/georeplication",
+			HandlerFunc: a.GeoReplicationStatus},
+		rest.Route{
+			Name:        "GeoReplicationVolumeStatus",
+			Method:      "GET",
+			Pattern:     "/volumes/{id:[A-Fa-f0-9]+}/georeplication",
+			HandlerFunc: a.GeoReplicationVolumeStatus},
+		rest.Route{
+			Name:        "GeoReplication",
+			Method:      "POST",
+			Pattern:     "/volumes/{id:[A-Fa-f0-9]+}/georeplication",
+			HandlerFunc: a.GeoReplicationPostHandler},
 		// Backup
 		rest.Route{
 			Name:        "Backup",

--- a/apps/glusterfs/app_georep.go
+++ b/apps/glusterfs/app_georep.go
@@ -1,3 +1,11 @@
+//
+// Copyright (c) 2015 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
 package glusterfs
 
 import (

--- a/apps/glusterfs/app_georep.go
+++ b/apps/glusterfs/app_georep.go
@@ -1,0 +1,219 @@
+package glusterfs
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/boltdb/bolt"
+	"github.com/gorilla/mux"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/utils"
+)
+
+// GeoReplicationStatus is the handler returning the geo-replication session
+// status
+func (a *App) GeoReplicationStatus(w http.ResponseWriter, r *http.Request) {
+	logger.Debug("In GeoReplicationStatus")
+
+	var node *NodeEntry
+	var err error
+
+	err = a.db.View(func(tx *bolt.Tx) error {
+		clusters, err := ClusterList(tx)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return err
+		}
+
+		if len(clusters) == 0 {
+			http.Error(w, fmt.Sprintf("No clusters configured"), http.StatusBadRequest)
+			logger.LogError("No clusters configured")
+			return ErrNotFound
+		}
+
+		cluster, err := NewClusterEntryFromId(tx, clusters[0])
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return err
+		}
+
+		if len(cluster.Info.Nodes) == 0 {
+			errMsg := "No clusters configured"
+			http.Error(w, fmt.Sprintf(errMsg), http.StatusBadRequest)
+			logger.LogError(errMsg)
+			return ErrNotFound
+		}
+
+		//use first node of the first cluster to get status
+		node, err = NewNodeEntryFromId(tx, cluster.Info.Nodes[0])
+		if err == ErrNotFound {
+			http.Error(w, "Node Id not found", http.StatusNotFound)
+			return err
+		} else if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return
+	}
+
+	resp, err := node.NewGeoReplicationStatusResponse(a.executor)
+	if err != nil {
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		panic(err)
+	}
+}
+
+// GeoReplicationVolumeStatus is the handler returning the geo-replication session
+// status for a specific volume
+func (a *App) GeoReplicationVolumeStatus(w http.ResponseWriter, r *http.Request) {
+	logger.Debug("In GeoReplicationVolumeStatus")
+
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	var volume *VolumeEntry
+	var host string
+	var err error
+
+	err = a.db.View(func(tx *bolt.Tx) error {
+		volume, err = NewVolumeEntryFromId(tx, id)
+		if err == ErrNotFound {
+			http.Error(w, "Volume Id not found", http.StatusNotFound)
+			return err
+		} else if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return err
+		}
+
+		cluster, err := NewClusterEntryFromId(tx, volume.Info.Cluster)
+		if err == ErrNotFound {
+			http.Error(w, "Cluster Id not found", http.StatusNotFound)
+			return err
+		} else if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return err
+		}
+
+		node, err := NewNodeEntryFromId(tx, cluster.Info.Nodes[0])
+		if err == ErrNotFound {
+			http.Error(w, "Node Id not found", http.StatusNotFound)
+			return err
+		} else if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return err
+		}
+
+		host = node.ManageHostName()
+
+		return nil
+	})
+	if err != nil {
+		return
+	}
+
+	resp, err := volume.NewGeoReplicationStatusResponse(a.executor, host)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		logger.LogError("Failed to get geo-replication status: %s", err.Error())
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		panic(err)
+	}
+}
+
+// GeoReplicationPostHandler is the handler for managing a geo-replication session
+// It covers create, config, start, stop, pause, resume and delete
+func (a *App) GeoReplicationPostHandler(w http.ResponseWriter, r *http.Request) {
+	logger.Debug("In VolumeGeoReplication")
+
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	var volume *VolumeEntry
+	var host string
+	var err error
+
+	var msg api.GeoReplicationRequest
+	if err := utils.GetJsonFromRequest(r, &msg); err != nil {
+		http.Error(w, "request unable to be parsed", http.StatusUnprocessableEntity)
+		return
+	}
+	logger.Debug("Msg: %v", msg)
+
+	switch {
+	case msg.SlaveHost == "":
+		errMsg := "Slave host not defined"
+		http.Error(w, errMsg, http.StatusBadRequest)
+		logger.LogError(errMsg)
+		return
+	case msg.SlaveVolume == "":
+		errMsg := "Slave volume not defined"
+		http.Error(w, errMsg, http.StatusBadRequest)
+		logger.LogError(errMsg)
+		return
+	}
+
+	err = a.db.View(func(tx *bolt.Tx) error {
+		volume, err = NewVolumeEntryFromId(tx, id)
+		if err == ErrNotFound {
+			http.Error(w, "Volume Id not found", http.StatusNotFound)
+			return err
+		} else if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return err
+		}
+
+		cluster, err := NewClusterEntryFromId(tx, volume.Info.Cluster)
+		if err == ErrNotFound {
+			http.Error(w, "Cluster Id not found", http.StatusNotFound)
+			return err
+		} else if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return err
+		}
+
+		node, err := NewNodeEntryFromId(tx, cluster.Info.Nodes[0])
+		if err == ErrNotFound {
+			http.Error(w, "Node Id not found", http.StatusNotFound)
+			return err
+		} else if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return err
+		}
+
+		host = node.ManageHostName()
+
+		return nil
+	})
+	if err != nil {
+		return
+	}
+
+	// Perform GeoReplication action on volume in an asynchronous function
+	a.asyncManager.AsyncHttpRedirectFunc(w, r, func() (string, error) {
+		if err := volume.GeoReplicationAction(a.db, a.executor, host, msg); err != nil {
+			return "", err
+		}
+
+		if msg.Action == api.GeoReplicationActionDelete {
+			return "/georeplication", nil
+		}
+
+		return "/volumes/" + volume.Info.Id + "/georeplication", nil
+	})
+
+}

--- a/apps/glusterfs/app_volume.go
+++ b/apps/glusterfs/app_volume.go
@@ -179,7 +179,6 @@ func (a *App) VolumeList(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-
 	// Send list back
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusOK)

--- a/apps/glusterfs/georep.go
+++ b/apps/glusterfs/georep.go
@@ -49,6 +49,15 @@ func (v *VolumeEntry) GeoReplicationAction(db *bolt.DB,
 	return nil
 }
 
+//
+// Copyright (c) 2015 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
 // NewGeoReplicationStatusResponse returns a geo-replication status response
 // populated with data from the executor
 func (v *VolumeEntry) NewGeoReplicationStatusResponse(executor executors.Executor,

--- a/apps/glusterfs/georep.go
+++ b/apps/glusterfs/georep.go
@@ -1,0 +1,133 @@
+package glusterfs
+
+import (
+	"fmt"
+
+	"github.com/boltdb/bolt"
+	"github.com/heketi/heketi/executors"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/lpabon/godbc"
+)
+
+func (v *VolumeEntry) GeoReplicationAction(db *bolt.DB,
+	executor executors.Executor,
+	host string,
+	msg api.GeoReplicationRequest) error {
+
+	logger.Debug("In GeoReplicationAction")
+
+	godbc.Require(db != nil)
+
+	geoRep := &executors.GeoReplicationRequest{
+		ActionParams: msg.ActionParams,
+		SlaveVolume:  msg.SlaveVolume,
+		SlaveHost:    msg.SlaveHost,
+		SlaveSSHPort: msg.SlaveSSHPort,
+	}
+
+	switch msg.Action {
+	case api.GeoReplicationActionCreate:
+		logger.Info("Creating geo-replication session for volume %s", v.Info.Id)
+		if err := executor.GeoReplicationCreate(host, v.Info.Name, geoRep); err != nil {
+			return err
+		}
+	case api.GeoReplicationActionConfig:
+		logger.Info("Configuring geo-replication session for volume %s", v.Info.Id)
+		if err := executor.GeoReplicationConfig(host, v.Info.Name, geoRep); err != nil {
+			return err
+		}
+	case api.GeoReplicationActionStart, api.GeoReplicationActionStop, api.GeoReplicationActionPause, api.GeoReplicationActionResume, api.GeoReplicationActionDelete:
+		action := string(msg.Action)
+		logger.Info("Executing action %s geo-replication session for volume %s", action, v.Info.Id)
+		if err := executor.GeoReplicationAction(host, v.Info.Name, action, geoRep); err != nil {
+			return err
+		}
+	default:
+		logger.LogError("Unsupported action %s", msg.Action)
+	}
+
+	return nil
+}
+
+// NewGeoReplicationStatusResponse returns a geo-replication status response
+// populated with data from the executor
+func (v *VolumeEntry) NewGeoReplicationStatusResponse(executor executors.Executor,
+	host string) (resp *api.GeoReplicationStatus, err error) {
+
+	status, err := executor.GeoReplicationVolumeStatus(host, v.Info.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(status.Volume) < 1 {
+		return nil, fmt.Errorf("Could not get replication status for volume %s", v.Info.Id)
+	}
+
+	volume := newGeoReplicationVolume(status.Volume[0])
+
+	resp = &api.GeoReplicationStatus{
+		Volumes: []api.GeoReplicationVolume{
+			volume,
+		},
+	}
+
+	return resp, nil
+}
+
+// NewGeoReplicationStatusResponse returns a geo-replication status response
+// populated with data from the executor
+func (n *NodeEntry) NewGeoReplicationStatusResponse(executor executors.Executor) (resp *api.GeoReplicationStatus, err error) {
+
+	status, err := executor.GeoReplicationStatus(n.ManageHostName())
+	if err != nil {
+		return nil, err
+	}
+
+	resp = &api.GeoReplicationStatus{
+		Volumes: []api.GeoReplicationVolume{},
+	}
+
+	for _, volume := range status.Volume {
+		v := newGeoReplicationVolume(volume)
+		resp.Volumes = append(resp.Volumes, v)
+	}
+
+	return resp, nil
+}
+
+func newGeoReplicationVolume(v executors.GeoReplicationVolume) api.GeoReplicationVolume {
+	result := api.GeoReplicationVolume{
+		VolumeName: v.VolumeName,
+		Sessions:   api.GeoReplicationSessions{},
+	}
+
+	for _, session := range v.Sessions.SessionList {
+		p := []api.GeoReplicationPair{}
+		for _, pair := range session.Pairs {
+			p = append(p, api.GeoReplicationPair{
+				MasterNode:               pair.MasterNode,
+				MasterBrick:              pair.MasterBrick,
+				SlaveUser:                pair.SlaveUser,
+				Slave:                    pair.Slave,
+				SlaveNode:                pair.SlaveNode,
+				Status:                   pair.Status,
+				CrawlStatus:              pair.CrawlStatus,
+				Entry:                    pair.Entry,
+				Data:                     pair.Data,
+				Meta:                     pair.Meta,
+				Failures:                 pair.Failures,
+				CheckpointCompleted:      pair.CheckpointCompleted,
+				MasterNodeUUID:           pair.MasterNodeUUID,
+				LastSynced:               pair.LastSynced,
+				CheckpointTime:           pair.CheckpointTime,
+				CheckpointCompletionTime: pair.CheckpointCompletionTime,
+			})
+		}
+
+		result.Sessions.SessionList = append(result.Sessions.SessionList, api.GeoReplicationSession{
+			SessionSlave: session.SessionSlave,
+			Pairs:        p,
+		})
+	}
+	return result
+}

--- a/client/api/go-client/georep.go
+++ b/client/api/go-client/georep.go
@@ -1,0 +1,138 @@
+//
+// Copyright (c) 2015 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
+//
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/utils"
+)
+
+func (c *Client) GeoReplicationPostAction(id string, request *api.GeoReplicationRequest) (*api.GeoReplicationStatus, error) {
+	// Marshal request to JSON
+	buffer, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a request
+	req, err := http.NewRequest("POST", c.host+"/volumes/"+id+"/georeplication", bytes.NewBuffer(buffer))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Set token
+	err = c.setToken(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Send request
+	r, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	if r.StatusCode != http.StatusAccepted {
+		return nil, utils.GetErrorFromResponse(r)
+	}
+
+	// Wait for response
+	r, err = c.waitForResponseWithTimer(r, time.Second)
+	if err != nil {
+		return nil, err
+	}
+	if r.StatusCode != http.StatusOK {
+		return nil, utils.GetErrorFromResponse(r)
+	}
+
+	// Read JSON response
+	var resp api.GeoReplicationStatus
+	err = utils.GetJsonFromResponse(r, &resp)
+	r.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (c *Client) GeoReplicationVolumeStatus(id string) (*api.GeoReplicationStatus, error) {
+	// Create request
+	req, err := http.NewRequest("GET", c.host+"/volumes/"+id+"/georeplication", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set token
+	err = c.setToken(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get status
+	r, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	if r.StatusCode != http.StatusOK {
+		return nil, utils.GetErrorFromResponse(r)
+	}
+
+	// Read JSON response
+	var status api.GeoReplicationStatus
+	err = utils.GetJsonFromResponse(r, &status)
+	r.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return &status, nil
+}
+
+func (c *Client) GeoReplicationStatus() (*api.GeoReplicationStatus, error) {
+	// Create request
+	req, err := http.NewRequest("GET", c.host+"/georeplication", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set token
+	err = c.setToken(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get status
+	r, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	if r.StatusCode != http.StatusOK {
+		return nil, utils.GetErrorFromResponse(r)
+	}
+
+	// Read JSON response
+	var status api.GeoReplicationStatus
+	err = utils.GetJsonFromResponse(r, &status)
+	r.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return &status, nil
+}

--- a/client/api/python/heketi/heketi.py
+++ b/client/api/python/heketi/heketi.py
@@ -214,3 +214,129 @@ class HeketiClient(object):
         uri = '/volumes/' + volume_id
         req = self._make_request('DELETE', uri)
         return req.status_code == requests.codes.NO_CONTENT
+
+    def georeplication_create(self, volume_id, slave_host, slave_volume,
+                              slave_ssh_port=0, cmd_options={}):
+        ''' create_options is a dict with geo-replication session
+            creation options:
+             - option: push-pem | no-verify
+             - force
+        '''
+        uri = '/volumes/' + volume_id
+
+        payload = {
+            'action': 'create',
+            'slavehost': slave_host,
+            'slavevolume': slave_volume
+        }
+
+        if slave_ssh_port != 0:
+            payload['slavesshport'] = slave_ssh_port
+
+        payload['actionparams'] = cmd_options
+
+        req = self._make_request('POST', uri, payload)
+        if req.status_code == requests.codes.ok:
+            return req.json()
+
+    def georeplication_config(self, volume_id, slave_host, slave_volume,
+                              cmd_options={}):
+        ''' cmd_options is a dict with geo-replication session
+            configuration options:
+             - sync-jobs
+             - log-level
+             - changelog-log-level
+             - ...
+        '''
+        uri = '/volumes/' + volume_id
+
+        payload = {
+            'action': 'config',
+            'slavehost': slave_host,
+            'slavevolume': slave_volume
+        }
+
+        payload['actionparams'] = cmd_options
+
+        req = self._make_request('POST', uri, payload)
+        if req.status_code == requests.codes.ok:
+            return req.json()
+
+    def georeplication_start(self, volume_id, slave_host, slave_volume):
+        uri = '/volumes/' + volume_id
+
+        payload = {
+            'action': 'start',
+            'slavehost': slave_host,
+            'slavevolume': slave_volume
+        }
+
+        req = self._make_request('POST', uri, payload)
+        if req.status_code == requests.codes.ok:
+            return req.json()
+
+    def georeplication_stop(self, volume_id, slave_host, slave_volume):
+        uri = '/volumes/' + volume_id
+
+        payload = {
+            'action': 'stop',
+            'slavehost': slave_host,
+            'slavevolume': slave_volume
+        }
+
+        req = self._make_request('POST', uri, payload)
+        if req.status_code == requests.codes.ok:
+            return req.json()
+
+    def georeplication_pause(self, volume_id, slave_host, slave_volume):
+        uri = '/volumes/' + volume_id
+
+        payload = {
+            'action': 'pause',
+            'slavehost': slave_host,
+            'slavevolume': slave_volume
+        }
+
+        req = self._make_request('POST', uri, payload)
+        if req.status_code == requests.codes.ok:
+            return req.json()
+
+    def georeplication_resume(self, volume_id, slave_host, slave_volume):
+        uri = '/volumes/' + volume_id
+
+        payload = {
+            'action': 'resume',
+            'slavehost': slave_host,
+            'slavevolume': slave_volume
+        }
+
+        req = self._make_request('POST', uri, payload)
+        if req.status_code == requests.codes.ok:
+            return req.json()
+
+    def georeplication_delete(self, volume_id, slave_host, slave_volume):
+        uri = '/volumes/' + volume_id
+
+        payload = {
+            'action': 'delete',
+            'slavehost': slave_host,
+            'slavevolume': slave_volume
+        }
+
+        req = self._make_request('POST', uri, payload)
+        if req.status_code == requests.codes.ok:
+            return req.json()
+
+    def georeplication_status(self):
+        uri = '/georeplication'
+
+        req = self._make_request('GET', uri)
+        if req.status_code == requests.codes.ok:
+            return req.json()
+
+    def georeplication_volume_status(self, volume_id):
+        uri = '/volumes/' + volume_id
+
+        req = self._make_request('GET', uri)
+        if req.status_code == requests.codes.ok:
+            return req.json()

--- a/client/cli/go/cmds/georep.go
+++ b/client/cli/go/cmds/georep.go
@@ -209,7 +209,7 @@ var geoReplicationConfigCommand = &cobra.Command{
 	Use:     "config",
 	Short:   "Configure session",
 	Long:    "Configure geo-replication session",
-	Example: "  $ heketi-cli volume georep --slave-host=blah --slave-volume=23423423 config sync-jobs 1 886a86a868711bef83001",
+	Example: "  $ heketi-cli volume georep --slave-host=blah --slave-volume=23423423 config --ssh-port 2222 --sync-jobs 1 886a86a868711bef83001",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		//ensure proper number of args
 		if len(cmd.Flags().Args()) < 1 {
@@ -266,7 +266,7 @@ var geoReplicationVolumeStatusCommand = &cobra.Command{
 	Use:     "status",
 	Short:   "Status of geo-replication session",
 	Long:    "Get the status of the geo-replication session for a specific volume",
-	Example: "  $ heketi-cli volume status 886a86a868711bef83001 886a86a868711bef83001",
+	Example: "  $ heketi-cli volume georep status 886a86a868711bef83001",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		//ensure proper number of args
 		if len(cmd.Flags().Args()) < 1 {

--- a/client/cli/go/cmds/georep.go
+++ b/client/cli/go/cmds/georep.go
@@ -1,3 +1,12 @@
+//
+// Copyright (c) 2015 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
 package cmds
 
 import (

--- a/client/cli/go/cmds/georep.go
+++ b/client/cli/go/cmds/georep.go
@@ -1,0 +1,372 @@
+package cmds
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	client "github.com/heketi/heketi/client/api/go-client"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/spf13/cobra"
+)
+
+var (
+	slaveHost, slaveVolume string
+	volumeID               string
+)
+
+func initGeoRepCommand() {
+	RootCmd.AddCommand(geoReplicationCommand)
+	geoReplicationCommand.AddCommand(geoReplicationStatusCommand)
+	volumeCommand.AddCommand(geoReplicationVolumeCommand)
+	geoReplicationVolumeCommand.AddCommand(
+		geoReplicationCreateCommand,
+		geoReplicationVolumeStatusCommand,
+		geoReplicationDeleteCommand,
+		geoReplicationConfigCommand,
+		geoReplicationStartCommand,
+		geoReplicationStopCommand,
+		geoReplicationPauseCommand,
+		geoReplicationResumeCommand,
+	)
+
+	// Flags
+	geoReplicationVolumeCommand.PersistentFlags().StringVar(&slaveHost, "slave-host", "", "The host of the slave volume")
+	geoReplicationVolumeCommand.PersistentFlags().StringVar(&slaveVolume, "slave-volume", "", "The volume name of the geo-replication target")
+	geoReplicationVolumeCommand.PersistentFlags().Bool("force", false, "\n\tForce creation")
+	geoReplicationCreateCommand.Flags().String("option", "no-verify", "\n\tSet option for create command")
+	geoReplicationCreateCommand.Flags().Int("ssh-port", 0, "\n\tThe gluster SSH port on the slave host")
+	geoReplicationConfigCommand.Flags().Int("sync-jobs", 0, "\n\tConfigure sync-jobs option for the specific volume")
+	geoReplicationConfigCommand.Flags().Int("timeout", 0, "\n\tConfigure timeout option for the specific volume")
+	geoReplicationConfigCommand.Flags().Int("ssh-port", 0, "\n\tConfigure ssh_port option for the specific volume")
+	geoReplicationConfigCommand.Flags().Bool("use-tarssh", false, "\n\tConfigure use-tarssh option for the specific volume")
+	geoReplicationConfigCommand.Flags().Bool("use-meta-volume", false, "\n\tConfigure use-meta-volume option for the specific volume")
+	geoReplicationConfigCommand.Flags().Bool("ignore-deletes", false, "\n\tConfigure ignore-deletes for the specific volume (to 1 if true)")
+	geoReplicationConfigCommand.Flags().String("log-level", "", "\n\tConfigure log-level for the specific volume")
+	geoReplicationConfigCommand.Flags().String("gluster-log-level", "", "\n\tConfigure gluster-log-level for the specific volume")
+	geoReplicationConfigCommand.Flags().String("changelog-log-level", "", "\n\tConfigure changelog-log-level for the specific volume")
+	geoReplicationConfigCommand.Flags().String("ssh-command", "", "\n\tConfigure ssh-command for the specific volume")
+	geoReplicationConfigCommand.Flags().String("rsync-command", "", "\n\tConfigure rsync-command for the specific volume")
+}
+
+var geoReplicationCommand = &cobra.Command{
+	Use:   "georep",
+	Short: "Heketi geo-replication Management",
+	Long:  "Heketi geo-replication Management",
+}
+
+var geoReplicationStatusCommand = &cobra.Command{
+	Use:   "status",
+	Short: "geo-replication status",
+	Long:  "Displays geo-replication status from the first node of the first cluster",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Create a client
+		heketi := client.NewClient(options.Url, options.User, options.Key)
+		// Get volume status
+		status, err := heketi.GeoReplicationStatus()
+		if err != nil {
+			return err
+		}
+
+		if options.Json {
+			data, err := json.Marshal(status)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(stdout, string(data))
+		} else {
+			fmt.Fprintf(stdout, "%v", status)
+		}
+		return nil
+	},
+}
+
+var geoReplicationVolumeCommand = &cobra.Command{
+	Use:   "georep",
+	Short: "Volume geo-replication Management",
+	Long:  "Heketi Volume geo-replication Management",
+}
+
+func actionFunc(actionName string) func(*cobra.Command, []string) error {
+	var action api.GeoReplicationActionType
+	var doneMsg string
+
+	switch actionName {
+	case "start":
+		action = api.GeoReplicationActionStart
+		doneMsg = "geo-replication session started\n"
+	case "stop":
+		action = api.GeoReplicationActionStop
+		doneMsg = "geo-replication session stopped\n"
+	case "pause":
+		action = api.GeoReplicationActionPause
+		doneMsg = "geo-replication session paused\n"
+	case "resume":
+		action = api.GeoReplicationActionResume
+		doneMsg = "geo-replication session resumed\n"
+	case "delete":
+		action = api.GeoReplicationActionDelete
+		doneMsg = "geo-replication session deleted\n"
+	default:
+		return nil
+	}
+
+	return func(cmd *cobra.Command, args []string) error {
+		//ensure proper number of args
+		if len(cmd.Flags().Args()) < 1 {
+			return errors.New("Volume id missing")
+		}
+
+		volumeID := cmd.Flags().Arg(0)
+		if volumeID == "" {
+			return errors.New("Volume id missing")
+		}
+
+		if slaveHost == "" {
+			return errors.New("Slave host is missing")
+		}
+
+		if slaveVolume == "" {
+			return errors.New("Slave volume is missing")
+		}
+
+		actionParams := make(map[string]string)
+		addActionParam("force", "bool", cmd, actionParams)
+
+		// Create a client
+		heketi := client.NewClient(options.Url, options.User, options.Key)
+		req := api.GeoReplicationRequest{
+			Action:       action,
+			ActionParams: actionParams,
+			GeoReplicationInfo: api.GeoReplicationInfo{
+				SlaveHost:   slaveHost,
+				SlaveVolume: slaveVolume,
+			},
+		}
+
+		// Execute geo-replication action
+		_, err := heketi.GeoReplicationPostAction(volumeID, &req)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(stdout, doneMsg)
+
+		return nil
+	}
+}
+
+var geoReplicationStartCommand = &cobra.Command{
+	Use:     "start",
+	Short:   "Start session",
+	Long:    "Start geo-replication session for given volume",
+	Example: "  $ heketi-cli volume georep --slave-host=blah --slave-volume=23423423 start 886a86a868711bef83001",
+	RunE:    actionFunc("start"),
+}
+
+var geoReplicationStopCommand = &cobra.Command{
+	Use:     "stop",
+	Short:   "Stop session",
+	Long:    "Stop geo-replication session for given volume",
+	Example: "  $ heketi-cli volume georep --slave-host=blah --slave-volume=23423423 stop 886a86a868711bef83001",
+	RunE:    actionFunc("stop"),
+}
+
+var geoReplicationPauseCommand = &cobra.Command{
+	Use:     "pause",
+	Short:   "Pause session",
+	Long:    "Pause geo-replication session for given volume",
+	Example: "  $ heketi-cli volume georep --slave-host=blah --slave-volume=23423423 pause 886a86a868711bef83001",
+	RunE:    actionFunc("pause"),
+}
+
+var geoReplicationResumeCommand = &cobra.Command{
+	Use:     "resume",
+	Short:   "Resume session",
+	Long:    "Resume geo-replication session for given volume",
+	Example: "  $ heketi-cli volume georep --slave-host=blah --slave-volume=23423423 resume 886a86a868711bef83001",
+	RunE:    actionFunc("resume"),
+}
+
+var geoReplicationDeleteCommand = &cobra.Command{
+	Use:     "delete",
+	Short:   "Delete a geo-replication session",
+	Long:    "Delete the geo-replication session for a specific volume",
+	Example: "  $ heketi-cli volume georep --slave-host=blah --slave-volume=23423423 delete 886a86a868711bef83001",
+	RunE:    actionFunc("delete"),
+}
+
+var geoReplicationConfigCommand = &cobra.Command{
+	Use:     "config",
+	Short:   "Configure session",
+	Long:    "Configure geo-replication session",
+	Example: "  $ heketi-cli volume georep --slave-host=blah --slave-volume=23423423 config sync-jobs 1 886a86a868711bef83001",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		//ensure proper number of args
+		if len(cmd.Flags().Args()) < 1 {
+			return errors.New("Volume id missing")
+		}
+
+		volumeID := cmd.Flags().Arg(0)
+		if volumeID == "" {
+			return errors.New("Volume id missing")
+		}
+
+		if slaveHost == "" {
+			return errors.New("Slave host is missing")
+		}
+
+		if slaveVolume == "" {
+			return errors.New("Slave volume is missing")
+		}
+
+		actionParams := make(map[string]string)
+		addActionParam("timeout", "int", cmd, actionParams)
+		addActionParam("ssh-port", "int", cmd, actionParams) // due to gluster CLI inconsistency, this is translated to ssh_port serverside
+		addActionParam("sync-jobs", "int", cmd, actionParams)
+		addActionParam("use-tarssh", "bool", cmd, actionParams)
+		addActionParam("use-meta-volume", "bool", cmd, actionParams)
+		addActionParam("ignore-deletes", "bool", cmd, actionParams)
+		addActionParam("log-level", "string", cmd, actionParams)
+		addActionParam("gluster-log-level", "string", cmd, actionParams)
+		addActionParam("changelog-log-level", "string", cmd, actionParams)
+		addActionParam("ssh-command", "string", cmd, actionParams)
+		addActionParam("rsync-command", "string", cmd, actionParams)
+
+		// Create a client
+		heketi := client.NewClient(options.Url, options.User, options.Key)
+		req := api.GeoReplicationRequest{
+			Action:       api.GeoReplicationActionConfig,
+			ActionParams: actionParams,
+			GeoReplicationInfo: api.GeoReplicationInfo{
+				SlaveHost:   slaveHost,
+				SlaveVolume: slaveVolume,
+			},
+		}
+
+		// Send geo-replication config command
+		if _, err := heketi.GeoReplicationPostAction(volumeID, &req); err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var geoReplicationVolumeStatusCommand = &cobra.Command{
+	Use:     "status",
+	Short:   "Status of geo-replication session",
+	Long:    "Get the status of the geo-replication session for a specific volume",
+	Example: "  $ heketi-cli volume status 886a86a868711bef83001 886a86a868711bef83001",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		//ensure proper number of args
+		if len(cmd.Flags().Args()) < 1 {
+			return errors.New("Volume id missing")
+		}
+
+		volumeID := cmd.Flags().Arg(0)
+		if volumeID == "" {
+			return errors.New("Volume id missing")
+		}
+
+		// Create a client
+		heketi := client.NewClient(options.Url, options.User, options.Key)
+		// Get volume status
+		status, err := heketi.GeoReplicationVolumeStatus(volumeID)
+		if err != nil {
+			return err
+		}
+
+		if options.Json {
+			data, err := json.Marshal(status)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(stdout, string(data))
+		} else {
+			fmt.Fprintf(stdout, "%v", status)
+		}
+		return nil
+	},
+}
+
+func addActionParam(name, paramType string, cmd *cobra.Command, params map[string]string) {
+	switch paramType {
+	case "string":
+		if value, err := cmd.Flags().GetString(name); err == nil && value != "" {
+			params[name] = value
+		}
+	case "bool":
+		if value, err := cmd.Flags().GetBool(name); err == nil && value {
+			params[name] = fmt.Sprintf("%t", value)
+		}
+	case "int":
+		if value, err := cmd.Flags().GetInt(name); err == nil && value != 0 {
+			params[name] = fmt.Sprintf("%d", value)
+		}
+	}
+}
+
+var geoReplicationCreateCommand = &cobra.Command{
+	Use:     "create",
+	Short:   "Create session",
+	Long:    "Create geo-replication session",
+	Example: "  $ heketi-cli volume georep --slave-host=blah --slave-volume=23423423 create 886a86a868711bef83001",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		//ensure proper number of args
+		if len(cmd.Flags().Args()) < 1 {
+			return errors.New("Volume id missing")
+		}
+
+		volumeID := cmd.Flags().Arg(0)
+		if volumeID == "" {
+			return errors.New("Volume id missing")
+		}
+
+		if slaveHost == "" {
+			return errors.New("Slave host is missing")
+		}
+
+		if slaveVolume == "" {
+			return errors.New("Slave volume is missing")
+		}
+
+		actionParams := make(map[string]string)
+		addActionParam("force", "bool", cmd, actionParams)
+		addActionParam("option", "string", cmd, actionParams)
+
+		sshPortFlag, err := cmd.Flags().GetInt("ssh-port")
+		if err != nil {
+			return err
+		}
+
+		// Create a client
+		heketi := client.NewClient(options.Url, options.User, options.Key)
+		req := api.GeoReplicationRequest{
+			Action:       api.GeoReplicationActionCreate,
+			ActionParams: actionParams,
+			GeoReplicationInfo: api.GeoReplicationInfo{
+				SlaveHost:    slaveHost,
+				SlaveVolume:  slaveVolume,
+				SlaveSSHPort: sshPortFlag,
+			},
+		}
+
+		// Get volume status
+		status, err := heketi.GeoReplicationPostAction(volumeID, &req)
+		if err != nil {
+			return err
+		}
+
+		if options.Json {
+			data, err := json.Marshal(status)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(stdout, string(data))
+		} else {
+			fmt.Fprintf(stdout, "%v", status)
+		}
+		return nil
+	},
+}

--- a/client/cli/go/cmds/volume.go
+++ b/client/cli/go/cmds/volume.go
@@ -113,28 +113,28 @@ var volumeCreateCommand = &cobra.Command{
 	Short: "Create a GlusterFS volume",
 	Long:  "Create a GlusterFS volume",
 	Example: `  * Create a 100GB replica 3 volume:
-	$ heketi-cli volume create --size=100
-	
-	* Create a 100GB replica 3 volume specifying two specific clusters:
-	$ heketi-cli volume create --size=100 \
-	--clusters=0995098e1284ddccb46c7752d142c832,60d46d518074b13a04ce1022c8c7193c
-	
-	* Create a 100GB replica 2 volume with 50GB of snapshot storage:
-	$ heketi-cli volume create --size=100 --snapshot-factor=1.5 --replica=2
-	
-	* Create a 100GB distributed volume
-	$ heketi-cli volume create --size=100 --durability=none
-	
-	* Create a 100GB erasure coded 4+2 volume with 25GB snapshot storage:
-	$ heketi-cli volume create --size=100 --durability=disperse --snapshot-factor=1.25
-	
-	* Create a 100GB erasure coded 8+3 volume with 25GB snapshot storage:
-	$ heketi-cli volume create --size=100 --durability=disperse --snapshot-factor=1.25 \
-	--disperse-data=8 --redundancy=3
-	
-	* Create a 100GB distributed volume which supports performance related volume options.
-	$ heketi-cli volume create --size=100 --durability=none --gluster-volume-options="performance.rda-cache-limit 10MB","performance.nl-cache-positive-entry no"
-	`,
+      $ heketi-cli volume create --size=100
+
+  * Create a 100GB replica 3 volume specifying two specific clusters:
+      $ heketi-cli volume create --size=100 \
+        --clusters=0995098e1284ddccb46c7752d142c832,60d46d518074b13a04ce1022c8c7193c
+
+  * Create a 100GB replica 2 volume with 50GB of snapshot storage:
+      $ heketi-cli volume create --size=100 --snapshot-factor=1.5 --replica=2
+
+  * Create a 100GB distributed volume
+      $ heketi-cli volume create --size=100 --durability=none
+
+  * Create a 100GB erasure coded 4+2 volume with 25GB snapshot storage:
+      $ heketi-cli volume create --size=100 --durability=disperse --snapshot-factor=1.25
+
+  * Create a 100GB erasure coded 8+3 volume with 25GB snapshot storage:
+      $ heketi-cli volume create --size=100 --durability=disperse --snapshot-factor=1.25 \
+        --disperse-data=8 --redundancy=3
+
+  * Create a 100GB distributed volume which supports performance related volume options.
+      $ heketi-cli volume create --size=100 --durability=none --gluster-volume-options="performance.rda-cache-limit 10MB","performance.nl-cache-positive-entry no"
+`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Check volume size
 		if size == -1 {
@@ -264,7 +264,7 @@ var volumeExpandCommand = &cobra.Command{
 	Long:  "Expand a volume",
 	Example: `  * Add 10GB to a volume
     $ heketi-cli volume expand --volume=60d46d518074b13a04ce1022c8c7193c --expand-size=10
-	`,
+`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Check volume size
 		if expandSize == -1 {

--- a/client/cli/go/cmds/volume.go
+++ b/client/cli/go/cmds/volume.go
@@ -47,6 +47,7 @@ func init() {
 	volumeCommand.AddCommand(volumeExpandCommand)
 	volumeCommand.AddCommand(volumeInfoCommand)
 	volumeCommand.AddCommand(volumeListCommand)
+	initGeoRepCommand()
 
 	volumeCreateCommand.Flags().IntVar(&size, "size", -1,
 		"\n\tSize of volume in GB")
@@ -112,28 +113,28 @@ var volumeCreateCommand = &cobra.Command{
 	Short: "Create a GlusterFS volume",
 	Long:  "Create a GlusterFS volume",
 	Example: `  * Create a 100GB replica 3 volume:
-      $ heketi-cli volume create --size=100
-
-  * Create a 100GB replica 3 volume specifying two specific clusters:
-      $ heketi-cli volume create --size=100 \
-        --clusters=0995098e1284ddccb46c7752d142c832,60d46d518074b13a04ce1022c8c7193c
-
-  * Create a 100GB replica 2 volume with 50GB of snapshot storage:
-      $ heketi-cli volume create --size=100 --snapshot-factor=1.5 --replica=2
-
-  * Create a 100GB distributed volume
-      $ heketi-cli volume create --size=100 --durability=none
-
-  * Create a 100GB erasure coded 4+2 volume with 25GB snapshot storage:
-      $ heketi-cli volume create --size=100 --durability=disperse --snapshot-factor=1.25
-
-  * Create a 100GB erasure coded 8+3 volume with 25GB snapshot storage:
-      $ heketi-cli volume create --size=100 --durability=disperse --snapshot-factor=1.25 \
-        --disperse-data=8 --redundancy=3
-
-  * Create a 100GB distributed volume which supports performance related volume options.
-      $ heketi-cli volume create --size=100 --durability=none --gluster-volume-options="performance.rda-cache-limit 10MB","performance.nl-cache-positive-entry no"
-`,
+	$ heketi-cli volume create --size=100
+	
+	* Create a 100GB replica 3 volume specifying two specific clusters:
+	$ heketi-cli volume create --size=100 \
+	--clusters=0995098e1284ddccb46c7752d142c832,60d46d518074b13a04ce1022c8c7193c
+	
+	* Create a 100GB replica 2 volume with 50GB of snapshot storage:
+	$ heketi-cli volume create --size=100 --snapshot-factor=1.5 --replica=2
+	
+	* Create a 100GB distributed volume
+	$ heketi-cli volume create --size=100 --durability=none
+	
+	* Create a 100GB erasure coded 4+2 volume with 25GB snapshot storage:
+	$ heketi-cli volume create --size=100 --durability=disperse --snapshot-factor=1.25
+	
+	* Create a 100GB erasure coded 8+3 volume with 25GB snapshot storage:
+	$ heketi-cli volume create --size=100 --durability=disperse --snapshot-factor=1.25 \
+	--disperse-data=8 --redundancy=3
+	
+	* Create a 100GB distributed volume which supports performance related volume options.
+	$ heketi-cli volume create --size=100 --durability=none --gluster-volume-options="performance.rda-cache-limit 10MB","performance.nl-cache-positive-entry no"
+	`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Check volume size
 		if size == -1 {
@@ -263,7 +264,7 @@ var volumeExpandCommand = &cobra.Command{
 	Long:  "Expand a volume",
 	Example: `  * Add 10GB to a volume
     $ heketi-cli volume expand --volume=60d46d518074b13a04ce1022c8c7193c --expand-size=10
-`,
+	`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Check volume size
 		if expandSize == -1 {

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -9,9 +9,7 @@
 
 package executors
 
-import (
-	"encoding/xml"
-)
+import "encoding/xml"
 
 type Executor interface {
 	GlusterdCheck(host string) error

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -9,7 +9,9 @@
 
 package executors
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type Executor interface {
 	GlusterdCheck(host string) error
@@ -27,8 +29,59 @@ type Executor interface {
 	VolumeExpand(host string, volume *VolumeRequest) (*Volume, error)
 	VolumeReplaceBrick(host string, volume string, oldBrick *BrickInfo, newBrick *BrickInfo) error
 	VolumeInfo(host string, volume string) (*Volume, error)
+	GeoReplicationCreate(host, volume string, geoRep *GeoReplicationRequest) error
+	GeoReplicationConfig(host, volume string, geoRep *GeoReplicationRequest) error
+	GeoReplicationAction(host, volume, action string, geoRep *GeoReplicationRequest) error
+	GeoReplicationVolumeStatus(host, volume string) (*GeoReplicationStatus, error)
+	GeoReplicationStatus(host string) (*GeoReplicationStatus, error)
 	HealInfo(host string, volume string) (*HealInfo, error)
 	SetLogLevel(level string)
+}
+
+type GeoReplicationStatus struct {
+	XMLName xml.Name               `xml:"geoRep"`
+	Volume  []GeoReplicationVolume `xml:"volume"`
+}
+type GeoReplicationVolume struct {
+	XMLName    xml.Name               `xml:"volume"`
+	VolumeName string                 `xml:"name"`
+	Sessions   GeoReplicationSessions `xml:"sessions"`
+}
+
+type GeoReplicationSessions struct {
+	XMLName     xml.Name                `xml:"sessions"`
+	SessionList []GeoReplicationSession `xml:"session"`
+}
+
+type GeoReplicationSession struct {
+	XMLName      xml.Name             `xml:"session"`
+	SessionSlave string               `xml:"session_slave"`
+	Pairs        []GeoReplicationPair `xml:"pair"`
+}
+type GeoReplicationPair struct {
+	MasterNode               string `xml:"master_node"`
+	MasterBrick              string `xml:"master_brick"`
+	SlaveUser                string `xml:"slave_user"`
+	Slave                    string `xml:"slave"`
+	SlaveNode                string `xml:"slave_node"`
+	Status                   string `xml:"status"`
+	CrawlStatus              string `xml:"crawl_status"`
+	Entry                    string `xml:"entry"`
+	Data                     string `xml:"data"`
+	Meta                     string `xml:"meta"`
+	Failures                 string `xml:"failures"`
+	CheckpointCompleted      string `xml:"checkpoint_completed"`
+	MasterNodeUUID           string `xml:"master_node_uuid"`
+	LastSynced               string `xml:"last_string"`
+	CheckpointTime           string `xml:"checkpoint_time"`
+	CheckpointCompletionTime string `xml:"checkpoint_completion_time"`
+}
+
+type GeoReplicationRequest struct {
+	ActionParams map[string]string
+	SlaveHost    string
+	SlaveVolume  string
+	SlaveSSHPort int
 }
 
 // Enumerate durability types

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -15,21 +15,26 @@ import (
 
 type MockExecutor struct {
 	// These functions can be overwritten for testing
-	MockGlusterdCheck      func(host string) error
-	MockPeerProbe          func(exec_host, newnode string) error
-	MockPeerDetach         func(exec_host, newnode string) error
-	MockDeviceSetup        func(host, device, vgid string) (*executors.DeviceInfo, error)
-	MockDeviceTeardown     func(host, device, vgid string) error
-	MockBrickCreate        func(host string, brick *executors.BrickRequest) (*executors.BrickInfo, error)
-	MockBrickDestroy       func(host string, brick *executors.BrickRequest) error
-	MockBrickDestroyCheck  func(host string, brick *executors.BrickRequest) error
-	MockVolumeCreate       func(host string, volume *executors.VolumeRequest) (*executors.Volume, error)
-	MockVolumeExpand       func(host string, volume *executors.VolumeRequest) (*executors.Volume, error)
-	MockVolumeDestroy      func(host string, volume string) error
-	MockVolumeDestroyCheck func(host, volume string) error
-	MockVolumeReplaceBrick func(host string, volume string, oldBrick *executors.BrickInfo, newBrick *executors.BrickInfo) error
-	MockVolumeInfo         func(host string, volume string) (*executors.Volume, error)
-	MockHealInfo           func(host string, volume string) (*executors.HealInfo, error)
+	MockGlusterdCheck              func(host string) error
+	MockPeerProbe                  func(exec_host, newnode string) error
+	MockPeerDetach                 func(exec_host, newnode string) error
+	MockDeviceSetup                func(host, device, vgid string) (*executors.DeviceInfo, error)
+	MockDeviceTeardown             func(host, device, vgid string) error
+	MockBrickCreate                func(host string, brick *executors.BrickRequest) (*executors.BrickInfo, error)
+	MockBrickDestroy               func(host string, brick *executors.BrickRequest) error
+	MockBrickDestroyCheck          func(host string, brick *executors.BrickRequest) error
+	MockVolumeCreate               func(host string, volume *executors.VolumeRequest) (*executors.Volume, error)
+	MockVolumeExpand               func(host string, volume *executors.VolumeRequest) (*executors.Volume, error)
+	MockVolumeDestroy              func(host string, volume string) error
+	MockVolumeDestroyCheck         func(host, volume string) error
+	MockVolumeReplaceBrick         func(host string, volume string, oldBrick *executors.BrickInfo, newBrick *executors.BrickInfo) error
+	MockVolumeInfo                 func(host string, volume string) (*executors.Volume, error)
+	MockGeoReplicationCreate       func(host string, volume string, geoRep *executors.GeoReplicationRequest) error
+	MockGeoReplicationConfig       func(host string, volume string, geoRep *executors.GeoReplicationRequest) error
+	MockGeoReplicationAction       func(host string, volume string, action string, geoRep *executors.GeoReplicationRequest) error
+	MockGeoReplicationVolumeStatus func(host string, volume string) (*executors.GeoReplicationStatus, error)
+	MockGeoReplicationStatus       func(host string) (*executors.GeoReplicationStatus, error)
+	MockHealInfo                   func(host string, volume string) (*executors.HealInfo, error)
 }
 
 func NewMockExecutor() (*MockExecutor, error) {
@@ -114,6 +119,26 @@ func NewMockExecutor() (*MockExecutor, error) {
 		return &executors.HealInfo{}, nil
 	}
 
+	m.MockGeoReplicationCreate = func(host, volume string, geoRep *executors.GeoReplicationRequest) error {
+		return nil
+	}
+
+	m.MockGeoReplicationConfig = func(host, volume string, geoRep *executors.GeoReplicationRequest) error {
+		return nil
+	}
+
+	m.MockGeoReplicationAction = func(host, volume, action string, geoRep *executors.GeoReplicationRequest) error {
+		return nil
+	}
+
+	m.MockGeoReplicationVolumeStatus = func(host, volume string) (*executors.GeoReplicationStatus, error) {
+		return nil, nil
+	}
+
+	m.MockGeoReplicationStatus = func(host string) (*executors.GeoReplicationStatus, error) {
+		return nil, nil
+	}
+
 	return m, nil
 }
 
@@ -183,4 +208,24 @@ func (m *MockExecutor) VolumeInfo(host string, volume string) (*executors.Volume
 
 func (m *MockExecutor) HealInfo(host string, volume string) (*executors.HealInfo, error) {
 	return m.MockHealInfo(host, volume)
+}
+
+func (m *MockExecutor) GeoReplicationCreate(host, volume string, geoRep *executors.GeoReplicationRequest) error {
+	return m.MockGeoReplicationCreate(host, volume, geoRep)
+}
+
+func (m *MockExecutor) GeoReplicationConfig(host, volume string, geoRep *executors.GeoReplicationRequest) error {
+	return m.MockGeoReplicationConfig(host, volume, geoRep)
+}
+
+func (m *MockExecutor) GeoReplicationAction(host, volume, action string, geoRep *executors.GeoReplicationRequest) error {
+	return m.MockGeoReplicationAction(host, volume, action, geoRep)
+}
+
+func (m *MockExecutor) GeoReplicationVolumeStatus(host, volume string) (*executors.GeoReplicationStatus, error) {
+	return m.MockGeoReplicationVolumeStatus(host, volume)
+}
+
+func (m *MockExecutor) GeoReplicationStatus(host string) (*executors.GeoReplicationStatus, error) {
+	return m.MockGeoReplicationStatus(host)
 }

--- a/executors/sshexec/georep.go
+++ b/executors/sshexec/georep.go
@@ -1,3 +1,12 @@
+//
+// Copyright (c) 2015 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
 package sshexec
 
 import (

--- a/executors/sshexec/georep.go
+++ b/executors/sshexec/georep.go
@@ -1,0 +1,191 @@
+package sshexec
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strconv"
+
+	"github.com/heketi/heketi/executors"
+	"github.com/lpabon/godbc"
+)
+
+// GeoReplicationCreate creates a geo-rep session for the given volume
+func (s *SshExecutor) GeoReplicationCreate(host, volume string, geoRep *executors.GeoReplicationRequest) error {
+	logger.Debug("In GeoReplicationCreate")
+	logger.Debug("actionParams: %+v", geoRep.ActionParams)
+
+	godbc.Require(host != "")
+	godbc.Require(volume != "")
+	godbc.Require(geoRep.SlaveHost != "")
+	godbc.Require(geoRep.SlaveVolume != "")
+	_, optionOK := geoRep.ActionParams["option"]
+	godbc.Require(optionOK && (geoRep.ActionParams["option"] == "push-pem" || geoRep.ActionParams["option"] == "no-verify"))
+
+	sshPort := " "
+	if geoRep.SlaveSSHPort != 0 {
+		sshPort = fmt.Sprintf(" ssh-port %d ", geoRep.SlaveSSHPort)
+	}
+	cmd := fmt.Sprintf("gluster --mode=script volume geo-replication %s %s::%s create%s%s", volume, geoRep.SlaveHost, geoRep.SlaveVolume, sshPort, geoRep.ActionParams["option"])
+
+	if force, ok := geoRep.ActionParams["force"]; ok && force == "true" {
+		cmd = fmt.Sprintf("%s %s", cmd, force)
+	}
+
+	commands := []string{cmd}
+	if _, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 10); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GeoReplicationAction executes the given geo-replication action for the given volume
+func (s *SshExecutor) GeoReplicationAction(host, volume, action string, geoRep *executors.GeoReplicationRequest) error {
+	logger.Debug("In GeoReplicationAction: %s", action)
+
+	godbc.Require(host != "")
+	godbc.Require(volume != "")
+	godbc.Require(geoRep.SlaveHost != "")
+	godbc.Require(geoRep.SlaveVolume != "")
+
+	cmd := fmt.Sprintf("gluster --mode=script volume geo-replication %s %s::%s %s", volume, geoRep.SlaveHost, geoRep.SlaveVolume, action)
+
+	if force, ok := geoRep.ActionParams["force"]; ok && force == "true" {
+		cmd = fmt.Sprintf("%s %s", cmd, force)
+	}
+
+	commands := []string{cmd}
+	if _, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 10); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GeoReplicationStatus returns the geo-replication status
+func (s *SshExecutor) GeoReplicationStatus(host string) (*executors.GeoReplicationStatus, error) {
+	logger.Debug("In GeoReplicationStatus")
+
+	godbc.Require(host != "")
+
+	type CliOutput struct {
+		OpRet        int                            `xml:"opRet"`
+		OpErrno      int                            `xml:"opErrno"`
+		OpErrStr     string                         `xml:"opErrstr"`
+		GeoRepStatus executors.GeoReplicationStatus `xml:"geoRep"`
+	}
+
+	commands := []string{"gluster --mode=script volume geo-replication status --xml"}
+
+	var output []string
+	var err error
+	if output, err = s.RemoteExecutor.RemoteCommandExecute(host, commands, 10); err != nil {
+		return nil, err
+	}
+
+	var geoRepStatus CliOutput
+
+	if err := xml.Unmarshal([]byte(output[0]), &geoRepStatus); err != nil {
+		return nil, fmt.Errorf("Unable to determine geo-replication status on host %s: %v", host, err)
+	}
+
+	return &geoRepStatus.GeoRepStatus, nil
+}
+
+// GeoReplicationVolumeStatus returns the geo-replication status of a specific volume
+func (s *SshExecutor) GeoReplicationVolumeStatus(host, volume string) (*executors.GeoReplicationStatus, error) {
+	logger.Debug("In GeoReplicationVolumeStatus")
+
+	godbc.Require(host != "")
+	godbc.Require(volume != "")
+
+	type CliOutput struct {
+		OpRet        int                            `xml:"opRet"`
+		OpErrno      int                            `xml:"opErrno"`
+		OpErrStr     string                         `xml:"opErrstr"`
+		GeoRepStatus executors.GeoReplicationStatus `xml:"geoRep"`
+	}
+
+	cmd := fmt.Sprintf("gluster --mode=script volume geo-replication %s status --xml", volume)
+	commands := []string{cmd}
+
+	var output []string
+	var err error
+	if output, err = s.RemoteExecutor.RemoteCommandExecute(host, commands, 10); err != nil {
+		return nil, err
+	}
+
+	var geoRepStatus CliOutput
+
+	if err := xml.Unmarshal([]byte(output[0]), &geoRepStatus); err != nil {
+		return nil, fmt.Errorf("Unable to determine geo-replication status for volume %v: %v", volume, err)
+	}
+
+	return &geoRepStatus.GeoRepStatus, nil
+}
+
+// GeoReplicationConfig configures the geo-replication session for the given volume
+func (s *SshExecutor) GeoReplicationConfig(host, volume string, geoRep *executors.GeoReplicationRequest) error {
+	logger.Debug("In GeoReplicationConfig")
+
+	godbc.Require(host != "")
+	godbc.Require(volume != "")
+	godbc.Require(geoRep.SlaveHost != "")
+	godbc.Require(geoRep.SlaveVolume != "")
+
+	commands := s.createConfigCommands(volume, geoRep)
+
+	if _, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 10); err != nil {
+		logger.LogError("Invalid configuration for volume georeplication %s", volume)
+		return err
+	}
+	return nil
+}
+
+func (s *SshExecutor) createConfigCommands(volume string, geoRep *executors.GeoReplicationRequest) []string {
+	commands := []string{}
+
+	cmdTpl := "gluster --mode=script volume geo-replication %s %s::%s config %s %s"
+	for param, value := range geoRep.ActionParams {
+		switch param {
+		// String parameters
+		case "log-level", "gluster-log-level", "changelog-log-level", "ssh-command", "rsync-command":
+			commands = append(commands, fmt.Sprintf(cmdTpl, volume, geoRep.SlaveHost, geoRep.SlaveVolume, param, value))
+		// Boolean parameters
+		case "use-tarssh", "use-meta-volume":
+			if value != "false" && value != "true" {
+				logger.LogError("Invalid value %v for config option %s", value, param)
+				continue
+			}
+			commands = append(commands, fmt.Sprintf(cmdTpl, volume, geoRep.SlaveHost, geoRep.SlaveVolume, param, value))
+		case "ignore-deletes":
+			if value != "false" && value != "true" {
+				logger.LogError("Invalid value %v for config option %s", value, param)
+				continue
+			}
+
+			// set to 1 if explicitly set to true, skip otherwise
+			if value == "true" {
+				commands = append(commands, fmt.Sprintf(cmdTpl, volume, geoRep.SlaveHost, geoRep.SlaveVolume, param, "1"))
+			}
+		// Integer parameters
+		case "timeout", "sync-jobs":
+			if _, err := strconv.Atoi(value); err != nil {
+				logger.LogError("Invalid value %v for config option %s", value, param)
+				continue
+			}
+			commands = append(commands, fmt.Sprintf(cmdTpl, volume, geoRep.SlaveHost, geoRep.SlaveVolume, param, value))
+		case "ssh-port":
+			// due to gluster cli client inconsistency, set the parameter to ssh_port
+			param = "ssh_port"
+			if _, err := strconv.Atoi(value); err != nil {
+				logger.LogError("Invalid value %v for config option %s", value, param)
+				continue
+			}
+			commands = append(commands, fmt.Sprintf(cmdTpl, volume, geoRep.SlaveHost, geoRep.SlaveVolume, param, value))
+		}
+
+	}
+
+	return commands
+}

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -186,6 +186,69 @@ type VolumeExpandRequest struct {
 	Size int `json:"expand_size"`
 }
 
+// GeoReplicationActionType defines the different actions relevant to geo-rep sessions, except for delete
+type GeoReplicationActionType string
+
+// Supported GeoReplication action types
+const (
+	GeoReplicationActionCreate GeoReplicationActionType = "create"
+	GeoReplicationActionConfig GeoReplicationActionType = "config"
+	GeoReplicationActionStart  GeoReplicationActionType = "start"
+	GeoReplicationActionStop   GeoReplicationActionType = "stop"
+	GeoReplicationActionStatus GeoReplicationActionType = "status"
+	GeoReplicationActionPause  GeoReplicationActionType = "pause"
+	GeoReplicationActionResume GeoReplicationActionType = "resume"
+	GeoReplicationActionDelete GeoReplicationActionType = "delete"
+)
+
+type GeoReplicationStatus struct {
+	Volumes []GeoReplicationVolume `json:"volume"`
+}
+type GeoReplicationVolume struct {
+	VolumeName string                 `json:"name"`
+	Sessions   GeoReplicationSessions `json:"sessions"`
+}
+
+type GeoReplicationSessions struct {
+	SessionList []GeoReplicationSession `json:"session"`
+}
+
+type GeoReplicationSession struct {
+	SessionSlave string               `json:"session_slave"`
+	Pairs        []GeoReplicationPair `json:"pair"`
+}
+type GeoReplicationPair struct {
+	MasterNode               string `json:"master_node"`
+	MasterBrick              string `json:"master_brick"`
+	SlaveUser                string `json:"slave_user"`
+	Slave                    string `json:"slave"`
+	SlaveNode                string `json:"slave_node"`
+	Status                   string `json:"status"`
+	CrawlStatus              string `json:"crawl_status"`
+	Entry                    string `json:"entry"`
+	Data                     string `json:"data"`
+	Meta                     string `json:"meta"`
+	Failures                 string `json:"failures"`
+	CheckpointCompleted      string `json:"checkpoint_completed"`
+	MasterNodeUUID           string `json:"master_node_uuid"`
+	LastSynced               string `json:"last_string"`
+	CheckpointTime           string `json:"checkpoint_time"`
+	CheckpointCompletionTime string `json:"checkpoint_completion_time"`
+}
+
+type GeoReplicationInfo struct {
+	SlaveHost    string `json:"slavehost"`
+	SlaveVolume  string `json:"slavevolume"`
+	SlaveSSHPort int    `json:"slavesshport"`
+}
+
+//VolumeGeoReplicationRequest is the body for a GeoReplication POST request
+type GeoReplicationRequest struct {
+	Action       GeoReplicationActionType `json:"action"`
+	ActionParams map[string]string        `json:"actionparams,omitempty"`
+	GeoReplicationInfo
+}
+
 // Constructors
 
 func NewVolumeInfoResponse() *VolumeInfoResponse {
@@ -195,6 +258,55 @@ func NewVolumeInfoResponse() *VolumeInfoResponse {
 	info.Bricks = make([]BrickInfo, 0)
 
 	return info
+}
+
+func (v *GeoReplicationStatus) String() string {
+	var s string
+	for _, vol := range v.Volumes {
+		s = fmt.Sprintf("Master Volume Name: %v\n"+
+			"Session slave: %v\n",
+			vol.VolumeName,
+			vol.Sessions.SessionList[0].SessionSlave)
+
+		s += "Pairs:\n"
+		for _, p := range vol.Sessions.SessionList[0].Pairs {
+			s += fmt.Sprintf("\tMaster Node: %s\n"+
+				"\tMaster Brick: %s\n"+
+				"\tSlave User: %s\n"+
+				"\tSlave: %s\n"+
+				"\tSlave Node: %s\n"+
+				"\tStatus: %s\n"+
+				"\tCrawl Status: %s\n"+
+				"\tEntry: %s\n"+
+				"\tData: %s\n"+
+				"\tMeta: %s\n"+
+				"\tFailures: %s\n"+
+				"\tCheckpoint Completed: %s\n"+
+				"\tMaster Node UUID: %s\n"+
+				"\tLast Synced: %s\n"+
+				"\tCheckpoint Time: %s\n"+
+				"\tCheckpoint Completion Time: %s\n\n",
+				p.MasterNode,
+				p.MasterBrick,
+				p.SlaveUser,
+				p.Slave,
+				p.SlaveNode,
+				p.Status,
+				p.CrawlStatus,
+				p.Entry,
+				p.Data,
+				p.Meta,
+				p.Failures,
+				p.CheckpointCompleted,
+				p.MasterNodeUUID,
+				p.LastSynced,
+				p.CheckpointTime,
+				p.CheckpointCompletionTime,
+			)
+		}
+	}
+
+	return s
 }
 
 // String functions


### PR DESCRIPTION
With these changes, heketi can support geo-replication features of gluster in their basic form. The intention was to stay close to the glusterfs syntax as described [here](http://gluster.readthedocs.io/en/latest/Administrator%20Guide/Geo%20Replication/). At this point, nothing is stored in the database.

Relevant changes:

* executors extended to support the various geo-replication commands
* endpoints defined on the server-side
* heketi-cli commands added

examples of heketi-cli commands:

```
$ heketi-cli georep status #returns the status information from the first node of the first cluster
$ heketi-cli volume georep --slave-host=blah --slave-volume=23423423 create 886a86a868711bef83001
$ heketi-cli volume georep --slave-host=blah --slave-volume=23423423 config 886a86a868711bef83001 --sync-jobs 2 --ssh-port 2222
$ heketi-cli volume georep --slave-host=blah --slave-volume=23423423 start 886a86a868711bef83001
$ heketi-cli volume georep status 886a86a868711bef83001
$ heketi-cli volume georep --slave-host=blah --slave-volume=23423423 stop 886a86a868711bef83001
$ heketi-cli volume georep --slave-host=blah --slave-volume=23423423 delete 886a86a868711bef83001
```

 