### PR TITLE
executor:block: explicitly use GiB in gluster-block volume create

### DIFF
--- a/executors/sshexec/block_volume.go
+++ b/executors/sshexec/block_volume.go
@@ -42,7 +42,7 @@ func (s *SshExecutor) BlockVolumeCreate(host string,
 		auth_set = "disable"
 	}
 
-	cmd := fmt.Sprintf("gluster-block create %v/%v  ha %v auth %v prealloc full %v %vG --json",
+	cmd := fmt.Sprintf("gluster-block create %v/%v  ha %v auth %v prealloc full %v %vGiB --json",
 		volume.GlusterVolumeName, volume.Name, volume.Hacount, auth_set, strings.Join(volume.BlockHosts, ","), volume.Size)
 
 	// Initialize the commands with the create command


### PR DESCRIPTION
G is interpreted by gluster-block as GiB.
So be more explicit about it.

Signed-off-by: Michael Adam <obnox@redhat.com>