### PR TITLE
app: use heketi/heketi/pkg/utils instead of heketi/utils

### DIFF
--- a/apps/glusterfs/app_block_volume_test.go
+++ b/apps/glusterfs/app_block_volume_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/boltdb/bolt"
 	"github.com/gorilla/mux"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/heketi/pkg/utils"
 	"github.com/heketi/tests"
-	"github.com/heketi/utils"
 )
 
 func TestBlockVolumeCreateBadJson(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Michael Adam <obnox@redhat.com>