### PR TITLE
executors: predetermine the brick paths

### DIFF
--- a/apps/glusterfs/brick_entry.go
+++ b/apps/glusterfs/brick_entry.go
@@ -152,6 +152,7 @@ func (b *BrickEntry) Create(db *bolt.DB, executor executors.Executor) error {
 	req.TpSize = b.TpSize
 	req.VgId = b.Info.DeviceId
 	req.PoolMetadataSize = b.PoolMetadataSize
+	req.Path = utils.BrickMountPoint(req.VgId, req.Name)
 
 	// Create brick on node
 	logger.Info("Creating brick %v", b.Info.Id)
@@ -194,6 +195,7 @@ func (b *BrickEntry) Destroy(db *bolt.DB, executor executors.Executor) error {
 	req.Size = b.Info.Size
 	req.TpSize = b.TpSize
 	req.VgId = b.Info.DeviceId
+	req.Path = utils.BrickMountPoint(req.VgId, req.Name)
 
 	// Delete brick on node
 	logger.Info("Deleting brick %v", b.Info.Id)
@@ -232,6 +234,7 @@ func (b *BrickEntry) DestroyCheck(db *bolt.DB, executor executors.Executor) erro
 	req.Size = b.Info.Size
 	req.TpSize = b.TpSize
 	req.VgId = b.Info.DeviceId
+	req.Path = utils.BrickMountPoint(req.VgId, req.Name)
 
 	// Check brick on node
 	return executor.BrickDestroyCheck(host, req)

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -57,6 +57,8 @@ type BrickRequest struct {
 	Size             uint64
 	PoolMetadataSize uint64
 	Gid              int64
+	// Path is the brick mountpoint (named Path for symmetry with BrickInfo)
+	Path string
 }
 
 // Returns information about the location of the brick

--- a/executors/sshexec/brick.go
+++ b/executors/sshexec/brick.go
@@ -14,25 +14,9 @@ import (
 	"strings"
 
 	"github.com/heketi/heketi/executors"
+	"github.com/heketi/heketi/pkg/utils"
 	"github.com/lpabon/godbc"
 )
-
-const (
-	rootMountPoint = "/var/lib/heketi/mounts"
-)
-
-// Return the mount point for the brick
-func (s *SshExecutor) brickMountPoint(brick *executors.BrickRequest) string {
-	return rootMountPoint + "/" +
-		s.vgName(brick.VgId) + "/" +
-		s.brickName(brick.Name)
-}
-
-// Device node for the lvm volume
-func (s *SshExecutor) devnode(brick *executors.BrickRequest) string {
-	return "/dev/mapper/" + s.vgName(brick.VgId) +
-		"-" + s.brickName(brick.Name)
-}
 
 func (s *SshExecutor) BrickCreate(host string,
 	brick *executors.BrickRequest) (*executors.BrickInfo, error) {
@@ -43,16 +27,15 @@ func (s *SshExecutor) BrickCreate(host string,
 	godbc.Require(brick.Size > 0)
 	godbc.Require(brick.TpSize >= brick.Size)
 	godbc.Require(brick.VgId != "")
+	godbc.Require(brick.Path != "")
 	godbc.Require(s.Fstab != "")
 
-	// Create mountpoint name
-	mountpoint := s.brickMountPoint(brick)
-
 	// Create command set to execute on the node
+	devnode := utils.BrickDevNode(brick.VgId, brick.Name)
 	commands := []string{
 
 		// Create a directory
-		fmt.Sprintf("mkdir -p %v", mountpoint),
+		fmt.Sprintf("mkdir -p %v", brick.Path),
 
 		// Setup the LV
 		fmt.Sprintf("lvcreate --poolmetadatasize %vK -c 256K -L %vK -T %v/%v -V %vK -n %v",
@@ -63,31 +46,31 @@ func (s *SshExecutor) BrickCreate(host string,
 			brick.TpSize,
 
 			// volume group
-			s.vgName(brick.VgId),
+			utils.VgIdToName(brick.VgId),
 
 			// ThinP name
-			s.tpName(brick.Name),
+			utils.BrickIdToThinPoolName(brick.Name),
 
 			// Allocation size
 			brick.Size,
 
 			// Logical Vol name
-			s.brickName(brick.Name)),
+			utils.BrickIdToName(brick.Name)),
 
 		// Format
-		fmt.Sprintf("mkfs.xfs -i size=512 -n size=8192 %v", s.devnode(brick)),
+		fmt.Sprintf("mkfs.xfs -i size=512 -n size=8192 %v", devnode),
 
 		// Fstab
 		fmt.Sprintf("echo \"%v %v xfs rw,inode64,noatime,nouuid 1 2\" | tee -a %v > /dev/null ",
-			s.devnode(brick),
-			mountpoint,
+			devnode,
+			brick.Path,
 			s.Fstab),
 
 		// Mount
-		fmt.Sprintf("mount -o rw,inode64,noatime,nouuid %v %v", s.devnode(brick), mountpoint),
+		fmt.Sprintf("mount -o rw,inode64,noatime,nouuid %v %v", devnode, brick.Path),
 
 		// Create a directory inside the formated volume for GlusterFS
-		fmt.Sprintf("mkdir %v/brick", mountpoint),
+		fmt.Sprintf("mkdir %v/brick", brick.Path),
 	}
 
 	// Only set the GID if the value is other than root(gid 0).
@@ -95,10 +78,10 @@ func (s *SshExecutor) BrickCreate(host string,
 	if 0 != brick.Gid {
 		commands = append(commands, []string{
 			// Set GID on brick
-			fmt.Sprintf("chown :%v %v/brick", brick.Gid, mountpoint),
+			fmt.Sprintf("chown :%v %v/brick", brick.Gid, brick.Path),
 
 			// Set writable by GID and UID
-			fmt.Sprintf("chmod 2775 %v/brick", mountpoint),
+			fmt.Sprintf("chmod 2775 %v/brick", brick.Path),
 		}...)
 	}
 
@@ -112,7 +95,7 @@ func (s *SshExecutor) BrickCreate(host string,
 
 	// Save brick location
 	b := &executors.BrickInfo{
-		Path: fmt.Sprintf("%v/brick", mountpoint),
+		Path: fmt.Sprintf("%v/brick", brick.Path),
 	}
 	return b, nil
 }
@@ -125,9 +108,10 @@ func (s *SshExecutor) BrickDestroy(host string,
 	godbc.Require(brick.Name != "")
 	godbc.Require(brick.VgId != "")
 
+	mp := utils.BrickMountPoint(brick.VgId, brick.Name)
 	// Try to unmount first
 	commands := []string{
-		fmt.Sprintf("umount %v", s.brickMountPoint(brick)),
+		fmt.Sprintf("umount %v", mp),
 	}
 	_, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 5)
 	if err != nil {
@@ -136,7 +120,7 @@ func (s *SshExecutor) BrickDestroy(host string,
 
 	// Now try to remove the LV
 	commands = []string{
-		fmt.Sprintf("lvremove -f %v/%v", s.vgName(brick.VgId), s.tpName(brick.Name)),
+		fmt.Sprintf("lvremove -f %v", utils.BrickThinLvName(brick.VgId, brick.Name)),
 	}
 	_, err = s.RemoteExecutor.RemoteCommandExecute(host, commands, 5)
 	if err != nil {
@@ -145,7 +129,7 @@ func (s *SshExecutor) BrickDestroy(host string,
 
 	// Now cleanup the mount point
 	commands = []string{
-		fmt.Sprintf("rmdir %v", s.brickMountPoint(brick)),
+		fmt.Sprintf("rmdir %v", mp),
 	}
 	_, err = s.RemoteExecutor.RemoteCommandExecute(host, commands, 5)
 	if err != nil {
@@ -155,7 +139,7 @@ func (s *SshExecutor) BrickDestroy(host string,
 	// Remove from fstab
 	commands = []string{
 		fmt.Sprintf("sed -i.save \"/%v/d\" %v",
-			s.brickName(brick.Name),
+			utils.BrickIdToName(brick.Name),
 			s.Fstab),
 	}
 	_, err = s.RemoteExecutor.RemoteCommandExecute(host, commands, 5)
@@ -193,7 +177,7 @@ func (s *SshExecutor) checkThinPoolUsage(host string,
 	// 		tp_8d4e0849a5c90608a543928961bd2387:1
 	//		tp_3b9b3e07f06b93d94006ef272d3c10eb:2
 
-	tp := s.tpName(brick.Name)
+	tp := utils.BrickIdToThinPoolName(brick.Name)
 	commands := []string{
 		fmt.Sprintf("lvs --options=lv_name,thin_count --separator=:"),
 	}

--- a/executors/sshexec/brick_test.go
+++ b/executors/sshexec/brick_test.go
@@ -46,6 +46,7 @@ func TestSshExecBrickCreate(t *testing.T) {
 		TpSize:           100,
 		Size:             10,
 		PoolMetadataSize: 5,
+		Path:             utils.BrickMountPoint("xvgid", "id"),
 	}
 
 	// Mock ssh function
@@ -132,6 +133,7 @@ func TestSshExecBrickCreateWithGid(t *testing.T) {
 		Size:             10,
 		PoolMetadataSize: 5,
 		Gid:              1234,
+		Path:             utils.BrickMountPoint("xvgid", "id"),
 	}
 
 	// Mock ssh function
@@ -228,6 +230,7 @@ func TestSshExecBrickCreateSudo(t *testing.T) {
 		TpSize:           100,
 		Size:             10,
 		PoolMetadataSize: 5,
+		Path:             utils.BrickMountPoint("xvgid", "id"),
 	}
 
 	// Mock ssh function
@@ -314,6 +317,7 @@ func TestSshExecBrickDestroy(t *testing.T) {
 		TpSize:           100,
 		Size:             10,
 		PoolMetadataSize: 5,
+		Path:             utils.BrickMountPoint("xvgid", "id"),
 	}
 
 	// Mock ssh function

--- a/executors/sshexec/device.go
+++ b/executors/sshexec/device.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/heketi/heketi/executors"
+	"github.com/heketi/heketi/pkg/utils"
 )
 
 const (
@@ -35,7 +36,7 @@ func (s *SshExecutor) DeviceSetup(host, device, vgid string) (d *executors.Devic
 	// Setup commands
 	commands := []string{
 		fmt.Sprintf("pvcreate --metadatasize=128M --dataalignment=256K '%v'", device),
-		fmt.Sprintf("vgcreate %v %v", s.vgName(vgid), device),
+		fmt.Sprintf("vgcreate %v %v", utils.VgIdToName(vgid), device),
 	}
 
 	// Execute command
@@ -68,7 +69,7 @@ func (s *SshExecutor) DeviceTeardown(host, device, vgid string) error {
 
 	// Setup commands
 	commands := []string{
-		fmt.Sprintf("vgremove %v", s.vgName(vgid)),
+		fmt.Sprintf("vgremove %v", utils.VgIdToName(vgid)),
 		fmt.Sprintf("pvremove '%v'", device),
 	}
 
@@ -79,8 +80,9 @@ func (s *SshExecutor) DeviceTeardown(host, device, vgid string) error {
 			device, vgid, host, err)
 	}
 
+	pdir := utils.BrickMountPointParent(vgid)
 	commands = []string{
-		fmt.Sprintf("ls %v/%v", rootMountPoint, s.vgName(vgid)),
+		fmt.Sprintf("ls %v", pdir),
 	}
 	_, err = s.RemoteExecutor.RemoteCommandExecute(host, commands, 5)
 	if err != nil {
@@ -88,7 +90,7 @@ func (s *SshExecutor) DeviceTeardown(host, device, vgid string) error {
 	}
 
 	commands = []string{
-		fmt.Sprintf("rmdir %v/%v", rootMountPoint, s.vgName(vgid)),
+		fmt.Sprintf("rmdir %v", pdir),
 	}
 
 	_, err = s.RemoteExecutor.RemoteCommandExecute(host, commands, 5)
@@ -106,7 +108,7 @@ func (s *SshExecutor) getVgSizeFromNode(
 
 	// Setup command
 	commands := []string{
-		fmt.Sprintf("vgdisplay -c %v", s.vgName(vgid)),
+		fmt.Sprintf("vgdisplay -c %v", utils.VgIdToName(vgid)),
 	}
 
 	// Execute command

--- a/executors/sshexec/sshexec.go
+++ b/executors/sshexec/sshexec.go
@@ -203,18 +203,6 @@ func (s *SshExecutor) RemoteCommandExecute(host string,
 	return s.exec.ConnectAndExec(host+":"+s.port, commands, timeoutMinutes, s.config.Sudo)
 }
 
-func (s *SshExecutor) vgName(vgId string) string {
-	return "vg_" + vgId
-}
-
-func (s *SshExecutor) brickName(brickId string) string {
-	return "brick_" + brickId
-}
-
-func (s *SshExecutor) tpName(brickId string) string {
-	return "tp_" + brickId
-}
-
 func (s *SshExecutor) RebalanceOnExpansion() bool {
 	return s.config.RebalanceOnExpansion
 }

--- a/pkg/utils/paths.go
+++ b/pkg/utils/paths.go
@@ -1,0 +1,70 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package utils
+
+import (
+	"path"
+)
+
+const (
+	brickMountPointRoot = "/var/lib/heketi/mounts"
+	deviceMapperRoot    = "/dev/mapper"
+)
+
+// VgIdToName return the string to be used for the name of
+// an LVM VG given the id of the vg.
+func VgIdToName(vgId string) string {
+	return "vg_" + vgId
+}
+
+// BrickIdToName returns the string to be used for the
+// name of the brick when used in paths or lvm device names.
+func BrickIdToName(brickId string) string {
+	return "brick_" + brickId
+}
+
+// BrickIdToThinPoolName returns the string to be used for
+// a LVM thin-pool name for a given brick id.
+func BrickIdToThinPoolName(brickId string) string {
+	return "tp_" + brickId
+}
+
+// BrickMountPoint returns the path of a directory
+// where a brick is to be mounted.
+func BrickMountPoint(vgId, brickId string) string {
+	return path.Join(
+		brickMountPointRoot,
+		VgIdToName(vgId),
+		BrickIdToName(brickId))
+}
+
+// BrickMountPointParent returns the path of the parent
+// directory where a brick is to be mounted.
+func BrickMountPointParent(vgId string) string {
+	return path.Join(
+		brickMountPointRoot,
+		VgIdToName(vgId))
+}
+
+// BrickThinLvName returns the name of the thin-pool LV
+// for a brick.
+func BrickThinLvName(vgId, brickId string) string {
+	return path.Join(
+		VgIdToName(vgId),
+		BrickIdToThinPoolName(brickId))
+}
+
+// BrickDevNode returns the path to the device node
+// managed by LVM/device-mapper for a brick.
+func BrickDevNode(vgId, brickId string) string {
+	return path.Join(
+		deviceMapperRoot,
+		VgIdToName(vgId)+"-"+BrickIdToName(brickId))
+}

--- a/pkg/utils/paths_test.go
+++ b/pkg/utils/paths_test.go
@@ -1,0 +1,69 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/heketi/tests"
+)
+
+func TestVgIdToName(t *testing.T) {
+	expected := "vg_asdf"
+	result := VgIdToName("asdf")
+	tests.Assert(t, expected == result,
+		`calling VgIdToName("asdf"), expected`, expected, "got", result)
+}
+
+func TestBrickIdToName(t *testing.T) {
+	expected := "brick_fireplace"
+	result := BrickIdToName("fireplace")
+	tests.Assert(t, expected == result,
+		`calling BrickIdToName("fireplace"), expected`, expected, "got", result)
+}
+
+func TestBrickIdToThinPoolName(t *testing.T) {
+	expected := "tp_123456"
+	result := BrickIdToThinPoolName("123456")
+	tests.Assert(t, expected == result,
+		`calling BrickIdToThinPoolName("123456"), expected`, expected, "got", result)
+}
+
+func TestBrickMountPoint(t *testing.T) {
+	expected := "/var/lib/heketi/mounts/vg_asdf/brick_fireplace"
+	result := BrickMountPoint("asdf", "fireplace")
+	tests.Assert(t, expected == result,
+		`calling BrickMountPoint("asdf", "fireplace"), expected`,
+		expected, "got", result)
+}
+
+func TestBrickMountPointParent(t *testing.T) {
+	expected := "/var/lib/heketi/mounts/vg_asdf"
+	result := BrickMountPointParent("asdf")
+	tests.Assert(t, expected == result,
+		`calling BrickMountPointParent("asdf"), expected`,
+		expected, "got", result)
+}
+
+func TestBrickThinLvName(t *testing.T) {
+	expected := "vg_asdf/tp_fireplace"
+	result := BrickThinLvName("asdf", "fireplace")
+	tests.Assert(t, expected == result,
+		`calling BrickThinLvName("asdf", "fireplace"), expected`,
+		expected, "got", result)
+}
+
+func TestBrickDevNode(t *testing.T) {
+	expected := "/dev/mapper/vg_asdf-brick_fireplace"
+	result := BrickDevNode("asdf", "fireplace")
+	tests.Assert(t, expected == result,
+		`calling BrickDevNode("asdf", "fireplace"), expected`,
+		expected, "got", result)
+}


### PR DESCRIPTION
Traditionally, Heketi has been letting the executor decide where
in the filesystem bricks were being mounted. In an effort to remove
state from the executor we move the logic for determining where these paths are to their own file and move state out of the executor and into the BrickRequest.