### PR TITLE
Import administrative docs from wiki

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -9,6 +9,7 @@ volumes.
 ## Topics
 
 * [Heketi API](./api/api.md)
+* [Adminstration](./admin/readme.md)
 * [Troubleshooting Guide](./troubleshooting.md)
 
 

--- a/doc/admin/install-kubernetes.md
+++ b/doc/admin/install-kubernetes.md
@@ -1,0 +1,124 @@
+## Overview
+
+This guide enables the integration, deployment, and management of GlusterFS containerized storage nodes in a Kubernetes cluster. This enables Kubernetes administrators to provide their users with reliable, shared storage.
+
+There are other guides available, as well. The [gluster-kubernetes](https://github.com/gluster/gluster-kubernetes), includes a [setup guide](https://github.com/gluster/gluster-kubernetes/blob/master/docs/setup-guide.md) for running most of the directions in this guide through a deployment tool called [gk-deploy](https://github.com/gluster/gluster-kubernetes/blob/master/deploy/gk-deploy). It also includes a [Hello World](https://github.com/gluster/gluster-kubernetes/tree/master/docs/examples/hello_world) featuring an nginx pod using a dynamically-provisioned GlusterFS volume for storage. For those looking to test or play around with this quickly, follow the Quickstart instructions found in the main [README](https://github.com/gluster/gluster-kubernetes) for gluster-kubernetes
+
+## Infrastructure Requirements
+
+* A running Kubernetes cluster with at least three Kubernetes worker nodes that each have an available raw block device attached (like an EBS Volume or a local disk).
+* The three Kubernetes nodes intended to run the GlusterFS Pods must have the appropriate ports opened for GlusterFS communication. Run the following commands on each of the nodes.
+```
+iptables -N HEKETI
+iptables -A HEKETI -p tcp -m state --state NEW -m tcp --dport 24007 -j ACCEPT
+iptables -A HEKETI -p tcp -m state --state NEW -m tcp --dport 24008 -j ACCEPT
+iptables -A HEKETI -p tcp -m state --state NEW -m tcp --dport 2222 -j ACCEPT
+iptables -A HEKETI -p tcp -m state --state NEW -m multiport --dports 49152:49251 -j ACCEPT
+service iptables save
+```
+
+## Client Setup
+
+Heketi provides a CLI that provides users with a means to administer the deployment and configuration of GlusterFS in Kubernetes. [Download and install the heketi-cli](https://github.com/heketi/heketi/releases) on your client machine (usually your laptop).
+
+## Kubernetes Deployment
+All the following files are located under `extras/kubernetes`.
+
+* Deploy the GlusterFS DaemonSet
+
+```
+$ kubectl create -f glusterfs-daemonset.json
+```
+
+* Get node name by running:
+
+```
+$ kubectl get nodes
+```
+
+* Deploy gluster container onto specified node by setting the label `storagenode=glusterfs` on that node
+
+```
+$ kubectl label node <...node...> storagenode=glusterfs
+```
+
+Repeat as needed.  Verify that the pods are running on the nodes.
+
+```
+$ kubectl get pods
+```
+
+* Next we need to deploy the Pod and Service Heketi Service Interface to the GlusterFS cluster. In the repo you cloned, there will be a deploy-heketi-deployment.json file. 
+
+Submit the file and verify everything is running properly as demonstrated below:
+
+```
+# kubectl create -f deploy-heketi-deployment.json 
+service "deploy-heketi" created
+deployment "deploy-heketi" created
+
+# kubectl get pods
+NAME                                                      READY     STATUS    RESTARTS   AGE
+deploy-heketi-1211581626-2jotm                            1/1       Running   0          35m
+glusterfs-ip-172-20-0-217.ec2.internal-1217067810-4gsvx   1/1       Running   0          1h
+glusterfs-ip-172-20-0-218.ec2.internal-2001140516-i9dw9   1/1       Running   0          1h
+glusterfs-ip-172-20-0-219.ec2.internal-2785213222-q3hba   1/1       Running   0          1h
+```
+
+* Now that the Bootstrap Heketi Service is running we are going to configure port-fowarding so that we can communicate with the service using the Heketi CLI. Using the name of the Heketi pod, run the command below:
+
+`kubectl port-forward deploy-heketi-1211581626-2jotm :8080`
+
+Now verify that the port forwarding is working, by running a sample query againt the Heketi Service. The command should return a local port that it will be forwarding from. Incorporate that into a localhost query to test the service, as demonstrated below:
+
+```
+curl http://localhost:57598/hello
+Handling connection for 57598
+Hello from Heketi
+```
+
+Lastly, set an environment variable for the Heketi CLI client so that it knows how to reach the Heketi Server.
+
+`export HEKETI_CLI_SERVER=http://localhost:57598`
+
+* Next we are going to provide Heketi with the information about the GlusterFS cluster it is to manage. We provide this information via [a topology file](https://github.com/heketi/heketi/wiki/Setting-up-the-topology). There is a sample topology file within the repo you cloned called topology-sample.json. Topologies primarily specify what Kubernetes Nodes the GlusterFS containers are to run on as well as the corresponding available raw block device for each of the nodes. 
+
+> NOTE: Make sure that `hostnames/manage` points to the exact name as shown under `kubectl get nodes`, and `hostnames/storage` is the ip address of the storage network.
+
+Modify the topology file to reflect the choices you have made and then deploy it as demonstrated below:
+
+```
+heketi-client/bin/heketi-cli topology load --json=topology-sample.json
+Handling connection for 57598
+	Found node ip-172-20-0-217.ec2.internal on cluster e6c063ba398f8e9c88a6ed720dc07dd2
+		Adding device /dev/xvdg ... OK
+	Found node ip-172-20-0-218.ec2.internal on cluster e6c063ba398f8e9c88a6ed720dc07dd2
+		Adding device /dev/xvdg ... OK
+	Found node ip-172-20-0-219.ec2.internal on cluster e6c063ba398f8e9c88a6ed720dc07dd2
+		Adding device /dev/xvdg ... OK
+```
+
+* Next we are going to use Heketi to provision a volume for it to storage its database:
+
+```
+# heketi-client/bin/heketi-cli setup-openshift-heketi-storage
+# kubectl create -f heketi-storage.json
+```
+
+Wait until the job is complete then delete the bootstrap Heketi:
+
+```
+# kubectl delete all,service,jobs,deployment,secret --selector="deploy-heketi" 
+```
+
+* Submit Heketi:
+
+```
+# kubectl create -f heketi-deployment.json 
+service "heketi" created
+deployment "heketi" created
+```
+
+# Usage Example
+
+There are two ways to provision storage.  The primary way is to setup StorageClass which lets Kubernetes automatically provision storage for an PersistentVolumeClaim submitted.  Another is to manually submit and create the volumes.

--- a/doc/admin/install-kubernetes.md
+++ b/doc/admin/install-kubernetes.md
@@ -81,7 +81,7 @@ Lastly, set an environment variable for the Heketi CLI client so that it knows h
 
 `export HEKETI_CLI_SERVER=http://localhost:57598`
 
-* Next we are going to provide Heketi with the information about the GlusterFS cluster it is to manage. We provide this information via [a topology file](https://github.com/heketi/heketi/wiki/Setting-up-the-topology). There is a sample topology file within the repo you cloned called topology-sample.json. Topologies primarily specify what Kubernetes Nodes the GlusterFS containers are to run on as well as the corresponding available raw block device for each of the nodes. 
+* Next we are going to provide Heketi with the information about the GlusterFS cluster it is to manage. We provide this information via [a topology file](./topology.md). There is a sample topology file within the repo you cloned called topology-sample.json. Topologies primarily specify what Kubernetes Nodes the GlusterFS containers are to run on as well as the corresponding available raw block device for each of the nodes.
 
 > NOTE: Make sure that `hostnames/manage` points to the exact name as shown under `kubectl get nodes`, and `hostnames/storage` is the ip address of the storage network.
 

--- a/doc/admin/install-openshift.md
+++ b/doc/admin/install-openshift.md
@@ -96,7 +96,7 @@ It should return:
 Hello from Heketi
 ```
 
-Register your [Topology](Setting-up-the-topology) with the bootstrap Heketi:
+Register your [Topology](./topology.md) with the bootstrap Heketi:
 
 ```
 $ heketi-cli -s http://<address to deploy-heketi service> topology load --json=<topology file>

--- a/doc/admin/install-openshift.md
+++ b/doc/admin/install-openshift.md
@@ -1,0 +1,181 @@
+# Overview
+
+![overview](https://github.com/heketi/heketi/wiki/images/aplo_arch.png)
+
+This guide enables the integration, deployment, and management of GlusterFS containerized storage nodes in an OpenShift cluster.  This enables OpenShift administrators to provide their users with reliable, shared storage.
+
+# Demo
+[![demo](https://github.com/heketi/heketi/wiki/images/aplo_demo.png)](https://asciinema.org/a/50531)
+
+For simplicity, you can deploy an OpenShift cluster using the configured [Heketi Vagrant Demo](https://github.com/heketi/vagrant-heketi)
+
+# Requirements
+
+* OpenShift cluster must be up and running
+* OpenShift router must be created and DNS setup
+* A cluster-admin user created
+* At least three OpenShift nodes must be storage nodes with at least one raw device per node
+* Non-Atomic systems: All OpenShift nodes must have glusterfs-client RPM installed which should match the version of GlusterFS server running in the containers
+* OpenShift nodes which are to be used with GlusterFS must have the correct ports opened for GlusterFS communication. On each Openshift minion that will host a glusterfs container, add the following rules to `/etc/sysconfig/iptables`:
+
+```
+-A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 24007 -j ACCEPT
+-A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 24008 -j ACCEPT
+-A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 2222 -j ACCEPT
+-A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m multiport --dports 49152:49251 -j ACCEPT
+```
+
+# Setup
+The following setup assumes that you will be using a client machine to communicate with the OpenShift cluser as shown:
+
+![setup](https://github.com/heketi/heketi/wiki/images/aplo_install.png)
+
+## Client Setup
+* Install the following packages in Fedora/CentOS(EPEL): `heketi-templates heketi-client`
+* For other Linux systems or MacOS X, install from the [releases page](https://github.com/heketi/heketi/releases/tag/v2.0.6)
+
+## Deployment
+
+Create a project for the storage containers:
+
+```
+$ oc new-project aplo
+```
+
+Make sure to allow privileged containers in the new project (on Atomic, you may need to do this command on the master for the `aplo` project). On the master, run the following:
+
+```
+$ oc project aplo
+$ oadm policy add-scc-to-user privileged -z default
+```
+
+Register the Heketi and GlusterFS OpenShift templates:
+
+```
+$ oc create -f /usr/share/heketi/templates
+```
+
+Show the node names:
+
+```
+$ oc get nodes
+```
+
+Deploy GlusterFS container by doing the following for each node which will run GlusterFS:
+
+```
+$ oc process glusterfs -v GLUSTERFS_NODE=<name of a node to use glusterfs as shown above> | oc create -f -
+```
+
+Deploy the bootstrap Heketi container which will be used to setup the database:
+
+```
+$ oc process deploy-heketi -v \
+         HEKETI_KUBE_NAMESPACE=aplo \
+         HEKETI_KUBE_APIHOST=https://<host of OpenShift master and port> \
+         HEKETI_KUBE_INSECURE=y \
+         HEKETI_KUBE_USER=<cluster admin username> \
+         HEKETI_KUBE_PASSWORD=<cluster admin password> | oc create -f -
+```
+
+Wait until the deploy-heketi pod is running, then note the exported name for your the deploy-heketi service:
+
+```
+$ oc status
+```
+
+Wait until all services are up, check Heketi communication:
+
+```
+$ curl http://<address to deploy-heketi service>/hello
+```
+
+It should return:
+
+```
+Hello from Heketi
+```
+
+Register your [Topology](Setting-up-the-topology) with the bootstrap Heketi:
+
+```
+$ heketi-cli -s http://<address to deploy-heketi service> topology load --json=<topology file>
+```
+
+Setup storage volume for Heketi database:
+
+```
+$ heketi-cli -s http://<address to deploy-heketi service> setup-openshift-heketi-storage
+$ oc create -f heketi-storage.json
+```
+
+Wait until the job is complete then delete the bootstrap Heketi:
+
+```
+$ oc delete all,job,template,secret --selector="deploy-heketi"
+```
+
+Install Heketi service:
+
+```
+$ oc process heketi -v \
+         HEKETI_KUBE_NAMESPACE=aplo \
+         HEKETI_KUBE_APIHOST=https://<host of OpenShift master and port> \
+         HEKETI_KUBE_INSECURE=y \
+         HEKETI_KUBE_USER=<cluster admin username> \
+         HEKETI_KUBE_PASSWORD=<cluster admin password> | oc create -f -
+```
+
+Wait until the Heketi service is up, then note the exported DNS name for Heketi:
+
+```
+$ oc status
+```
+
+# Usage Example
+
+Normally you would need to setup another project for an applications, and setup the appropriate [endpoints and services](https://github.com/kubernetes/kubernetes/tree/master/examples/glusterfs).  As an example, you will create an application in the same project as above using the endpoints and service already registered.
+
+Download the example application:
+
+```
+$ wget https://raw.githubusercontent.com/lpabon/aplo-demo/master/nginx.yml
+```
+
+Because nginx container sets up a USER in their Dockerfile, you will need to run the following command on the master:
+
+```
+$ oadm policy add-scc-to-group anyuid system:authenticated
+```
+
+Create a 100G volume for nginx:
+
+```
+$ export HEKETI_CLI_SERVER=http://<address to heketi service>
+$ heketi-cli volume create --size=100 \
+  --persistent-volume \
+  --persistent-volume-endpoint=heketi-storage-endpoints | oc create -f -
+```
+
+Bring up nginx application:
+
+```
+$ cat nginx.yml | oc create -f -
+```
+
+Wait until the nginx application is up and running, then note the exported DNS name for the nginx service:
+
+```
+$ oc status
+```
+
+Create a sample `index.html` file:
+
+```
+$ oc rsh nginx
+# df -h
+# echo 'I love GlusterFS!' > /usr/share/nginx/html/index.html
+# exit
+$ curl http://<address to nginx service>
+I love GlusterFS!
+```

--- a/doc/admin/install-standalone.md
+++ b/doc/admin/install-standalone.md
@@ -1,0 +1,37 @@
+
+# Standalone Installation
+Heketi can be installed on any system as long as it has access to all storage nodes that it will be required to manage.  Also, please keep in mind that the database today is a single point of failure, so it must be installed in a safe location (see [#208](https://github.com/heketi/heketi/issues/208)).
+
+## EPEL/Fedora Installation
+To install Heketi on an EPEL/Fedora please type the following:
+
+* Fedora: 
+
+```
+# dnf install heketi
+```
+
+* EPEL
+
+```
+# yum install heketi
+```
+
+
+
+## Other Linux Systems
+Download the latest Heketi version from [Releases](https://github.com/heketi/heketi/releases). For example:
+
+```
+$ wget https://github.com/heketi/heketi/releases/download/1.0.1/heketi-1.0.1.linux.amd64.tar.gz
+$ tar xzvf heketi-1.0.1.linux.amd64.tar.gz
+$ cd heketi
+$ ./heketi -version
+Heketi v1.0.1
+```
+
+## Installing as a container
+You can also install Heketi as a container.  Please see https://hub.docker.com/r/heketi/heketi for more information
+
+## Next
+Please visit [Running the server](Running-the-server)

--- a/doc/admin/install-standalone.md
+++ b/doc/admin/install-standalone.md
@@ -32,6 +32,3 @@ Heketi v1.0.1
 
 ## Installing as a container
 You can also install Heketi as a container.  Please see https://hub.docker.com/r/heketi/heketi for more information
-
-## Next
-Please visit [Running the server](Running-the-server)

--- a/doc/admin/readme.md
+++ b/doc/admin/readme.md
@@ -1,5 +1,6 @@
 # Example
-An example of the usage workflow can be seen by visiting the [Demo](Demo).
+An example of the usage workflow can be seen by visiting
+the [Demo](http://github.com/heketi/heketi/wiki/Demo).
 
 # Requirements
 Heketi requires ssh access to the nodes that it will manage.  For that reason, Heketi has the following requirements:

--- a/doc/admin/readme.md
+++ b/doc/admin/readme.md
@@ -1,0 +1,23 @@
+# Example
+An example of the usage workflow can be seen by visiting the [Demo](Demo).
+
+# Requirements
+Heketi requires ssh access to the nodes that it will manage.  For that reason, Heketi has the following requirements:
+
+* SSH Access
+    * SSH user and public key already setup on the node
+    * SSH user must have password-less sudo
+    * Must be able to run sudo commands from ssh.  This requires disabling `requiretty` in the /etc/sudoers file
+* System must have glusterd service enabled and glusterfs-server installed
+* Disks registered with Heketi must be in raw format.
+
+# Workflow
+
+* Installation:
+  * [OpenShift](./install-openshift.md): New in v2.0, Heketi can now be used to manage GlusterFS containers deployed in an OpenShift Cluster.
+  * [Standalone](./install-standalone.md): This method allows a Heketi to be installed on a system to manage GlusterFS storage nodes.
+  * [Kubernetes](./install-kubernetes.md): Heketi can now be used to manage GlusterFS containers deployed in a Kubernetes Cluster. 
+* [Running the server](./server.md)
+* [Setting up the topology](./topology.md)
+* [Creating a volume](./volume.md)
+

--- a/doc/admin/server.md
+++ b/doc/admin/server.md
@@ -122,4 +122,4 @@ $ heketi-cli --server http://<server:port> --user <user> --secret <secret> clust
 ```
 
 # Next
-Please see [Topology Setup](Setting-up-the-topology)
+Please see [Topology Setup](./topology.md)

--- a/doc/admin/server.md
+++ b/doc/admin/server.md
@@ -1,0 +1,125 @@
+# Overview
+Before starting the service for the first time, you need to setup the configuration file accordingly.  On EPEL/Fedora systems, the file is located in `/etc/heketi/heketi.json`.  On other Linux systems, the example configuration file comes as part of the tar file.
+
+# Config file
+The config file has information required to run the Heketi server.  The config file must be in JSON format with the following settings:
+
+* port: _string_, Heketi REST service port number
+* use_auth: _bool_, Enable JWT Authentication.  See [API/Authentication](https://github.com/heketi/heketi/wiki/API#authentication)
+* jwt: _map_, JWT Authentication settings
+    * admin: _map_, Settings for the Heketi administrator
+        * key: _string_, Shared secret
+    * user: _map_, Settings for the Heketi volume requests access user
+        * key: _string_, Shared secret
+* glusterfs: _map_, GlusterFS settings
+    * loglevel: _string_, Set log level.  Possible values are:
+        * none, critical, error, warning, info, debug
+    * executor: _string_, Determines the type of command executor to use.  Environment variable HEKETI_EXECUTOR can also be used to customize executor type.  Possible values are:
+        * **mock**: Does not send any commands out to servers. Can be used for development and tests
+        * **ssh**: Sends commands to real systems over ssh
+        * **kubernetes**: Communicate with GlusterFS containers over Kubernetes exec
+    * db: _string_, Location of Heketi database
+    * sshexec: _map_, SSH configuration
+        * keyfile: _string_, File with private ssh key
+        * user: _string_, SSH user
+        * port: _string_, SSH port number
+        * fstab: _string_, Fstab file where to store mount points
+        * sudo: _bool_, set to true when SSHing as a non root user
+    * kubexec: _map_, Kubernetes configuration
+        * host: _string_, Kubernetes API host.  Example `https://myhost:8443`.  Can also be use using environment variable HEKETI_KUBE_APIHOST
+        * cert: _string_, Certificate file to for HTTPS connection. Can also be use using environment variable HEKETI_KUBE_CERTFILE
+        * insecure: _bool_, Insecure HTTPS access, only use during testing. Can also be use using environment variable HEKETI_KUBE_INSECURE to _y_.
+        * user: _string_, OpenShift/Kubernetes user to access Kubernetes API server. Can also be use using environment variable HEKETI_KUBE_USER.
+        * password: _string_, Password for _user_. Can also be use using environment variable HEKETI_KUBE_PASSWORD.
+        * namespace: _string_, Kubernetes namespace or OpenShift project where GlusterFS containers/Pods are running. Can also be use using environment variable HEKETI_KUBE_NAMESPACE.
+        * fstab: _string_, Fstab file where to store mount points
+
+## Advanced Options
+The following configuration options should only be set on advanced configurations under `glusterfs` section:
+* brick_max_size_gb: _int_, Maximum brick size (Gb)
+* brick_min_size_gb: _int_, Minimum brick size (Gb)
+* max_bricks_per_volume: _int_, Maximum number of bricks per volume
+
+Example:
+
+```
+...
+	"glusterfs" : {
+                ...
+		"db" : "/var/lib/heketi/heketi.db",
+		"brick_max_size_gb" : 1024,
+		"brick_min_size_gb" : 1,
+		"max_bricks_per_volume" : 33
+                ...
+	}
+...
+```
+
+## Notes
+* On EPEL/Fedora systems, the private ssh keyfile must be readable by `heketi` user.    
+
+## Examples
+* [Mock setup](https://github.com/heketi/heketi/blob/master/etc/heketi.json)
+* ~~[Functional test setup](https://github.com/heketi/heketi/blob/master/tests/functional/large/config/heketi.json)~~
+
+# Starting the server
+
+## EPEL7/Fedora
+To start Heketi, simply type:
+
+```
+# systemctl enable heketi
+# systemctl start heketi
+# systemctl status heketi
+```
+
+To see the logs, type:
+
+```
+journalctl -u heketi
+```
+
+The database will be installed in `/var/lib/heketi`.
+
+## EPEL6
+To start Heketi, type:
+
+```
+# chkconfig --add heketi
+# service heketi start
+```
+
+To see the logs, type:
+
+```
+# less /var/log/heketi/heketi
+```
+
+The database will be installed in `/var/lib/heketi`.
+
+## Other Linux Systems
+To run the server you run the following command:
+
+```
+$ heketi --config=<config file>
+```
+
+The server will continue running in the foreground with all logs printed to standard output.
+
+# Testing the configuration
+To test that the server is running, please type the following:
+
+* Using `curl` can be used if Heketi has not been setup with authentication:
+
+```
+$ curl http://<server:port>/hello
+```
+
+* Using heketi-cli
+
+```
+$ heketi-cli --server http://<server:port> --user <user> --secret <secret> cluster list
+```
+
+# Next
+Please see [Topology Setup](Setting-up-the-topology)

--- a/doc/admin/topology.md
+++ b/doc/admin/topology.md
@@ -5,7 +5,8 @@ Before informing Heketi of the topology of the data center, you need to determin
 
 You also need to determine which nodes would constitute a cluster.  Heketi supports multiple GlusterFS clusters, which gives cloud services the option of specifying a set of clusters where a volume must be created.  This provides cloud services and administrators the option of creating SSD, SAS, SATA, or any other type of cluster which provide a specific quality of service to users.
 
-In the [demo](Demo), the topology is setup of a single cluster composed of four nodes across two zones.
+In the [demo](http://github.com/heketi/heketi/wiki/Demo),
+the topology is setup of a single cluster composed of four nodes across two zones.
 
 # Topology setup
 Cloud services can provide their own method of informing Heketi of the topology by using the REST API.  For simplicity, the [heketi-cli](heketi-cli) client can be use as an example of how to interact with Heketi.
@@ -35,5 +36,5 @@ An example of a topology file is available in the [demo](https://github.com/heke
 An example is available [client/cli/go/topology-sample.json](https://github.com/heketi/heketi/blob/master/client/cli/go/topology-sample.json)
 
 # Next
-[Create a volume](Create-a-volume)
+[Create a volume](./volume.md)
 

--- a/doc/admin/topology.md
+++ b/doc/admin/topology.md
@@ -1,0 +1,39 @@
+You must provide Heketi with the information about the topology of the systems.  This allows Heketi to determine which nodes, disks, and clusters to use.
+
+# Preparation
+Before informing Heketi of the topology of the data center, you need to determine the node failure domains and clusters of nodes.  Failure domains, called _zones_ in the [API](https://github.com/heketi/heketi/wiki/API#node_add), is a value given to a set of nodes which share the same switch, power supply, or anything else that would cause them to fail at the same time. Heketi uses this information to make sure that replicas are created across failure domains, thus providing cloud services volumes which are resilient to both data unavailability and data loss.  For example you may have 16 nodes where each four nodes share the same power bar.  In this example model, you would have four nodes per zone.
+
+You also need to determine which nodes would constitute a cluster.  Heketi supports multiple GlusterFS clusters, which gives cloud services the option of specifying a set of clusters where a volume must be created.  This provides cloud services and administrators the option of creating SSD, SAS, SATA, or any other type of cluster which provide a specific quality of service to users.
+
+In the [demo](Demo), the topology is setup of a single cluster composed of four nodes across two zones.
+
+# Topology setup
+Cloud services can provide their own method of informing Heketi of the topology by using the REST API.  For simplicity, the [heketi-cli](heketi-cli) client can be use as an example of how to interact with Heketi.
+
+## Loading a topology with heketi-cli
+You can use the command line client to create a cluster, then add nodes to that cluster, then add disks to each one of those nodes.  This process can be quite tedious from the command line.  For that reason, the command line client supports the option of loading this information to Heketi using a _topology_ file, which describes clusters, their nodes and disks on each node.
+
+To load a topology file with heketi-cli, you would type the following:
+
+```
+$ export HEKETI_CLI_SERVER=http://<heketi server and port>
+$ heketi-cli topology load --json=<topology>
+```
+
+Where _topology_ is a file in JSON format describing the clusters, nodes, and disks to add to Heketi.  The format of the file is as follows:
+
+* clusters: _array of clusters_, Array of clusters
+    * Each element on the array is a _map_ which describes the cluster as follows
+        * nodes: _array of nodes_, Array of nodes in a cluster
+            * Each element on the array is a _map_ which describes the node as follows
+                * node: _map_, Same map as [Node Add](https://github.com/heketi/heketi/wiki/API#node_add) except there is no need to supply the cluster id.
+                * devices: _array of strings_, Name of each disk to be added, which should be raw block storage, and not a file system.
+
+An example of a topology file is available in the [demo](https://github.com/heketi/vagrant-heketi/blob/master/standalone/roles/heketi/files/topology_virtualbox.json).  Also there is a description of the topology file during the [Gluster.Next talk](https://www.youtube.com/watch?v=iBFfHv4bne8&t=2425).
+
+# Example
+An example is available [client/cli/go/topology-sample.json](https://github.com/heketi/heketi/blob/master/client/cli/go/topology-sample.json)
+
+# Next
+[Create a volume](Create-a-volume)
+

--- a/doc/admin/volume.md
+++ b/doc/admin/volume.md
@@ -1,0 +1,80 @@
+To create a volume you can use the [Volume Create API](https://github.com/heketi/heketi/wiki/API#volume_create) or the command line client.
+
+From the command line client, you can type the following to create a 1TB volume with replica 3 durability:
+
+```
+$ heketi-cli volume create --size=1024
+```
+
+Once the request has been completed, which could take some time depending on the hardware, information about the volume will be displayed on standard out, including the mount point of the volume.
+
+# Example
+There is an example of how to create a volume during the [Gluster.Next](https://www.youtube.com/watch?v=iBFfHv4bne8&t=2750) talk.
+
+# heketi-cli usage
+```
+Create a GlusterFS volume
+
+USAGE
+  heketi-cli volume create [options]
+
+OPTIONS
+  -clusters string
+    	
+	Optional: Comma separated list of cluster ids where this volume
+	must be allocated. If ommitted, Heketi will allocate the volume
+	on any of the configured clusters which have the available space.
+	Providing a set of clusters will ensure Heketi allocates storage
+	for this volume only in the clusters specified.
+  -disperse-data int
+    	
+	Optional: Dispersion value for durability type 'disperse'.
+	Default is 4 (default 4)
+  -durability string
+    	
+	Optional: Durability type.  Values are:
+		none: No durability.  Distributed volume only.
+		replicate: (Default) Distributed-Replica volume.
+		disperse: Distributed-Erasure Coded volume. (default "replicate")
+  -name string
+    	
+	Optional: Name of volume. Only set if really necessary
+  -redundancy int
+    	
+	Optional: Redundancy value for durability type 'disperse'.
+	Default is 2 (default 2)
+  -replica int
+    	
+	Replica value for durability type 'replicate'.
+	Default is 3 (default 3)
+  -size int
+    	
+	Size of volume in GB (default -1)
+  -snapshot-factor float
+    	
+	Optional: Amount of storage to allocate for snapshot support.
+	Must be greater 1.0.  For example if a 10TiB volume requires 5TiB of
+	snapshot storage, then snapshot-factor would be set to 1.5.  If the
+	value is set to 1, then snapshots will not be enabled for this volume (default 1)
+
+EXAMPLES
+  * Create a 100GB replica 3 volume:
+      $ heketi-cli volume create -size=100
+
+  * Create a 100GB replica 3 volume specifying two specific clusters:
+      $ heketi-cli volume create -size=100 \
+          -clusters=0995098e1284ddccb46c7752d142c832,60d46d518074b13a04ce1022c8c7193c
+
+  * Create a 100GB replica 2 volume with 50GB of snapshot storage:
+      $ heketi-cli volume create -size=100 -snapshot-factor=1.5 -replica=2 
+
+  * Create a 100GB distributed volume
+      $ heketi-cli volume create -size=100 -durabilty=none
+
+  * Create a 100GB erasure coded 4+2 volume with 25GB snapshot storage:
+      $ heketi-cli volume create -size=100 -durability=disperse -snapshot-factor=1.25
+
+  * Create a 100GB erasure coded 8+3 volume with 25GB snapshot storage:
+      $ heketi-cli volume create -size=100 -durability=disperse -snapshot-factor=1.25 \
+          -disperse-data=8 -redundancy=3
+```


### PR DESCRIPTION
First commit brings the files in, mostly as-is, but with file name simplifications.
Second commit cleans up broken links that I could find.