### PR TITLE
generally improve the kubernetes install admin doc

### DIFF
--- a/doc/admin/install-kubernetes.md
+++ b/doc/admin/install-kubernetes.md
@@ -2,11 +2,26 @@
 
 This guide enables the integration, deployment, and management of GlusterFS containerized storage nodes in a Kubernetes cluster. This enables Kubernetes administrators to provide their users with reliable, shared storage.
 
-There are other guides available, as well. The [gluster-kubernetes](https://github.com/gluster/gluster-kubernetes), includes a [setup guide](https://github.com/gluster/gluster-kubernetes/blob/master/docs/setup-guide.md) for running most of the directions in this guide through a deployment tool called [gk-deploy](https://github.com/gluster/gluster-kubernetes/blob/master/deploy/gk-deploy). It also includes a [Hello World](https://github.com/gluster/gluster-kubernetes/tree/master/docs/examples/hello_world) featuring an nginx pod using a dynamically-provisioned GlusterFS volume for storage. For those looking to test or play around with this quickly, follow the Quickstart instructions found in the main [README](https://github.com/gluster/gluster-kubernetes) for gluster-kubernetes
+Another important resource on this topic is the
+[gluster-kubernetes](https://github.com/gluster/gluster-kubernetes) project.
+It is focused on the deployment of GlusterFS within a Kubernetes cluster,
+and provides streamlined tools to accomplish this task.
+It includes a [setup guide](https://github.com/gluster/gluster-kubernetes/blob/master/docs/setup-guide.md).
+It also includes a [Hello World](https://github.com/gluster/gluster-kubernetes/tree/master/docs/examples/hello_world)
+featuring an example web server pod using a dynamically-provisioned
+GlusterFS volume for storage. For those looking to test or learn more about
+this topic, follow the Quick-start instructions found in the main
+[README](https://github.com/gluster/gluster-kubernetes) for gluster-kubernetes
+
+This guide is intended to demonstrate a minimal example of Heketi managing
+Gluster in a Kubernetes environment. It is meant to highlight the major
+components of this configuration and is not suitable for production.
 
 ## Infrastructure Requirements
 
-* A running Kubernetes cluster with at least three Kubernetes worker nodes that each have an available raw block device attached (like an EBS Volume or a local disk).
+* A running Kubernetes cluster with at least three Kubernetes worker nodes
+  that each have at least one available raw block device attached
+  (like an EBS Volume or a local disk).
 * The three Kubernetes nodes intended to run the GlusterFS Pods must have the appropriate ports opened for GlusterFS communication. Run the following commands on each of the nodes.
 ```
 iptables -N HEKETI
@@ -19,7 +34,10 @@ service iptables save
 
 ## Client Setup
 
-Heketi provides a CLI that provides users with a means to administer the deployment and configuration of GlusterFS in Kubernetes. [Download and install the heketi-cli](https://github.com/heketi/heketi/releases) on your client machine (usually your laptop).
+Heketi provides a CLI that provides users with a means to administer
+the deployment and configuration of GlusterFS in Kubernetes.
+[Download and install the heketi-cli](https://github.com/heketi/heketi/releases)
+on your client machine.
 
 ## Kubernetes Deployment
 All the following files are located under `extras/kubernetes`.
@@ -30,30 +48,57 @@ All the following files are located under `extras/kubernetes`.
 $ kubectl create -f glusterfs-daemonset.json
 ```
 
-* Get node name by running:
+* Get node names by running:
 
 ```
 $ kubectl get nodes
 ```
 
-* Deploy gluster container onto specified node by setting the label `storagenode=glusterfs` on that node
+* Deploy gluster container onto a specified node by setting the
+  label `storagenode=glusterfs` on that node.
 
 ```
 $ kubectl label node <...node...> storagenode=glusterfs
 ```
 
-Repeat as needed.  Verify that the pods are running on the nodes.
+Repeat as needed. Verify that the pods are running on the nodes, at least
+three pods should be running.
 
 ```
 $ kubectl get pods
 ```
 
-* Next we need to deploy the Pod and Service Heketi Service Interface to the GlusterFS cluster. In the repo you cloned, there will be a deploy-heketi-deployment.json file. 
+* Next we will create a service account for Heketi:
+
+```
+$ kubectl create -f heketi-service-account.json
+```
+
+* We must now establish the ability for that service account to control
+  the gluster pods. We do this by creating a cluster role binding for
+  our newly created service account.
+
+```
+$ kubectl create clusterrolebinding heketi-gluster-admin --clusterrole=edit --serviceaccount=default:heketi-service-account
+```
+
+* Now we need to create a Kubernetes secret that will hold the configuration
+  of our Heketi instance. The configuration file must be set to use the
+  `kubernetes` executor in order for the Heketi server to control the
+  gluster pods. Beyond that, feel free to experiment with the configuration
+  options.
+
+```
+$ kubectl create secret generic heketi-config-secret --from-file=./heketi.json
+```
+
+* Next we need to deploy an initial Pod and a Service to access that pod.
+  In the repo you cloned, there will be a heketi-bootstrap.json file.
 
 Submit the file and verify everything is running properly as demonstrated below:
 
 ```
-# kubectl create -f deploy-heketi-deployment.json 
+# kubectl create -f heketi-bootstrap.json
 service "deploy-heketi" created
 deployment "deploy-heketi" created
 
@@ -65,11 +110,19 @@ glusterfs-ip-172-20-0-218.ec2.internal-2001140516-i9dw9   1/1       Running   0 
 glusterfs-ip-172-20-0-219.ec2.internal-2785213222-q3hba   1/1       Running   0          1h
 ```
 
-* Now that the Bootstrap Heketi Service is running we are going to configure port-fowarding so that we can communicate with the service using the Heketi CLI. Using the name of the Heketi pod, run the command below:
+* Now that the Bootstrap Heketi Service is running we are going to configure port-forwarding so that we can communicate with the service using the Heketi CLI. Using the name of the Heketi pod, run the command below:
 
 `kubectl port-forward deploy-heketi-1211581626-2jotm :8080`
 
-Now verify that the port forwarding is working, by running a sample query againt the Heketi Service. The command should return a local port that it will be forwarding from. Incorporate that into a localhost query to test the service, as demonstrated below:
+If local port 8080 is free on the system where you are running the commands,
+you can run the port-forward command so that it binds to 8080 for convenience:
+
+`kubectl port-forward deploy-heketi-1211581626-2jotm 8080:8080`
+
+Now verify that port forwarding is working by running a sample query
+against the Heketi Service. The command should have printed the local port
+that it will be forwarding from. Incorporate that into a URL to test the
+service, as demonstrated below:
 
 ```
 curl http://localhost:57598/hello
@@ -81,11 +134,24 @@ Lastly, set an environment variable for the Heketi CLI client so that it knows h
 
 `export HEKETI_CLI_SERVER=http://localhost:57598`
 
-* Next we are going to provide Heketi with the information about the GlusterFS cluster it is to manage. We provide this information via [a topology file](./topology.md). There is a sample topology file within the repo you cloned called topology-sample.json. Topologies primarily specify what Kubernetes Nodes the GlusterFS containers are to run on as well as the corresponding available raw block device for each of the nodes.
+* Next we are going to provide Heketi with information about the GlusterFS
+  cluster it is to manage. We provide this information via
+  [a topology file](./topology.md). There is a sample topology file within
+  the repo you cloned called topology-sample.json. Topologies specify what
+  Kubernetes Nodes the GlusterFS containers are running on as well as the
+  corresponding raw block device for each of the nodes.
 
-> NOTE: Make sure that `hostnames/manage` points to the exact name as shown under `kubectl get nodes`, and `hostnames/storage` is the ip address of the storage network.
+  Make sure that `hostnames/manage` points to the exact name as shown
+  under `kubectl get nodes`, and `hostnames/storage` is the ip address
+  of the storage network.
 
-Modify the topology file to reflect the choices you have made and then deploy it as demonstrated below:
+  **IMPORTANT**: At this time, the topology file must be loaded using a version
+  of heketi-cli that matches the server version. As a last resort the Heketi
+  container comes with a copy of heketi-cli that can be accessed via
+  `kubectl exec ...`.
+
+  Modify the topology file to reflect the choices you have made and then
+  deploy it as demonstrated below:
 
 ```
 heketi-client/bin/heketi-cli topology load --json=topology-sample.json
@@ -98,27 +164,51 @@ Handling connection for 57598
 		Adding device /dev/xvdg ... OK
 ```
 
-* Next we are going to use Heketi to provision a volume for it to storage its database:
+* Next we are going to use Heketi to provision a volume for it to store its database:
 
 ```
 # heketi-client/bin/heketi-cli setup-openshift-heketi-storage
 # kubectl create -f heketi-storage.json
 ```
 
-Wait until the job is complete then delete the bootstrap Heketi:
+> Pitfall: If heketi-cli reports an error of "No space"
+  when running the setup-openshift-heketi-storage subcommand you may
+  have inadvertently run `topology load` with mismatched versions of the
+  server and heketi-cli. Stop the running Heketi pod
+  (`kubectl scale deployment deploy-heketi --replicas=0`), manually remove any
+  signatures from the storage block devices and then resume running a
+  Heketi pod (`kubectl scale deployment deploy-heketi --replicas=1`). Then
+  reload the topology with a matching version of heketi-cli and retry the step.
+
+* Wait until the job is complete then delete the bootstrap Heketi:
 
 ```
-# kubectl delete all,service,jobs,deployment,secret --selector="deploy-heketi" 
+# kubectl delete all,service,jobs,deployment,secret --selector="deploy-heketi"
 ```
 
-* Submit Heketi:
+* Create the long-term Heketi instance:
 
 ```
-# kubectl create -f heketi-deployment.json 
+# kubectl create -f heketi-deployment.json
 service "heketi" created
 deployment "heketi" created
 ```
 
+* Now that this is done the Heketi db will persist in a GlusterFS volume
+  and will not reset every time the Heketi pod is restarted.
+
+  Use commands such as `heketi-cli cluster list` and `heketi-cli volume list`
+  to confirm that the cluster established earlier exists and that
+  Heketi is aware of the db storage volume created during the bootstrapping
+  phase.
+
 # Usage Example
 
-There are two ways to provision storage.  The primary way is to setup StorageClass which lets Kubernetes automatically provision storage for an PersistentVolumeClaim submitted.  Another is to manually submit and create the volumes.
+There are two ways to provision storage. The common way is to setup a
+StorageClass which lets Kubernetes automatically provision storage for a
+PersistentVolumeClaim submitted. Alternatively one can manually create and
+manage volumes (PVs) through Kubernetes or work directly with volumes
+from heketi-cli.
+
+Please refer to the [gluster-kubernetes hello world example](https://github.com/gluster/gluster-kubernetes/blob/master/docs/examples/hello_world/README.md)
+for more information on storageClass configuration.

--- a/extras/kubernetes/glusterfs-daemonset.json
+++ b/extras/kubernetes/glusterfs-daemonset.json
@@ -26,7 +26,7 @@
                 "hostNetwork": true,
                 "containers": [
                     {
-                        "image": "heketi/gluster:latest",
+                        "image": "gluster/gluster-centos:latest",
                         "imagePullPolicy": "Always",
                         "name": "glusterfs",
                         "volumeMounts": [

--- a/extras/kubernetes/heketi-bootstrap.json
+++ b/extras/kubernetes/heketi-bootstrap.json
@@ -3,24 +3,10 @@
   "apiVersion": "v1",
   "items": [
     {
-      "kind": "Secret",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "heketi-db-backup",
-        "labels": {
-          "glusterfs": "heketi-db",
-          "heketi": "db"
-        }
-      },
-      "data": {
-      },
-      "type": "Opaque"
-    },
-    {
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "heketi",
+        "name": "deploy-heketi",
         "labels": {
           "glusterfs": "heketi-service",
           "deploy-heketi": "support"
@@ -31,11 +17,11 @@
       },
       "spec": {
         "selector": {
-          "name": "heketi"
+          "name": "deploy-heketi"
         },
         "ports": [
           {
-            "name": "heketi",
+            "name": "deploy-heketi",
             "port": 8080,
             "targetPort": 8080
           }
@@ -46,9 +32,10 @@
       "kind": "Deployment",
       "apiVersion": "extensions/v1beta1",
       "metadata": {
-        "name": "heketi",
+        "name": "deploy-heketi",
         "labels": {
-          "glusterfs": "heketi-deployment"
+          "glusterfs": "heketi-deployment",
+          "deploy-heketi": "deployment"
         },
         "annotations": {
           "description": "Defines how to deploy Heketi"
@@ -58,10 +45,11 @@
         "replicas": 1,
         "template": {
           "metadata": {
-            "name": "heketi",
+            "name": "deploy-heketi",
             "labels": {
-              "name": "heketi",
-              "glusterfs": "heketi-pod"
+              "name": "deploy-heketi",
+              "glusterfs": "heketi-pod",
+              "deploy-heketi": "pod"
             }
           },
           "spec": {
@@ -70,7 +58,7 @@
               {
                 "image": "heketi/heketi:dev",
                 "imagePullPolicy": "Always",
-                "name": "heketi",
+                "name": "deploy-heketi",
                 "env": [
                   {
                     "name": "HEKETI_EXECUTOR",
@@ -95,10 +83,6 @@
                   }
                 ],
                 "volumeMounts": [
-                  {
-                    "mountPath": "/backupdb",
-                    "name": "heketi-db-secret"
-                  },
                   {
                     "name": "db",
                     "mountPath": "/var/lib/heketi"
@@ -128,17 +112,7 @@
             ],
             "volumes": [
               {
-                "name": "db",
-                "glusterfs": {
-                  "endpoints": "heketi-storage-endpoints",
-                  "path": "heketidbstorage"
-                }
-              },
-              {
-                "name": "heketi-db-secret",
-                "secret": {
-                  "secretName": "heketi-db-backup"
-                }
+                "name": "db"
               },
               {
                 "name": "config",

--- a/extras/kubernetes/heketi.json
+++ b/extras/kubernetes/heketi.json
@@ -1,0 +1,44 @@
+{
+  "_port_comment": "Heketi Server Port Number",
+  "port": "8080",
+
+  "_use_auth": "Enable JWT authorization. Please enable for deployment",
+  "use_auth": false,
+
+  "_jwt": "Private keys for access",
+  "jwt": {
+    "_admin": "Admin has access to all APIs",
+    "admin": {
+      "key": "My Secret"
+    },
+    "_user": "User only has access to /volumes endpoint",
+    "user": {
+      "key": "My Secret"
+    }
+  },
+
+  "_glusterfs_comment": "GlusterFS Configuration",
+  "glusterfs": {
+    "_executor_comment": "Execute plugin. Possible choices: mock, kubernetes, ssh",
+    "executor": "kubernetes",
+
+    "_db_comment": "Database file name",
+    "db": "/var/lib/heketi/heketi.db",
+
+    "kubeexec": {
+      "rebalance_on_expansion": true
+    },
+
+    "sshexec": {
+      "rebalance_on_expansion": true,
+      "keyfile": "/etc/heketi/private_key",
+      "fstab": "/etc/fstab",
+      "port": "22",
+      "user": "root",
+      "sudo": false
+    }
+  },
+
+  "_backup_db_to_kube_secret": "Backup the heketi database to a Kubernetes secret when running in Kubernetes. Default is off.",
+  "backup_db_to_kube_secret": false
+}

--- a/extras/kubernetes/topology-sample.json
+++ b/extras/kubernetes/topology-sample.json
@@ -1,0 +1,62 @@
+{
+  "clusters": [
+    {
+      "nodes": [
+        {
+          "node": {
+            "hostnames": {
+              "manage": [
+                "node0"
+              ],
+              "storage": [
+                "192.168.10.100"
+              ]
+            },
+            "zone": 1
+          },
+          "devices": [
+            "/dev/vdb",
+            "/dev/vdc",
+            "/dev/vdd"
+          ]
+        },
+        {
+          "node": {
+            "hostnames": {
+              "manage": [
+                "node1"
+              ],
+              "storage": [
+                "192.168.10.101"
+              ]
+            },
+            "zone": 1
+          },
+          "devices": [
+            "/dev/vdb",
+            "/dev/vdc",
+            "/dev/vdd"
+          ]
+        },
+        {
+          "node": {
+            "hostnames": {
+              "manage": [
+                "node2"
+              ],
+              "storage": [
+                "192.168.10.102"
+              ]
+            },
+            "zone": 1
+          },
+          "devices": [
+            "/dev/vdb",
+            "/dev/vdc",
+            "/dev/vdd"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The install doc for kubernetes was out of date/wrong in various regards. This change improves the document so that it is more correct, more readable and has better wording.

One should now be able to run through the steps and have a working example/test environment using Heketi & Gluster under Kubrnetes.

If @jarrpa has some time to review this in addition to the usual folks, I'd appreciate it as it does overlap with gluster-kubernetes some. My aim here is to do a basic set up so people can see how heketi interacts with kubernetes and the gluster containers, not redo the stuff in g-k! :-)