### PR TITLE
Build out support for running short tests scripts in tests dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,6 @@ LDFLAGS :=-ldflags "-X main.HEKETI_VERSION=$(VERSION) -extldflags '-z relro -z n
 PACKAGE :=$(DIR)/dist/$(APP_NAME)-$(VERSION).$(GOOS).$(GOARCH).tar.gz
 CLIENT_PACKAGE :=$(DIR)/dist/$(APP_NAME)-client-$(VERSION).$(GOOS).$(GOARCH).tar.gz
 DEPS_TARBALL :=$(DIR)/dist/$(APP_NAME)-deps-$(VERSION).tar.gz
-GOFILES=$(shell go list ./... | grep -v vendor)
 
 .DEFAULT: all
 
@@ -93,8 +92,7 @@ run: server
 	./$(APP_NAME)
 
 test: vendor glide.lock
-	go test $(GOFILES)	# TODO: move this into a sub-test inside test/*.sh
-	./test.sh
+	./test.sh $(TESTOPTIONS)
 
 clean:
 	@echo Cleaning Workspace...

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,88 @@
 #!/bin/bash
 
 # main test runner for heketi
+# Executes all executable scripts under tests dir
+# in sorted order.
 
-# TODO: add tests here...
+FAILURES=()
+
+vecho () {
+	if [[ "${verbose}" = "yes" ]] ; then
+		echo "$*"
+	fi
+}
+
+run_test() {
+	cmd="${1}"
+	vecho "-- Running: ${tname} --"
+	"${cmd}"
+	sts=$?
+	if [[ ${sts} -ne 0 ]]; then
+		vecho "failed ${cmd} [${sts}]"
+		FAILURES+=(${cmd})
+		if [[ "${exitfirst}" = "yes" ]]; then
+			exit 1
+		fi
+	fi
+}
+
+summary() {
+	if [[ ${#FAILURES[@]} -gt 0 ]]; then
+		echo "ERROR: failing tests:"
+		for i in ${!FAILURES[@]}; do
+			echo "  ${FAILURES[i]}"
+		done
+		exit 1
+	else
+		echo "all tests passed"
+		exit 0
+	fi
+}
+
+trap summary EXIT
+
+CLI="$(getopt -o xvh --long exitfirst,verbose,help -n $0 -- "$@")"
+eval set -- "${CLI}"
+while true ; do
+	case "$1" in
+		-x|--exitfirst)
+			exitfirst=yes
+			shift
+		;;
+		-v|--verbose)
+			verbose=yes
+			shift
+		;;
+		-h|--help)
+			echo "$0 [options]"
+			echo "  Options:"
+			echo "    -v|--verbose      Print verbose output"
+			echo "    -x|--exitfirst    Exit on first test failure"
+			echo "    -h|--help         Display help"
+			exit 0
+		;;
+		--)
+			shift
+			break
+		;;
+		*)
+			echo "unknown option" >&2
+			exit 2
+		;;
+	esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
+
+# environment vars exported for test scripts
+# (this way test scripts dont need cli parsing, we do it here)
+export HEKETI_TEST_EXITFIRST=${exitfirst}
+export HEKETI_TEST_SCRIPT_DIR="${SCRIPT_DIR}"
+
+cd "${SCRIPT_DIR}"
+for tname in $(ls tests | sort) ; do
+	tpath="./tests/${tname}"
+	if [[ ${tpath} =~ .*\.sh$ && -f ${tpath} && -x ${tpath} ]]; then
+		run_test "${tpath}"
+	fi
+done

--- a/tests/001-testtest.sh
+++ b/tests/001-testtest.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# This "test" exists merely to exercise the test "framework"
+
+if [ "$HEKETI_TEST_TEST" ]; then
+	exit "$HEKETI_TEST_TEST"
+fi
+exit 0

--- a/tests/100-gotest.sh
+++ b/tests/100-gotest.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+GOFILES="$(go list ./... | grep -v vendor)"
+exec go test ${GOFILES}

--- a/tests/100-gotest.sh
+++ b/tests/100-gotest.sh
@@ -1,4 +1,19 @@
 #!/bin/sh
 
 GOFILES="$(go list ./... | grep -v vendor)"
-exec go test ${GOFILES}
+# no special options, exec to go test w/ all pkgs
+if [[ ${HEKETI_TEST_EXITFIRST} != "yes" ]]; then
+	exec go test ${GOFILES}
+fi
+
+# our options are set so we need to handle each go package one
+# at at time
+failed=0
+for gofile in ${GOFILES}; do
+	go test "${gofile}"
+	[ $? -ne 0 ] && ((failed+=1))
+	if [[ ${failed} -ne 0 && ${HEKETI_TEST_EXITFIRST} = "yes" ]]; then
+		exit ${failed}
+	fi
+done
+exit ${failed}


### PR DESCRIPTION
 Implements changes for issue #887 
Adds code to the "framework" script for running individual tests scripts under the tests dir. Moves go test invocation to a test script.
Starting off small with many opportunities for improvement. :-)