### PR TITLE
Add make target for functional tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,9 @@ run: server
 test: vendor glide.lock
 	./test.sh $(TESTOPTIONS)
 
+test-functional: vendor glide.lock
+	$(MAKE) -C tests/functional test
+
 clean:
 	@echo Cleaning Workspace...
 	rm -rf $(APP_NAME)
@@ -149,4 +152,5 @@ release: deps_tarball darwin_amd64_dist linux_arm64_dist linux_arm_dist linux_am
 
 .PHONY: server client test clean name run version release \
 	darwin_amd64_dist linux_arm_dist linux_amd64_dist linux_arm64_dist \
-	heketi clean_vendor deps_tarball all dist
+	heketi clean_vendor deps_tarball all dist \
+	test-functional

--- a/tests/functional/Makefile
+++ b/tests/functional/Makefile
@@ -1,0 +1,4 @@
+test:
+	./run.sh
+
+.PHONY: test


### PR DESCRIPTION
This will allow us to remove the special knowledge about how to run the functional tests from the centos-ci integration at https://github.com/gluster/glusterfs-patch-acceptance-tests 