### PR TITLE
doc: begin importing some docs from the github wiki

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,17 @@
+
+# Heketi Documentation
+
+Heketi provides a RESTful management interface which can be used to manage
+the life cycle of GlusterFS volumes. With Heketi, cloud services like
+OpenStack Manila, Kubernetes, and OpenShift can dynamically provision GlusterFS
+volumes.
+
+## Topics
+
+* [Heketi API](./api/api.md)
+* [Troubleshooting Guide](./troubleshooting.md)
+
+
+As with many projects our documentation is a work in progress. If you
+find something wrong, misleading or out of date please consider
+contributing a bug report or change to the Heketi project.

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -1,0 +1,593 @@
+# Contents
+* [Overview](#overview)
+* [Development](#development)
+* [Authentication Model](#authentication)
+* [Asynchronous Operations](#async)
+* [API](#api)
+    * [Clusters](#clusters)
+        * [Create Cluster](#cluster_create)
+        * [Cluster Information](#cluster_info)
+        * [List Clusters](#cluster_list)
+        * [Delete Cluster](#cluster_delete)
+    * [Nodes](#nodes)
+        * [Add node](#node_add)
+        * [Node Information](#node_info)
+        * [Delete node](#node_delete)
+    * [Devices](#devices)
+        * [Add device](#device_add)
+        * [Device Information](#device_info)
+        * [Delete device](#device_delete)
+    * [Volumes](#volumes)
+        * [Create a Volume](#volume_create)
+        * [Volume Information](#volume_info)
+        * [Expand a Volume](#volume_expand)
+        * [Volume Delete](#volume_delete)
+        * [Volumes List](#volume_list)
+
+# Overview <a name="overview" />
+Heketi provides a RESTful management interface which can be used to manage the life cycle of GlusterFS volumes.  The goal of Heketi is to provide a simple way to create, list, and delete GlusterFS volumes in multiple storage clusters.  Heketi intelligently will manage the allocation, creation, and deletion of bricks throughout the disks in the cluster.  Heketi first needs to learn about the topologies of the clusters before satisfying any requests.  It organizes data resources into the following: Clusters, contain Nodes, which contain Devices, which will contain Bricks.
+
+# Development <a name="development" />
+To communicate with the Heketi service, you will need to either use a client library or directly communicate with the REST endpoints.  The following client libraries are supported: Go, Python
+
+## Go Client Library
+Here is a small example of how to use the Go client library:
+
+```go
+
+import (
+	"fmt"
+	"github.com/heketi/heketi/client/api/go-client"
+)
+
+func main() {
+	// Create a client
+	heketi := client.NewClient(options.Url, options.User, options.Key)
+
+	// List clusters
+	list, err := heketi.ClusterList()
+	if err != nil {
+		return err
+	}
+
+	output := strings.Join(list.Clusters, "\n")
+	fmt.Fprintf(stdout, "Clusters:\n%v\n", output)
+	return nil
+}
+```
+
+For more examples see the [Heketi cli client](https://github.com/heketi/heketi/tree/master/client/cli/go/cmds).
+
+* Source: https://github.com/heketi/heketi/tree/master/client/api/go-client
+
+## Python Client Library
+The python client library can be installed either from the source or by installing the `python-heketi` package in Fedora/RHEL.  The source is available https://github.com/heketi/heketi/tree/master/client/api/python , and for examples, please check out the [unit tests](https://github.com/heketi/heketi/blob/master/client/api/python/test/unit/test_client.py)
+
+## Running the development server
+The simplest way to development a client for Heketi is to run the Heketi service in `mock` mode.  In this mode, Heketi will not need to communicate with any storage nodes, instead it mocks the communication, while still supporting all REST calls and maintaining state.  The simplest way to run the Heketi server is to run it from a container as follows:
+
+```
+# docker run -d -p 8080:8080 heketi/heketi
+# curl http://localhost:8080/hello
+Hello from Heketi
+```
+
+# Authentication Model <a name="authentication" />
+Heketi uses a stateless authentication model based on the JSON Web Token (JWT) standard as proposed to the [IETF](https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25).  As specified by the specification, a JWT token has a set of _claims_ which can be added to a token to determine its correctness.  Heketi requires the use of the following standard claims:
+
+* [_iss_](http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#rfc.section.4.1.1): Issuer.  Heketi supports two types of issuers:
+    * _admin_: Has access to all APIs
+    * _user_: Has access to only _Volume_ APIs     
+* [_iat_](http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#rfc.section.4.1.6): Issued-at-time
+* [_exp_](http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#rfc.section.4.1.4): Time when the token should expire
+
+And a custom one following the model as described on [Atlassian](https://developer.atlassian.com/static/connect/docs/latest/concepts/understanding-jwt.html): 
+
+* _qsh_.  URL Tampering prevention.
+
+Heketi supports token signatures encrypted using the HMAC SHA-256 algorithm which is specified by the specification as `HS256`.
+
+## Clients
+There are JWT libraries available for most languages as highlighted on [jwt.io](http://jwt.io).  The client libraries allow you to easily create a JWT token which must be stored in the `Authorization: Bearer {token}` header.  A new token will need to be created for each REST call.  Here is an example of the header:
+
+`Authorization: Bearer eyJhb[...omitted for brevity...]HgQ`
+
+### Python Example
+Here is an example of how to create a token as Python client:
+
+```python
+import jwt
+import datetime
+import hashlib
+
+method = 'GET'
+uri = '/volumes'
+secret = 'My secret'
+
+claims = {}
+
+# Issuer
+claims['iss'] = 'admin'
+
+# Issued at time
+claims['iat'] = datetime.datetime.utcnow()
+
+# Expiration time
+claims['exp'] = datetime.datetime.utcnow() \
+	+ datetime.timedelta(minutes=10)
+
+# URI tampering protection
+claims['qsh'] = hashlib.sha256(method + '&' + uri).hexdigest()
+
+print jwt.encode(claims, secret, algorithm='HS256')
+```
+
+Example output:
+
+```
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhZG1pbiIsImlhdCI6MTQzNTY4MTY4OSwicXNoIjoiYzE2MmFjYzkwMjQyNzIxMjBiYWNmZmY3NzA5YzkzMmNjMjUyMzM3ZDBhMzBmYTE1YjAyNTAxMDA2NjY2MmJlYSIsImV4cCI6MTQzNTY4MjI4OX0.ZBd_NgzEoGckcnyY4_ypgJsN6Oi7x0KxX2w8AXVyiS8
+```
+
+### Ruby Example
+Run this as: `./heketi-api.rb volumes`
+
+```ruby
+#!/usr/bin/env ruby
+
+require 'jwt'
+require 'digest'
+
+user = "admin"
+pass = "password"
+server = "http://heketi.example.com:8443"
+
+uri = "/#{ARGV[0]}"
+
+payload = {}
+
+headers = {
+  iss: 'admin',
+  iat: Time.now.to_i,
+  exp: Time.now.to_i + 600,
+  qsh: Digest::SHA256.hexdigest("GET&#{uri}")
+}
+
+token = JWT.encode headers, pass, 'HS256'
+
+exec("curl -H \"Authorization: Bearer #{token}\" #{server}#{uri}")
+```
+
+Copy this example token and decode it in [jwt.io](http://jwt.io) by pasting it in the token area and changing the secret to `My secret`.
+
+## More Information
+* [JWT Specification](http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html)
+* [Debugger and clients at jwt.io](http://jwt.io)
+* [Stateless tokens with JWT](http://jonatan.nilsson.is/stateless-tokens-with-jwt/)
+* Clients
+    * [Go JWT client](https://github.com/auth0/go-jwt-middleware)
+    * [Python JWT client](https://github.com/jpadilla/pyjwt)
+    * [Java JWT client](https://bitbucket.org/b_c/jose4j/wiki/Home)
+    * [Ruby JWT client](https://github.com/jwt/ruby-jwt)
+
+
+# Asynchronous Operations <a name="async" />
+Some operations may take a long time to process.  For these operations, Heketi will return [202 Accepted](http://httpstatus.es/202) with a temporary resource set inside the `Location` header.  A client can then issue a _GET_ on this temporary resource and receive the following:
+
+* **HTTP Status 200**: Request is still in progress. _We may decide to add some JSON ETA data here in future releases_.
+    * **Header** _X-Pending_ will be set to the value of _true_
+* **HTTP Status 404**: Temporary resource requested is not found.
+* **HTTP Status [500](http://httpstatus.es/500)**: Request completed and has failed.  Body will be filled in with error information.
+* **HTTP Status [303 See Other](http://httpstatus.es/303)**: Request has been completed successfully. The information requested can be retrieved by issuing a _GET_ on the resource set inside the `Location` header.
+* **HTTP Status [204 Done](http://httpstatus.es/204)**: Request has been completed successfully. There is no data to return.
+
+
+# API <a name="api" />
+Heketi uses JSON as its data serialization format. XML is not supported.
+
+Most APIs use use the following methods on the URIs:
+
+* URIs in the form of `/<REST endpoint>/{id}`
+* Responses and requests are in JSON format
+* **POST**: Send data to Heketi where the _body_ has data described in JSON format.
+* **GET**: Retrieve data from Heketi where the _body_ has data described in JSON format.
+* **DELETE**: Deletes the specified object from Heketi.
+
+Before servicing any requests, Heketi must first learn the topology of the clusters.  Once it knows which nodes and disks to use, it can then service requests.
+
+# Clusters <a name="clusters" />
+Heketi is able to manage multiple GlusterFS clusters, each composed of a set of storage nodes.  Once a cluster has been created, nodes can then be added to it for Heketi to manage.  A GlusterFS cluster is a set of nodes participating as a trusted storage pool.  Volumes do not cross cluster boundaries.
+
+### Create Cluster <a name="cluster_create" />
+* **Method:** _POST_  
+* **Endpoint**:`/clusters`
+* **Content-Type**: `application/json`
+* **Response HTTP Status Code**: 201
+* **JSON Request**: Empty body, or an empty JSON request
+    * Example:
+
+```json
+{}
+```
+
+* **JSON Response**: See [Cluster Information](#cluster_info)
+    * Example:
+
+```json
+{
+    "id": "67e267ea403dfcdf80731165b300d1ca",
+    "nodes": [],
+    "volumes": [],
+}
+```
+
+### Cluster Information <a name="cluster_info" />
+* **Method:** _GET_  
+* **Endpoint**:`/clusters/{id}`
+* **Response HTTP Status Code**: 200
+* **JSON Request**: None
+* **JSON Response**:
+    * id: _string_, UUID for node
+    * nodes: _array of strings_, UUIDs of each node in the cluster
+    * volumes: _array of strings_, UUIDs of each volume in the cluster
+    * Example:
+
+```json
+{
+    "id": "67e267ea403dfcdf80731165b300d1ca",
+    "nodes": [
+        "78696abbba372659effa",
+        "799029acaa867a66934"
+    ],
+    "volumes": [
+        "aa927734601288237463aa",
+        "70927734601288237463aa"
+    ],
+}
+```
+
+### List Clusters <a name="cluster_list" />
+* **Method:** _GET_  
+* **Endpoint**:`/clusters`
+* **Response HTTP Status Code**: 200
+* **JSON Request**: None
+* **JSON Response**:
+    * clusters: _array of strings_, UUIDs of clusters
+    * Example:
+
+```json
+{
+    "clusters": [
+        "67e267ea403dfcdf80731165b300d1ca",
+        "ff6667ea403dfcdf80731165b300d1ca"
+    ]
+}
+```
+
+### Delete Cluster <a name="cluster_delete" />
+* **Method:** _DELETE_  
+* **Endpoint**:`/clusters/{id}`
+* **Response HTTP Status Code**: 200
+* **Response HTTP Status Code**: 409, Returned if it contains nodes
+* **JSON Request**: None
+* **JSON Response**: None
+
+## Nodes <a name="nodes" />
+The _node_ RESTful endpoint is used to register a storage system for Heketi to manage.  Devices in this node can then be registered.
+
+### Add Node <a name="node_add" />
+* **Method:** _POST_  
+* **Endpoint**:`/nodes`
+* **Content-Type**: `application/json`
+* **Response HTTP Status Code**: 202, See [Asynchronous Operations](#async)
+* **Temporary Resource Response HTTP Status Code**: 303, `Location` header will contain `/nodes/{id}`. See [Node Info](#node_info) for JSON response.
+* **JSON Request**:
+    * zone: _int_, failure domain.  Value of `0` is not allowed.
+    * hostnames: _map of strings_
+        * manage: _array of strings_, List of node management hostnames.  
+            * In SSH configurations, Heketi needs to be able to SSH to the host on any of the supplied management hostnames.  It is *highly* recommended to use hostnames instead of IP addresses.
+            * For Kubernetes and OpenShift, this must be the name of the node as shown in `kubectl get nodes` which is running the Gluster POD
+            * _NOTE:_  Even though it takes a list of hostnames, only one is supported at the moment.  The plan is to support multiple hostnames when glusterd-2 is used.  For Kubernetes and OpenShift, this must be the name of the Pod file, not the name of the node.
+        * storage: _array of strings_, List of node storage network hostnames.  These storage network addresses will be used to create and access the volume.  It is *highly* recommended to use hostnames instead of IP addresses. _NOTE:_  Even though it takes a list of hostnames, only one is supported at the moment.  The plan is to support multiple ip address when glusterd-2 is used.
+    * cluster: _string_, UUID of cluster to whom this node should be part of.
+    * Example:
+
+```json
+{
+    "zone": 1,
+    "hostnames": {
+        "manage": [
+            "node1-manage.gluster.lab.com"
+        ],
+        "storage": [
+            "node1-storage.gluster.lab.com"
+        ]
+    },
+    "cluster": "67e267ea403dfcdf80731165b300d1ca"
+}
+```
+
+### Node Information <a name="node_info" />
+* **Method:** _GET_
+* **Endpoint**:`/nodes/{id}`
+* **Response HTTP Status Code**: 200
+* **JSON Request**: None
+* **JSON Response**:
+    * zone: _int_, Failure Domain
+    * id: _string_, UUID for node
+    * cluster: _string_, UUID of cluster
+    * hostnames: _map of strings_
+        * manage: _array of strings_, List of node management hostnames.  Heketi needs to be able to SSH to the host on any of the supplied management hostnames.
+        * storage: _array of strings_, List of node storage network hostnames.  These storage network addresses will be used to create and access the volume.
+    * devices: _array maps_, See [Device Information](#device_info)
+    * Example:
+
+```json
+{
+    "zone": 1,
+    "id": "88ddb76ad403dfcdf80731165b300d1ca",
+    "cluster": "67e267ea403dfcdf80731165b300d1ca",
+    "hostnames": {
+        "manage": [
+            "node1-manage.gluster.lab.com"
+        ],
+        "storage": [
+            "node1-storage.gluster.lab.com"
+        ]
+    },
+    "devices": [
+        {
+            "name": "/dev/sdh",
+            "storage": {
+                "total": 2000000,
+                "free": 2000000,
+                "used": 0
+            },
+            "id": "49a9bd2e40df882180479024ac4c24c8",
+            "bricks": [
+                {
+                    "id": "aaaaaad2e40df882180479024ac4c24c8",
+                    "path": "/gluster/brick_aaaaaad2e40df882180479024ac4c24c8/brick",
+                    "size": 0
+                },
+                {
+                    "id": "bbbbbbd2e40df882180479024ac4c24c8",
+                    "path": "/gluster/brick_bbbbbbd2e40df882180479024ac4c24c8/brick",
+                    "size": 0
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Delete Node <a name="node_delete" />
+* **Method:** _DELETE_  
+* **Endpoint**:`/nodes/{id}`
+* **Response HTTP Status Code**: 202, See [Asynchronous Operations](#async)
+* **Response HTTP Status Code**: 409, Node contains devices
+* **Temporary Resource Response HTTP Status Code**: 204
+
+## Devices <a name="devices" />
+The `devices` endpoint allows management of raw devices in the cluster.
+
+### Add Device <a name="device_add" />
+* **Method:** _POST_  
+* **Endpoint**:`/devices`
+* **Content-Type**: `application/json`
+* **Response HTTP Status Code**: 202, See [Asynchronous Operations](#async)
+* **Temporary Resource Response HTTP Status Code**: 204
+* **JSON Request**:
+    * node: _string_, UUID of node which the devices belong to.
+    * name: _string_, Device name
+    * Example:
+
+```json
+{
+    "node": "714c510140c20e808002f2b074bc0c50",
+    "name": "/dev/sdb"
+}
+```
+
+### Device Information <a name="device_info" />
+* **Method:** _GET_
+* **Endpoint**:`/devices/{id}`
+* **Response HTTP Status Code**: 200
+* **JSON Request**: None
+* **JSON Response**:
+    * name: _string_, Name of device
+    * id: _string_, UUID of device
+    * total: _uint64_, Total storage in KB
+    * free: _uint64_, Available storage in KB
+    * used: _uint64_, Allocated storage in KB
+    * bricks: _array of maps_, Bricks allocated on this device
+        * id: _string_, UUID of brick
+        * path: _string_, Path of brick on the node
+        * size: _uint64_, Size of brick in KB
+    * Example:
+
+```json
+{
+    "name": "/dev/sdh",
+    "storage": {
+        "total": 1000000,
+        "free": 1000000,
+        "used": 0
+    },
+    "id": "49a9bd2e40df882180479024ac4c24c8",
+    "bricks": [
+        {
+            "id": "aaaaaad2e40df882180479024ac4c24c8",
+            "path": "/gluster/brick_aaaaaad2e40df882180479024ac4c24c8/brick",
+            "size": 0,
+            "node": "714c510140c20e808002f2b074bc0c50",
+            "device": "49a9bd2e40df882180479024ac4c24c8"
+        },
+        {
+            "id": "bbbbbbd2e40df882180479024ac4c24c8",
+            "path": "/gluster/brick_bbbbbbd2e40df882180479024ac4c24c8/brick",
+            "size": 0,
+            "node": "714c510140c20e808002f2b074bc0c50",
+            "device": "49a9bd2e40df882180479024ac4c24c8"
+        }
+    ]
+}
+```
+
+### Device Delete <a name="device_delete" />
+* **Method:** _DELETE_  
+* **Endpoint**:`/devices/{id}`
+* **Response HTTP Status Code**: 202, See [Asynchronous Operations](#async)
+* **Response HTTP Status Code**: 409, Device contains bricks
+* **Temporary Resource Response HTTP Status Code**: 204
+
+## Volumes <a name="volumes" />
+These APIs inform Heketi to create a network file system of a certain size available to be used by clients.
+
+
+### Create a Volume <a name="volume_create" />
+* **Method:** _POST_  
+* **Endpoint**:`/volumes`
+* **Content-Type**: `application/json`
+* **Response HTTP Status Code**: 202, See [Asynchronous Operations](#async)
+* **Temporary Resource Response HTTP Status Code**: 303, `Location` header will contain `/volumes/{id}`. See [Volume Info](#volume_info) for JSON response.
+* **JSON Request**:
+    * size: _int_, Size of volume requested in GB
+    * name: _string_, _optional_, Name of volume.  If not provided, the name of the volume will be `vol_{id}`, for example `vol_728faa5522838746abce2980`
+    * durability: _map_, _optional_, Durability Settings
+        * type: _string_, optional, Durability type.  Choices are **none** (Distributed Only), **replicate** (Distributed-Replicated), **disperse** (Distributed-Disperse).  If omitted, durability type will default to **none**.
+        * replicate: _map_, _optional_, Replica settings, only used if `type` is set to *replicate*.
+            * replica: _int_, _optional_, Number of replica per brick. If omitted, it will default to `2`.
+        * disperse: _map_, _optional_, Erasure Code settings, only used if `type` is set to *disperse*.
+            * data: _int_, _optional_ Number of dispersed data volumes. If omitted, it will default to `8`.
+            * redundancy: _int_, _optional_, Level of redundancy. If omitted, it will default to `2`.
+    * snapshot: _map_ 
+        * enable: _bool_, _optional_, Snapshot support requested for this volume.  If omitted, it will default to `false`.
+        * factor: _float32_, _optional_, Snapshot reserved space factor.  When creating a volume with snapshot enabled, the size of the brick will be set to _factor * brickSize_, where brickSize is automatically determined to satisfy the volume size request.  If omitted, it will default to _1.5_.
+            * Requirement: Value must be greater than one.
+    * clusters: _array of string_, _optional_, UUIDs of clusters where the volume should be created.  If omitted, each cluster will be checked until one is found that can satisfy the request.
+    * Example:
+
+```json
+{
+    "size": 10000000,
+    "snapshot": {
+        "enable": true,
+        "factor": 1.2
+    },
+    "durability": {
+        "type": "replicate",
+        "replicate": {
+            "replica": 3
+        }
+    },
+    "clusters": [
+        "2f84c71240f43e16808bc64b05ad0d06",
+        "5a2c52d04075373e80dbfa1e291ba0de"
+    ]
+}
+```
+
+
+### Volume Information <a name="volume_info" />
+* **Method:** _GET_
+* **Endpoint**:`/volumes/{id}`
+* **Response HTTP Status Code**: 200
+* **JSON Request**: None
+* **JSON Response**:
+    * name: _string_, Name of volume
+    * size: _int_, Size of volume in GB
+    * id: _string_, Volume UUID
+    * cluster: _string_, UUID of cluster which contains this volume
+    * durability: _map_, Durability settings.  See [Volume Create](#volume_create) for more information.
+    * snapshot: _map_, If omitted, snapshots are disabled.
+        * enable: _bool_, Snapshot support requested for this volume.
+        * factor: _float32_, _optional_, Snapshot reserved space factor if enabled
+    * replica: _int_, Replica count
+    * mounts: _map_, Information used to mount or gain access to the network volume file system
+        * glusterfs: _map_, Mount point information for native GlusterFS FUSE mount
+            * device: _string_, Mount point used for native GlusterFS FUSE mount
+            * options: _map_, Optional mount options to use
+                * backup-volfile-servers: _string_, List of backup volfile servers [[1](https://www.mankier.com/8/mount.glusterfs)] [[2](https://access.redhat.com/documentation/en-US/Red_Hat_Storage/2.0/html/Administration_Guide/chap-Administration_Guide-GlusterFS_Client.html#sect-Administration_Guide-GlusterFS_Client-GlusterFS_Client-Mounting_Volumes)] [[3](http://blog.gluster.org/category/mount-glusterfs/)].  It is up to the calling service to determine which of the volfile servers to use in the actual mount command.
+    * brick: _array of maps_, Bricks used to create volume. See [Device Information](#device_info) for brick JSON description
+    * Example:
+
+```json
+{
+    "name": "vol_70927734601288237463aa",
+    "id": "70927734601288237463aa",
+    "cluster": "67e267ea403dfcdf80731165b300d1ca",
+    "size": 123456,
+    "durability": {
+        "type": "replicate",
+        "replicate": {
+            "replica": 3
+        }
+    },
+    "snapshot": {
+        "enable": true,
+        "factor": 1.2
+    },
+    "mount": {
+        "glusterfs": {
+            "device": "192.168.1.103:vol_70927734601288237463aa",
+            "options": {
+                "backup-volfile-servers": "192.168.1.103,192.168.101"
+            }
+        }
+    },
+    "bricks": [
+        {
+            "id": "aaaaaad2e40df882180479024ac4c24c8",
+            "path": "/gluster/brick_aaaaaad2e40df882180479024ac4c24c8/brick",
+            "size": 0,
+            "node": "892761012093474071983852",
+            "device": "ff2137326add231578ffa7234"
+        },
+        {
+            "id": "bbbbbbd2e40df882180479024ac4c24c8",
+            "path": "/gluster/brick_bbbbbbd2e40df882180479024ac4c24c8/brick",
+            "size": 0,
+            "node": "714c510140c20e808002f2b074bc0c50",
+            "device": "49a9bd2e40df882180479024ac4c24c8"
+        }
+    ]
+}
+```
+
+### Expand a Volume <a name="volume_expand" />
+New volume size will be reflected in the volume information.
+* **Method:** _POST_  
+* **Endpoint**:`/volumes/{id}/expand`
+* **Content-Type**: `application/json`
+* **Response HTTP Status Code**: 202, See [Asynchronous Operations](#async)
+* **Temporary Resource Response HTTP Status Code**: 303, `Location` header will contain `/volumes/{id}`. See [Volume Info](#volume_info) for JSON response.
+* **JSON Request**:
+    * expand_size: _int_, Amount of storage to add to the existing volume in GB
+
+```json
+{ "expand_size" : 1000000 }
+```
+
+### Volume Delete <a name="volume_delete" />
+When a volume is deleted, Heketi will first stop, then destroy the volume.  Once destroyed, it will remove the allocated bricks and free the allocated space.
+* **Method:** _DELETE_  
+* **Endpoint**:`/volumes/{id}`
+* **Response HTTP Status Code**: 202, See [Asynchronous Operations](#async)
+* **Temporary Resource Response HTTP Status Code**: 204
+
+### Volume List <a name="volume_list" />
+* **Method:** _GET_  
+* **Endpoint**:`/volumes`
+* **Response HTTP Status Code**: 200
+* **JSON Response**:
+    * volumes: _array strings_, List of volume UUIDs.
+    * Example:
+
+```json
+{
+    "volumes": [
+        "aa927734601288237463aa",
+        "70927734601288237463aa"
+    ]
+}
+```

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -1,0 +1,15 @@
+Troubleshooting Guide
+========================================
+
+## Deployment
+
+## Setup
+
+1. Error "Unable to open topology file":
+    * You use old syntax of single '-' as prefix for json option. Solution: Use new syntax of double hyphens.
+1. Cannot create volumes smaller than 4GB:
+    * This is due to the limits set in Heketi.  If you want to change the limits, please update the config file using the [advanced settings](https://github.com/heketi/heketi/wiki/Running-the-server#advanced-options).  If you are using Heketi as a container, then you must create a new container based on Heketi which just updates the config file `/etc/heketi/heketi.json`.
+
+## Management
+
+TODO


### PR DESCRIPTION
Begin importing some of the Heketi documentation from the wiki
on github into the repo's doc dir. Start with the API and
troubleshooting pages since they are simple and standalone.
This also includes a doc/ dir level stub README.md.

Signed-off-by: John Mulligan <jmulligan@redhat.com>