### PR TITLE
git: Add .envrc ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,4 @@ debug
 .coverage
 .tox
 *.log
-
+.envrc


### PR DESCRIPTION
This is a useful tool to have in your project path and it is almost
certainly different per-user. Let's ignore it in git.