### PR TITLE
add coverage tooling to test scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ log
 .vscode
 debug
 
+coverage
+packagecover.out
 .coverage
 .tox
 *.log

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ test: vendor glide.lock
 clean:
 	@echo Cleaning Workspace...
 	rm -rf $(APP_NAME)
-	rm -rf dist
+	rm -rf dist coverage packagecover.out
 	@$(MAKE) -C client/cli/go clean
 
 clean_vendor:

--- a/tests/100-gotest.sh
+++ b/tests/100-gotest.sh
@@ -2,16 +2,37 @@
 
 GOPACKAGES="$(go list ./... | grep -v vendor)"
 # no special options, exec to go test w/ all pkgs
-if [[ ${HEKETI_TEST_EXITFIRST} != "yes" ]]; then
+if [[ ${HEKETI_TEST_EXITFIRST} != "yes" && -z ${HEKETI_TEST_COVERAGE} ]]; then
 	exec go test ${GOPACKAGES}
 fi
 
 # our options are set so we need to handle each go package one
 # at at time
+if [[ ${HEKETI_TEST_COVERAGE} ]]; then
+	GOTESTOPTS="-covermode=count -coverprofile=cover.out"
+	COVERFILE=packagecover.out
+	echo "mode: count" > "${COVERFILE}"
+fi
+
 failed=0
 for gopackage in ${GOPACKAGES}; do
-	go test "$gopackage"
+	echo "--- testing: ${gopackage} ---"
+	go test ${GOTESTOPTS} "${gopackage}"
 	[ $? -ne 0 ] && ((failed+=1))
+	if [[ -f cover.out ]]; then
+		# Append to coverfile
+		grep -v "^mode: count" cover.out >> "${COVERFILE}"
+	fi
+	if [[ ${HEKETI_TEST_COVERAGE} = "stdout" && -f cover.out ]]; then
+		go tool cover -func=cover.out
+	fi
+	if [[ ${HEKETI_TEST_COVERAGE} = "html" && -f cover.out ]]; then
+		mkdir -p coverage
+		fn="coverage/$(echo "${gopackage}" | sed 's,/,-,g').html"
+		echo " * generating coverage html: ${fn}"
+		go tool cover -html=cover.out -o "${fn}"
+	fi
+	rm -f cover.out
 	if [[ ${failed} -ne 0 && ${HEKETI_TEST_EXITFIRST} = "yes" ]]; then
 		exit ${failed}
 	fi

--- a/tests/100-gotest.sh
+++ b/tests/100-gotest.sh
@@ -1,16 +1,16 @@
 #!/bin/sh
 
-GOFILES="$(go list ./... | grep -v vendor)"
+GOPACKAGES="$(go list ./... | grep -v vendor)"
 # no special options, exec to go test w/ all pkgs
 if [[ ${HEKETI_TEST_EXITFIRST} != "yes" ]]; then
-	exec go test ${GOFILES}
+	exec go test ${GOPACKAGES}
 fi
 
 # our options are set so we need to handle each go package one
 # at at time
 failed=0
-for gofile in ${GOFILES}; do
-	go test "${gofile}"
+for gopackage in ${GOPACKAGES}; do
+	go test "$gopackage"
 	[ $? -ne 0 ] && ((failed+=1))
 	if [[ ${failed} -ne 0 && ${HEKETI_TEST_EXITFIRST} = "yes" ]]; then
 		exit ${failed}


### PR DESCRIPTION
These changes:
* clean up some naming
* add coverage support to the test runner and gotests script which tries to mimic the behavior of .travis-coverage script in generating a coverage summary in addition to being able to generate coverage html files
* clean up generated files
* add .gitignore rules for generated files