### PR TITLE
Improve mentions of GB to state GiB

### DIFF
--- a/client/cli/go/cmds/block_volume.go
+++ b/client/cli/go/cmds/block_volume.go
@@ -37,7 +37,7 @@ func init() {
 	blockVolumeCommand.AddCommand(blockVolumeListCommand)
 
 	blockVolumeCreateCommand.Flags().IntVar(&bv_size, "size", -1,
-		"\n\tSize of volume in GB")
+		"\n\tSize of volume in GiB")
 	blockVolumeCreateCommand.Flags().IntVar(&bv_ha, "ha", 0,
 		"\n\tHA count for block volume")
 	blockVolumeCreateCommand.Flags().BoolVar(&bv_auth, "auth", false,
@@ -66,18 +66,18 @@ var blockVolumeCreateCommand = &cobra.Command{
 	Use:   "create",
 	Short: "Create a GlusterFS block volume",
 	Long:  "Create a GlusterFS block volume",
-	Example: `  * Create a 100GB block volume
+	Example: `  * Create a 100GiB block volume
       $ heketi-cli blockvolume create --size=100
 
-  * Create a 100GB block volume specifying two specific clusters:
+  * Create a 100GiB block volume specifying two specific clusters:
       $ heketi-cli blockvolume create --size=100 \
         --clusters=0995098e1284ddccb46c7752d142c832,60d46d518074b13a04ce1022c8c7193c
 
-  * Create a 100GB block volume requesting ha count to be 2.
+  * Create a 100GiB block volume requesting ha count to be 2.
     (Otherwise HA count is all the nodes on which block hosting volume reside.):
 	  $ heketi-cli blockvolume create --size=100 --ha=2
 
-  * Create a 100GB block volume specifying two specific clusters auth enabled:
+  * Create a 100GiB block volume specifying two specific clusters auth enabled:
       $ heketi-cli blockvolume create --size=100 --auth \
         --clusters=0995098e1284ddccb46c7752d142c832,60d46d518074b13a04ce1022c8c7193c
 `,

--- a/client/cli/go/cmds/volume.go
+++ b/client/cli/go/cmds/volume.go
@@ -50,7 +50,7 @@ func init() {
 	volumeCommand.AddCommand(volumeListCommand)
 
 	volumeCreateCommand.Flags().IntVar(&size, "size", -1,
-		"\n\tSize of volume in GB")
+		"\n\tSize of volume in GiB")
 	volumeCreateCommand.Flags().Int64Var(&gid, "gid", 0,
 		"\n\tOptional: Initialize volume with the specified group id")
 	volumeCreateCommand.Flags().StringVar(&volname, "name", "",
@@ -92,7 +92,7 @@ func init() {
 	volumeCreateCommand.Flags().StringVar(&kubePvEndpoint, "persistent-volume-endpoint", "",
 		"\n\tOptional: Endpoint name for the persistent volume")
 	volumeExpandCommand.Flags().IntVar(&expandSize, "expand-size", -1,
-		"\n\tAmount in GB to add to the volume")
+		"\n\tAmount in GiB to add to the volume")
 	volumeExpandCommand.Flags().StringVar(&id, "volume", "",
 		"\n\tId of volume to expand")
 	volumeCreateCommand.Flags().BoolVar(&block, "block", false,
@@ -115,27 +115,27 @@ var volumeCreateCommand = &cobra.Command{
 	Use:   "create",
 	Short: "Create a GlusterFS volume",
 	Long:  "Create a GlusterFS volume",
-	Example: `  * Create a 100GB replica 3 volume:
+	Example: `  * Create a 100GiB replica 3 volume:
       $ heketi-cli volume create --size=100
 
-  * Create a 100GB replica 3 volume specifying two specific clusters:
+  * Create a 100GiB replica 3 volume specifying two specific clusters:
       $ heketi-cli volume create --size=100 \
         --clusters=0995098e1284ddccb46c7752d142c832,60d46d518074b13a04ce1022c8c7193c
 
-  * Create a 100GB replica 2 volume with 50GB of snapshot storage:
+  * Create a 100GiB replica 2 volume with 50GiB of snapshot storage:
       $ heketi-cli volume create --size=100 --snapshot-factor=1.5 --replica=2
 
-  * Create a 100GB distributed volume
+  * Create a 100GiB distributed volume
       $ heketi-cli volume create --size=100 --durability=none
 
-  * Create a 100GB erasure coded 4+2 volume with 25GB snapshot storage:
+  * Create a 100GiB erasure coded 4+2 volume with 25GiB snapshot storage:
       $ heketi-cli volume create --size=100 --durability=disperse --snapshot-factor=1.25
 
-  * Create a 100GB erasure coded 8+3 volume with 25GB snapshot storage:
+  * Create a 100GiB erasure coded 8+3 volume with 25GiB snapshot storage:
       $ heketi-cli volume create --size=100 --durability=disperse --snapshot-factor=1.25 \
         --disperse-data=8 --redundancy=3
 
-  * Create a 100GB distributed volume which supports performance related volume options.
+  * Create a 100GiB distributed volume which supports performance related volume options.
       $ heketi-cli volume create --size=100 --durability=none --gluster-volume-options="performance.rda-cache-limit 10MB","performance.nl-cache-positive-entry no"
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -266,7 +266,7 @@ var volumeExpandCommand = &cobra.Command{
 	Use:   "expand",
 	Short: "Expand a volume",
 	Long:  "Expand a volume",
-	Example: `  * Add 10GB to a volume
+	Example: `  * Add 10GiB to a volume
     $ heketi-cli volume expand --volume=60d46d518074b13a04ce1022c8c7193c --expand-size=10
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/doc/admin/volume.md
+++ b/doc/admin/volume.md
@@ -49,7 +49,7 @@ OPTIONS
 	Default is 3 (default 3)
   -size int
     	
-	Size of volume in GB (default -1)
+	Size of volume in GiB (default -1)
   -snapshot-factor float
     	
 	Optional: Amount of storage to allocate for snapshot support.
@@ -58,23 +58,23 @@ OPTIONS
 	value is set to 1, then snapshots will not be enabled for this volume (default 1)
 
 EXAMPLES
-  * Create a 100GB replica 3 volume:
+  * Create a 100GiB replica 3 volume:
       $ heketi-cli volume create -size=100
 
-  * Create a 100GB replica 3 volume specifying two specific clusters:
+  * Create a 100GiB replica 3 volume specifying two specific clusters:
       $ heketi-cli volume create -size=100 \
           -clusters=0995098e1284ddccb46c7752d142c832,60d46d518074b13a04ce1022c8c7193c
 
-  * Create a 100GB replica 2 volume with 50GB of snapshot storage:
+  * Create a 100GiB replica 2 volume with 50GiB of snapshot storage:
       $ heketi-cli volume create -size=100 -snapshot-factor=1.5 -replica=2 
 
-  * Create a 100GB distributed volume
+  * Create a 100GiB distributed volume
       $ heketi-cli volume create -size=100 -durabilty=none
 
-  * Create a 100GB erasure coded 4+2 volume with 25GB snapshot storage:
+  * Create a 100GiB erasure coded 4+2 volume with 25GiB snapshot storage:
       $ heketi-cli volume create -size=100 -durability=disperse -snapshot-factor=1.25
 
-  * Create a 100GB erasure coded 8+3 volume with 25GB snapshot storage:
+  * Create a 100GiB erasure coded 8+3 volume with 25GiB snapshot storage:
       $ heketi-cli volume create -size=100 -durability=disperse -snapshot-factor=1.25 \
           -disperse-data=8 -redundancy=3
 ```

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -451,7 +451,7 @@ These APIs inform Heketi to create a network file system of a certain size avail
 * **Response HTTP Status Code**: 202, See [Asynchronous Operations](#async)
 * **Temporary Resource Response HTTP Status Code**: 303, `Location` header will contain `/volumes/{id}`. See [Volume Info](#volume_info) for JSON response.
 * **JSON Request**:
-    * size: _int_, Size of volume requested in GB
+    * size: _int_, Size of volume requested in GiB
     * name: _string_, _optional_, Name of volume.  If not provided, the name of the volume will be `vol_{id}`, for example `vol_728faa5522838746abce2980`
     * durability: _map_, _optional_, Durability Settings
         * type: _string_, optional, Durability type.  Choices are **none** (Distributed Only), **replicate** (Distributed-Replicated), **disperse** (Distributed-Disperse).  If omitted, durability type will default to **none**.
@@ -495,7 +495,7 @@ These APIs inform Heketi to create a network file system of a certain size avail
 * **JSON Request**: None
 * **JSON Response**:
     * name: _string_, Name of volume
-    * size: _int_, Size of volume in GB
+    * size: _int_, Size of volume in GiB
     * id: _string_, Volume UUID
     * cluster: _string_, UUID of cluster which contains this volume
     * durability: _map_, Durability settings.  See [Volume Create](#volume_create) for more information.
@@ -562,7 +562,7 @@ New volume size will be reflected in the volume information.
 * **Response HTTP Status Code**: 202, See [Asynchronous Operations](#async)
 * **Temporary Resource Response HTTP Status Code**: 303, `Location` header will contain `/volumes/{id}`. See [Volume Info](#volume_info) for JSON response.
 * **JSON Request**:
-    * expand_size: _int_, Amount of storage to add to the existing volume in GB
+    * expand_size: _int_, Amount of storage to add to the existing volume in GiB
 
 ```json
 { "expand_size" : 1000000 }

--- a/doc/man/heketi-cli.8
+++ b/doc/man/heketi-cli.8
@@ -333,7 +333,7 @@ Create a GlusterFS volume
 .PP
 .RS
 .nf
-            Size of volume in GB
+            Size of volume in GiB
 .fi
 .RE
 .PP
@@ -350,18 +350,18 @@ Create a GlusterFS volume
 
 
     \fB       Example\fP
-           * Create a 100GB replica 3 volume:
+           * Create a 100GiB replica 3 volume:
                  $ heketi\-cli volume create \-\-size=100
-           * Create a 100GB replica 3 volume specifying two specific clusters:
+           * Create a 100GiB replica 3 volume specifying two specific clusters:
                  $ heketi\-cli volume create \-\-size=100 \\
                  \-\-clusters=0995098e1284ddccb46c7752d142c832,60d46d518074b13a04ce1022c8c7193c
-           * Create a 100GB replica 2 volume with 50GB of snapshot storage:
+           * Create a 100GiB replica 2 volume with 50GiB of snapshot storage:
                  $ heketi\-cli volume create \-\-size=100 \-\-snapshot\-factor=1.5 \-\-replica=2
-           * Create a 100GB distributed volume
+           * Create a 100GiB distributed volume
                  $ heketi\-cli volume create \-\-size=100 \-\-durability=none
-           * Create a 100GB erasure coded 4+2 volume with 25GB snapshot storage:
+           * Create a 100GiB erasure coded 4+2 volume with 25GiB snapshot storage:
                  $ heketi\-cli volume create \-\-size=100 \-\-durability=disperse \-\-snapshot\-factor=1.25
-           * Create a 100GB erasure coded 8+3 volume with 25GB snapshot storage:
+           * Create a 100GiB erasure coded 8+3 volume with 25GiB snapshot storage:
                  $ heketi\-cli volume create \-\-size=100 \-\-durability=disperse \-\-snapshot\-factor=1.25 \\
                  \-\-disperse\-data=8 \-\-redundancy=3
 
@@ -383,14 +383,14 @@ Expand a volume
 \fB           Options\fP
 .PP
 \fB               \-\-expand\fP=""
-                   Amount in GB to add to the volume
+                   Amount in GiB to add to the volume
 .PP
 \fB               \-\-volume\fP=""
                     Id of volume to expand
 
 
 \fB           Example\fP
-               * Add 10GB to a volume
+               * Add 10GiB to a volume
                      $ heketi\-cli volume expand \-\-volume=60d46d518074b13a04ce1022c8c7193c \-\-expand\-size=10
 
 .PP

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -7,7 +7,7 @@ Troubleshooting Guide
 
 1. Error "Unable to open topology file":
     * You use old syntax of single '-' as prefix for json option. Solution: Use new syntax of double hyphens.
-1. Cannot create volumes smaller than 4GB:
+1. Cannot create volumes smaller than 4GiB:
     * This is due to the limits set in Heketi.  If you want to change the limits, please update the config file using the [advanced settings](admin/server.md#advanced-options).  If you are using Heketi as a container, then you must create a new container based on Heketi which just updates the config file `/etc/heketi/heketi.json`.
 
 ## Management

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -157,7 +157,7 @@ type VolumeDurabilityInfo struct {
 }
 
 type VolumeCreateRequest struct {
-	// Size in GB
+	// Size in GiB
 	Size                 int                  `json:"size"`
 	Clusters             []string             `json:"clusters,omitempty"`
 	Name                 string               `json:"name"`
@@ -204,7 +204,7 @@ type VolumeExpandRequest struct {
 // BlockVolume
 
 type BlockVolumeCreateRequest struct {
-	// Size in GB
+	// Size in GiB
 	Size     int      `json:"size"`
 	Clusters []string `json:"clusters,omitempty"`
 	Name     string   `json:"name"`


### PR DESCRIPTION
Be more precise of what unit of storage we actually use.
GB is interpreted as (1000)^3 by many people.

Resolves: #915 