### PR TITLE
extras: fix fromsource Dockerfile for current fedora (fix #923)

### DIFF
--- a/extras/docker/fromsource/Dockerfile
+++ b/extras/docker/fromsource/Dockerfile
@@ -13,21 +13,21 @@ ENV HEKETI_BRANCH="master"
 
 # install dependencies, build and cleanup
 RUN mkdir $BUILD_HOME $GOPATH && \
-    dnf -q -y install glide golang git && \
-    dnf -q -y install make && \
-    dnf -q -y clean all && \
+    dnf -y install glide golang git make && \
+    dnf -y clean all && \
     mkdir -p $GOPATH/src/github.com/heketi && \
     cd $GOPATH/src/github.com/heketi && \
     git clone -b $HEKETI_BRANCH https://github.com/heketi/heketi.git && \
     cd $GOPATH/src/github.com/heketi/heketi && \
-    glide install -v && make && \
+    glide install -v && \
+    make && \
     cp heketi /usr/bin/heketi && \
     cp client/cli/go/heketi-cli /usr/bin/heketi-cli && \
     glide cc && \
     cd && rm -rf $BUILD_HOME && \
-    dnf -q -y remove git glide golang make && \
-    dnf -q -y autoremove && \
-    dnf -q -y clean all
+    dnf -y remove git glide golang && \
+    dnf -y autoremove && \
+    dnf -y clean all
 
 # post install config and volume setup
 ADD ./heketi.json /etc/heketi/heketi.json


### PR DESCRIPTION
It appears that in f27 make has become a dependency of dnf.
The RUN line in the dockerfile was trying to remove make causing
dnf to exit nonzero and failing the build.

I broke up some of the multi-action lines so that its clearer
what steps are being taken. I also kept the instruction to
install make but combined it with the existing dnf install
line. Finally, I removed the -q from some of the dnf calls
as it was also supressing error output making the failure
very mysterious.

Signed-off-by: John Mulligan <jmulligan@redhat.com>