### PR TITLE
switch travis toolchain to call test suite

### DIFF
--- a/.travis-coverage
+++ b/.travis-coverage
@@ -1,40 +1,14 @@
 #!/bin/sh
 
-# We cannot use go test -coverprofile=cover.out ./... because
-# the tool requires that it be used only on one package when
-# capturing the coverage
-# This is why we need this little script here.
-packages="./apps/glusterfs"
-packages="${packages} ./executors/sshexec"
-packages="${packages} ./executors/mockexec"
-packages="${packages} ./executors/kubeexec"
-packages="${packages} ./client/api/go-client"
-packages="${packages} ./middleware"
-packages="${packages} ./pkg/utils"
 COVERFILE=packagecover.out
 
-coverage()
-{
-
-    echo "mode: count" > $COVERFILE
-    for pkg in $packages ; do
-        echo "-- Testing $pkg --"
-
-        # Collect coverage
-        go test -covermode=count -coverprofile=cover.out $pkg || exit 1
-
-        # Show in the command line
-        go tool cover -func=cover.out
-
-        # Append to coverfile
-        grep -v "^mode: count" cover.out >> $COVERFILE
-
-        # Cleanup
-        rm -f cover.out
-    done
-}
-
-coverage
+if [ ! -f "$COVERFILE" ]; then
+	echo "ERROR: coverfile missing!" >&2
+	echo "  - Either the coverfile [$COVERFILE] was not generated yet or"
+	echo "    the tests were run without coverage enabled."
+	echo "  - This script can not continue without the coverfile."
+	exit 1
+fi
 
 if [ -n "$COVERALLS_TOKEN" ] ; then
     # Send to coveralls.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,9 @@ matrix:
     env: COVERAGE="true"
 script:
 - go fmt $(go list ./... | grep -v vendor) | wc -l | grep 0
-- go vet $(go list ./... | grep -v vendor)
 - make
-- if [[ -z "$COVERAGE" ]]; then make test ; fi
-- if [[ -n "$COVERAGE" ]]; then bash .travis-coverage; fi
+- if [[ -z "$COVERAGE" ]]; then make test TESTOPTIONS=-v ; fi
+- if [[ -n "$COVERAGE" ]]; then make test TESTOPTIONS=-vcstdout && bash .travis-coverage; fi
 - make release
 - cd client/api/python
 - ./unittests.sh

--- a/tests/001-testtest.sh
+++ b/tests/001-testtest.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This "test" exists merely to exercise the test "framework"
 

--- a/tests/030-govet.sh
+++ b/tests/030-govet.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+GOPACKAGES="$(go list ./... | grep -v vendor)"
+exec go vet ${GOPACKAGES}

--- a/tests/100-gotest.sh
+++ b/tests/100-gotest.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 GOPACKAGES="$(go list ./... | grep -v vendor)"
 # no special options, exec to go test w/ all pkgs


### PR DESCRIPTION
The following changes:
* Reduce the travis coverage script to only reporting coverage to coveralls service
* take the last "special" travis task and converts it into a test script (go vet)
* Convert travis.yml to use the makefile/test suite

Two things I thought about doing but did not:
* Rename/move the travis coverage script to something more discover-able
* Handle the "go fmt" step as we are already discussing that stuff in another PR.

Let me know if we feel these are things we ought to do and if we should update this PR or just do a follow-on one.