### PR TITLE
Remove erroneously committed binary, update gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ heketi-ci-docker.img
 
 # Generated files
 heketi
-client/cli/go/heketi-cli
+heketi-cli
 dist
 
 # Other


### PR DESCRIPTION
Fixing error in #864, updating the gitignore so it can't happen again.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>