### PR TITLE
Fix crosscompile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ script:
 - make
 - if [[ -z "$COVERAGE" ]]; then make test ; fi
 - if [[ -n "$COVERAGE" ]]; then bash .travis-coverage; fi
+- make release
 - cd client/api/python
 - ./unittests.sh
 - tox -e pep8

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,14 @@ VER := $(shell git describe --match='v[0-9].[0-9].[0-9]')
 TAG := $(shell git tag --points-at HEAD --sort=creatordate 'v[0-9].[0-9].[0-9]' | tail -n1)
 GOARCH := $(shell go env GOARCH)
 GOOS := $(shell go env GOOS)
+GOHOSTARCH := $(shell go env GOHOSTARCH)
+GOHOSTOS := $(shell go env GOHOSTOS)
+GOBUILDFLAGS :=
+ifeq ($(GOOS),$(GOHOSTOS))
+ifeq ($(GOARCH),$(GOHOSTARCH))
+  GOBUILDFLAGS :=-i
+endif
+endif
 GLIDEPATH := $(shell command -v glide 2> /dev/null)
 DIR=.
 
@@ -59,7 +67,7 @@ package:
 	@echo $(PACKAGE)
 
 heketi: vendor glide.lock
-	go build -i $(LDFLAGS) -o $(APP_NAME)
+	go build $(GOBUILDFLAGS) $(LDFLAGS) -o $(APP_NAME)
 
 server: heketi
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SHA := $(shell git rev-parse --short HEAD)
 BRANCH := $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
 VER := $(shell git describe --match='v[0-9].[0-9].[0-9]')
 TAG := $(shell git tag --points-at HEAD --sort=creatordate 'v[0-9].[0-9].[0-9]' | tail -n1)
-ARCH := $(shell go env GOARCH)
+GOARCH := $(shell go env GOARCH)
 GOOS := $(shell go env GOOS)
 GLIDEPATH := $(shell command -v glide 2> /dev/null)
 DIR=.
@@ -37,8 +37,8 @@ EXECUTABLES :=$(APP_NAME)
 # Build Binaries setting main.version and main.build vars
 LDFLAGS :=-ldflags "-X main.HEKETI_VERSION=$(VERSION) -extldflags '-z relro -z now'"
 # Package target
-PACKAGE :=$(DIR)/dist/$(APP_NAME)-$(VERSION).$(GOOS).$(ARCH).tar.gz
-CLIENT_PACKAGE :=$(DIR)/dist/$(APP_NAME)-client-$(VERSION).$(GOOS).$(ARCH).tar.gz
+PACKAGE :=$(DIR)/dist/$(APP_NAME)-$(VERSION).$(GOOS).$(GOARCH).tar.gz
+CLIENT_PACKAGE :=$(DIR)/dist/$(APP_NAME)-client-$(VERSION).$(GOOS).$(GOARCH).tar.gz
 DEPS_TARBALL :=$(DIR)/dist/$(APP_NAME)-deps-$(VERSION).tar.gz
 GOFILES=$(shell go list ./... | grep -v vendor)
 

--- a/client/cli/go/Makefile
+++ b/client/cli/go/Makefile
@@ -8,7 +8,7 @@ APP_NAME := heketi-cli
 SHA := $(shell git rev-parse --short HEAD)
 BRANCH := $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
 VER := $(shell git describe)
-ARCH := $(shell go env GOARCH)
+GOARCH := $(shell go env GOARCH)
 GOOS := $(shell go env GOOS)
 DIR=.
 
@@ -31,7 +31,7 @@ EXECUTABLES :=$(APP_NAME)
 # Build Binaries setting main.version and main.build vars
 LDFLAGS :=-ldflags "-X main.HEKETI_CLI_VERSION=$(VERSION) -extldflags '-z relro -z now'"
 # Package target
-PACKAGE :=$(DIR)/dist/$(APP_NAME)-$(VERSION).$(GOOS).$(ARCH).tar.gz
+PACKAGE :=$(DIR)/dist/$(APP_NAME)-$(VERSION).$(GOOS).$(GOARCH).tar.gz
 
 .DEFAULT: all
 

--- a/client/cli/go/Makefile
+++ b/client/cli/go/Makefile
@@ -10,6 +10,14 @@ BRANCH := $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
 VER := $(shell git describe)
 GOARCH := $(shell go env GOARCH)
 GOOS := $(shell go env GOOS)
+GOHOSTARCH := $(shell go env GOHOSTARCH)
+GOHOSTOS := $(shell go env GOHOSTOS)
+GOBUILDFLAGS :=
+ifeq ($(GOOS), $(GOHOSTOS))
+ifeq ($(GOARCH), $(GOHOSTARCH))
+	GOBUILDFLAGS :=-i
+endif
+endif
 DIR=.
 
 ifdef APP_SUFFIX
@@ -50,7 +58,7 @@ package:
 	@echo $(PACKAGE)
 
 build:
-	go build -i $(LDFLAGS) -o $(APP_NAME)
+	go build $(GOBUILDFLAGS) $(LDFLAGS) -o $(APP_NAME)
 
 run: build
 	./$(APP_NAME)


### PR DESCRIPTION
This fixes cross-compilation and thereby "make release"
by only conditionally using caching (go build -i instead of go build).