### PR TITLE
app:glusterfs:volume_entry: save bricks to db after creation

### DIFF
--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -385,6 +385,22 @@ func (v *VolumeEntry) Create(db *bolt.DB,
 		}
 	}()
 
+	// Save updated bricks (the have a path now)
+	err = db.Update(func(tx *bolt.Tx) error {
+		// Save brick entries
+		for _, brick := range brick_entries {
+			err := brick.Save(tx)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
 	// Create GlusterFS volume
 	err = v.createVolume(db, executor, brick_entries)
 	if err != nil {


### PR DESCRIPTION
The bricks have been given a path in the CreateBricks
function, but this is not yet stored in the DB. Store it.
This will reduce the chance of seeing invalid brick entries
without a path.

Note this is a temporary fix, since we're about to change
the way this code works.

Pair-Programmed-With: Raghavendra Talur <rtalur@redhat.com>

Signed-off-by: Michael Adam <obnox@redhat.com>
Signed-off-by: Raghavendra Talur <rtalur@redhat.com>