### PR TITLE
apps: change app to dynamically construct allocator

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -494,3 +494,7 @@ func (a *App) NotFoundHandler(w http.ResponseWriter, r *http.Request) {
 	logger.Warning("Invalid path or request %v", r.URL.Path)
 	http.Error(w, "Invalid path or request", http.StatusNotFound)
 }
+
+func (a *App) Allocator() (Allocator) {
+	return a.allocator
+}

--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -498,3 +498,7 @@ func (a *App) NotFoundHandler(w http.ResponseWriter, r *http.Request) {
 func (a *App) Allocator() (Allocator) {
 	return a.allocator
 }
+
+func (a *App) SetAllocator(allocator Allocator) {
+	a.allocator = allocator
+}

--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -502,13 +502,20 @@ func (a *App) setupAllocator() {
 	// Setup allocator
 	switch {
 	case a.conf.Allocator == "mock":
-		a._allocator = NewMockAllocator(a.db)
+		if r := NewMockAllocator(a.db); r != nil {
+			a._allocator = r
+		} else {
+			panic(errors.New("failed to set up mock allocator"))
+		}
 	case a.conf.Allocator == "simple" || a.conf.Allocator == "":
 		a.conf.Allocator = "simple"
-		a._allocator = NewSimpleAllocatorFromDb(a.db)
+		if r := NewSimpleAllocatorFromDb(a.db); r != nil {
+			a._allocator = r
+		} else {
+			panic(errors.New("failed to set up simple allocator"))
+		}
 	default:
-		err := errors.New("cannot load invalid allocator")
-		panic(err)
+		panic(errors.New("cannot load invalid allocator: " + a.conf.Allocator))
 	}
 	logger.Info("Loaded %v allocator", a.conf.Allocator)
 }

--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -185,8 +185,6 @@ func NewApp(configIo io.Reader) *App {
 	// Set block settings
 	app.setBlockSettings()
 
-	app.setupAllocator()
-
 	// Show application has loaded
 	logger.Info("GlusterFS Application Loaded")
 
@@ -487,6 +485,9 @@ func (a *App) NotFoundHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) Allocator() Allocator {
+	if a._allocator == nil {
+		a.setupAllocator()
+	}
 	return a._allocator
 }
 

--- a/apps/glusterfs/app_block_volume.go
+++ b/apps/glusterfs/app_block_volume.go
@@ -85,7 +85,7 @@ func (a *App) BlockVolumeCreate(w http.ResponseWriter, r *http.Request) {
 	a.asyncManager.AsyncHttpRedirectFunc(w, r, func() (string, error) {
 
 		logger.Info("Creating block volume %v", blockVolume.Info.Id)
-		err := blockVolume.Create(a.db, a.executor, a.allocator)
+		err := blockVolume.Create(a.db, a.executor, a.Allocator())
 		if err != nil {
 			logger.LogError("Failed to create block volume: %v", err)
 			return "", err

--- a/apps/glusterfs/app_block_volume_test.go
+++ b/apps/glusterfs/app_block_volume_test.go
@@ -300,7 +300,7 @@ func TestBlockVolumeInfo(t *testing.T) {
 	v := NewBlockVolumeEntryFromRequest(req)
 	tests.Assert(t, v != nil)
 	tests.Assert(t, v.Info.Auth == true)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Now that we have some data in the database, we can
@@ -531,7 +531,7 @@ func TestBlockVolumeDelete(t *testing.T) {
 	// Create a volume
 	v := createSampleBlockVolumeEntry(100)
 	tests.Assert(t, v != nil)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Delete the volume

--- a/apps/glusterfs/app_cluster.go
+++ b/apps/glusterfs/app_cluster.go
@@ -167,7 +167,7 @@ func (a *App) ClusterDelete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update allocator hat the cluster has been removed
-	a.allocator.RemoveCluster(id)
+	a.Allocator().RemoveCluster(id)
 
 	// Show that the key has been deleted
 	logger.Info("Deleted cluster [%s]", id)

--- a/apps/glusterfs/app_cluster.go
+++ b/apps/glusterfs/app_cluster.go
@@ -39,7 +39,7 @@ func (a *App) ClusterCreate(w http.ResponseWriter, r *http.Request) {
 			return err
 		}
 
-		err = a.allocator.AddCluster(entry.Info.Id)
+		err = a.Allocator().AddCluster(entry.Info.Id)
 		if err != nil {
 			logger.LogError("Error adding cluster to ring: %v", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/apps/glusterfs/app_device.go
+++ b/apps/glusterfs/app_device.go
@@ -139,7 +139,7 @@ func (a *App) DeviceAdd(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// Add to allocator
-			err = a.allocator.AddDevice(clusterEntry, nodeEntry, device)
+			err = a.Allocator().AddDevice(clusterEntry, nodeEntry, device)
 			if err != nil {
 				return err
 			}
@@ -261,7 +261,7 @@ func (a *App) DeviceDelete(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Remove device from allocator
-		err = a.allocator.RemoveDevice(cluster, node, device)
+		err = a.Allocator().RemoveDevice(cluster, node, device)
 		if err != nil {
 			return "", err
 		}
@@ -356,7 +356,7 @@ func (a *App) DeviceSetState(w http.ResponseWriter, r *http.Request) {
 
 	// Set state
 	a.asyncManager.AsyncHttpRedirectFunc(w, r, func() (string, error) {
-		err = device.SetState(a.db, a.executor, a.allocator, msg.State)
+		err = device.SetState(a.db, a.executor, a.Allocator(), msg.State)
 		if err != nil {
 			return "", err
 		}

--- a/apps/glusterfs/app_device_test.go
+++ b/apps/glusterfs/app_device_test.go
@@ -561,6 +561,7 @@ func TestDeviceState(t *testing.T) {
 	// Create mock allocator
 	mockAllocator := NewMockAllocator(app.db)
 	app.SetAllocator(mockAllocator)
+	defer app.ClearAllocator()
 
 	// Create a client
 	c := client.NewClientNoAuth(ts.URL)

--- a/apps/glusterfs/app_device_test.go
+++ b/apps/glusterfs/app_device_test.go
@@ -560,7 +560,7 @@ func TestDeviceState(t *testing.T) {
 
 	// Create mock allocator
 	mockAllocator := NewMockAllocator(app.db)
-	app.allocator = mockAllocator
+	app.SetAllocator(mockAllocator)
 
 	// Create a client
 	c := client.NewClientNoAuth(ts.URL)

--- a/apps/glusterfs/app_node.go
+++ b/apps/glusterfs/app_node.go
@@ -373,7 +373,7 @@ func (a *App) NodeSetState(w http.ResponseWriter, r *http.Request) {
 
 	// Set state
 	a.asyncManager.AsyncHttpRedirectFunc(w, r, func() (string, error) {
-		err = node.SetState(a.db, a.executor, a.allocator, msg.State)
+		err = node.SetState(a.db, a.executor, a.Allocator(), msg.State)
 		if err != nil {
 			return "", err
 		}

--- a/apps/glusterfs/app_node_test.go
+++ b/apps/glusterfs/app_node_test.go
@@ -1042,7 +1042,7 @@ func TestNodeState(t *testing.T) {
 
 	// Create mock allocator
 	mockAllocator := NewMockAllocator(app.db)
-	app.allocator = mockAllocator
+	app.SetAllocator(mockAllocator)
 
 	// Create a client
 	c := client.NewClientNoAuth(ts.URL)
@@ -1355,7 +1355,7 @@ func TestNodeInfoAfterDelete(t *testing.T) {
 
 	// Create mock allocator
 	mockAllocator := NewMockAllocator(app.db)
-	app.allocator = mockAllocator
+	app.SetAllocator(mockAllocator)
 
 	// Create a client
 	c := client.NewClientNoAuth(ts.URL)

--- a/apps/glusterfs/app_node_test.go
+++ b/apps/glusterfs/app_node_test.go
@@ -1043,6 +1043,7 @@ func TestNodeState(t *testing.T) {
 	// Create mock allocator
 	mockAllocator := NewMockAllocator(app.db)
 	app.SetAllocator(mockAllocator)
+	defer app.ClearAllocator()
 
 	// Create a client
 	c := client.NewClientNoAuth(ts.URL)
@@ -1356,6 +1357,7 @@ func TestNodeInfoAfterDelete(t *testing.T) {
 	// Create mock allocator
 	mockAllocator := NewMockAllocator(app.db)
 	app.SetAllocator(mockAllocator)
+	defer app.ClearAllocator()
 
 	// Create a client
 	c := client.NewClientNoAuth(ts.URL)

--- a/apps/glusterfs/app_volume.go
+++ b/apps/glusterfs/app_volume.go
@@ -150,7 +150,7 @@ func (a *App) VolumeCreate(w http.ResponseWriter, r *http.Request) {
 	a.asyncManager.AsyncHttpRedirectFunc(w, r, func() (string, error) {
 
 		logger.Info("Creating volume %v", vol.Info.Id)
-		err := vol.Create(a.db, a.executor, a.allocator)
+		err := vol.Create(a.db, a.executor, a.Allocator())
 		if err != nil {
 			logger.LogError("Failed to create volume: %v", err)
 			return "", err
@@ -344,7 +344,7 @@ func (a *App) VolumeExpand(w http.ResponseWriter, r *http.Request) {
 	a.asyncManager.AsyncHttpRedirectFunc(w, r, func() (string, error) {
 
 		logger.Info("Expanding volume %v", volume.Info.Id)
-		err := volume.Expand(a.db, a.executor, a.allocator, msg.Size)
+		err := volume.Expand(a.db, a.executor, a.Allocator(), msg.Size)
 		if err != nil {
 			logger.LogError("Failed to expand volume %v", volume.Info.Id)
 			return "", err

--- a/apps/glusterfs/app_volume_test.go
+++ b/apps/glusterfs/app_volume_test.go
@@ -648,7 +648,7 @@ func TestVolumeInfo(t *testing.T) {
 	req.Durability.Type = api.DurabilityEC
 	v := NewVolumeEntryFromRequest(req)
 	tests.Assert(t, v != nil)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Now that we have some data in the database, we can
@@ -877,7 +877,7 @@ func TestVolumeDelete(t *testing.T) {
 	// Create a volume
 	v := createSampleReplicaVolumeEntry(100, 2)
 	tests.Assert(t, v != nil)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Delete the volume
@@ -1022,7 +1022,7 @@ func TestVolumeExpand(t *testing.T) {
 	// Create a volume
 	v := createSampleReplicaVolumeEntry(100, 2)
 	tests.Assert(t, v != nil)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Keep a copy
@@ -1089,13 +1089,13 @@ func TestVolumeClusterResizeByAddingDevices(t *testing.T) {
 	// Create a volume which uses the entire storage
 	v := createSampleReplicaVolumeEntry(495, 2)
 	tests.Assert(t, v != nil)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Try to create another volume, but this should fail
 	v = createSampleReplicaVolumeEntry(495, 2)
 	tests.Assert(t, v != nil)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == ErrNoSpace)
 
 	// Create a client
@@ -1123,13 +1123,13 @@ func TestVolumeClusterResizeByAddingDevices(t *testing.T) {
 	// Now add a volume, and it should work
 	v = createSampleReplicaVolumeEntry(495, 2)
 	tests.Assert(t, v != nil)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Try to create another volume, but this should fail
 	v = createSampleReplicaVolumeEntry(495, 2)
 	tests.Assert(t, v != nil)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == ErrNoSpace)
 }
 

--- a/apps/glusterfs/block_volume_entry_test.go
+++ b/apps/glusterfs/block_volume_entry_test.go
@@ -280,7 +280,7 @@ func TestBlockVolumeEntryCreateMissingCluster(t *testing.T) {
 	})
 	tests.Assert(t, err == nil)
 
-	err = bv.Create(app.db, app.executor, app.allocator)
+	err = bv.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == ErrNoSpace)
 
 }
@@ -305,7 +305,7 @@ func TestBlockVolumeEntryDestroy(t *testing.T) {
 	// Create a blockvolume
 	bv := createSampleBlockVolumeEntry(200)
 
-	err = bv.Create(app.db, app.executor, app.allocator)
+	err = bv.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Destroy the blockvolume
@@ -407,13 +407,13 @@ func TestBlockVolumeEntryNameConflictSingleVolume(t *testing.T) {
 	// Create blockvolume
 	bv := createSampleBlockVolumeEntry(500)
 	bv.Info.Name = "myvol"
-	err = bv.Create(app.db, app.executor, app.allocator)
+	err = bv.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Create another blockvolume same name
 	bv = createSampleBlockVolumeEntry(400)
 	bv.Info.Name = "myvol"
-	err = bv.Create(app.db, app.executor, app.allocator)
+	err = bv.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err != nil, err)
 }
 
@@ -438,13 +438,13 @@ func TestBlockVolumeEntryNameConflictMultiVolume(t *testing.T) {
 	for i := 0; i < 8; i++ {
 		bv := createSampleBlockVolumeEntry(500)
 		bv.Info.Name = "myvol"
-		err = bv.Create(app.db, app.executor, app.allocator)
+		err = bv.Create(app.db, app.executor, app.Allocator())
 		tests.Assert(t, err == nil)
 	}
 	// Create another blockvolume same name
 	bv := createSampleBlockVolumeEntry(400)
 	bv.Info.Name = "myvol"
-	err = bv.Create(app.db, app.executor, app.allocator)
+	err = bv.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err != nil, err)
 }
 
@@ -469,12 +469,12 @@ func TestBlockVolumeEntryNameConflictMultiCluster(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		bv := createSampleBlockVolumeEntry(500)
 		bv.Info.Name = "myvol"
-		err = bv.Create(app.db, app.executor, app.allocator)
+		err = bv.Create(app.db, app.executor, app.Allocator())
 		tests.Assert(t, err == nil)
 	}
 	// Create another blockvolume same name
 	bv := createSampleBlockVolumeEntry(400)
 	bv.Info.Name = "myvol"
-	err = bv.Create(app.db, app.executor, app.allocator)
+	err = bv.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err != nil, err)
 }

--- a/apps/glusterfs/device_entry_test.go
+++ b/apps/glusterfs/device_entry_test.go
@@ -599,7 +599,7 @@ func TestDeviceSetStateFailed(t *testing.T) {
 
 	// Create allocator
 	mockAllocator := NewMockAllocator(app.db)
-	app.allocator = mockAllocator
+	app.SetAllocator(mockAllocator)
 
 	// Create cluster entry
 	c := NewClusterEntry()
@@ -682,7 +682,7 @@ func TestDeviceSetStateOfflineOnline(t *testing.T) {
 
 	// Create allocator
 	mockAllocator := NewMockAllocator(app.db)
-	app.allocator = mockAllocator
+	app.SetAllocator(mockAllocator)
 
 	// Create cluster entry
 	c := NewClusterEntry()

--- a/apps/glusterfs/device_entry_test.go
+++ b/apps/glusterfs/device_entry_test.go
@@ -600,6 +600,7 @@ func TestDeviceSetStateFailed(t *testing.T) {
 	// Create allocator
 	mockAllocator := NewMockAllocator(app.db)
 	app.SetAllocator(mockAllocator)
+	defer app.ClearAllocator()
 
 	// Create cluster entry
 	c := NewClusterEntry()
@@ -683,6 +684,7 @@ func TestDeviceSetStateOfflineOnline(t *testing.T) {
 	// Create allocator
 	mockAllocator := NewMockAllocator(app.db)
 	app.SetAllocator(mockAllocator)
+	defer app.ClearAllocator()
 
 	// Create cluster entry
 	c := NewClusterEntry()

--- a/apps/glusterfs/node_entry_test.go
+++ b/apps/glusterfs/node_entry_test.go
@@ -491,7 +491,7 @@ func TestNodeSetStateFailed(t *testing.T) {
 
 	// Create allocator
 	mockAllocator := NewMockAllocator(app.db)
-	app.allocator = mockAllocator
+	app.SetAllocator(mockAllocator)
 
 	// Create cluster entry
 	c := NewClusterEntry()
@@ -576,7 +576,7 @@ func TestNodeSetStateOfflineOnline(t *testing.T) {
 
 	// Create allocator
 	mockAllocator := NewMockAllocator(app.db)
-	app.allocator = mockAllocator
+	app.SetAllocator(mockAllocator)
 
 	// Create cluster entry
 	c := NewClusterEntry()

--- a/apps/glusterfs/node_entry_test.go
+++ b/apps/glusterfs/node_entry_test.go
@@ -492,6 +492,7 @@ func TestNodeSetStateFailed(t *testing.T) {
 	// Create allocator
 	mockAllocator := NewMockAllocator(app.db)
 	app.SetAllocator(mockAllocator)
+	defer app.ClearAllocator()
 
 	// Create cluster entry
 	c := NewClusterEntry()
@@ -577,6 +578,7 @@ func TestNodeSetStateOfflineOnline(t *testing.T) {
 	// Create allocator
 	mockAllocator := NewMockAllocator(app.db)
 	app.SetAllocator(mockAllocator)
+	defer app.ClearAllocator()
 
 	// Create cluster entry
 	c := NewClusterEntry()

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -42,11 +42,12 @@ func setupSampleDbWithTopology(app *App,
 	disksize uint64) error {
 
 	var clusterlist []string
+	alloc := app.Allocator()
 	err := app.db.Update(func(tx *bolt.Tx) error {
 		for c := 0; c < clusters; c++ {
 			cluster := createSampleClusterEntry()
 
-			if err := app.Allocator().AddCluster(cluster.Info.Id); err != nil {
+			if err := alloc.AddCluster(cluster.Info.Id); err != nil {
 				return err
 			}
 
@@ -62,7 +63,7 @@ func setupSampleDbWithTopology(app *App,
 					node.DeviceAdd(device.Id())
 
 					// Update allocator
-					err := app.Allocator().AddDevice(cluster, node, device)
+					err := alloc.AddDevice(cluster, node, device)
 					if err != nil {
 						return nil
 					}
@@ -955,6 +956,7 @@ func TestVolumeEntryCreateCheckingClustersForSpace(t *testing.T) {
 
 	// Create one large cluster
 	cluster := createSampleClusterEntry()
+	alloc := app.Allocator()
 	err = app.db.Update(func(tx *bolt.Tx) error {
 		for n := 0; n < 100; n++ {
 			node := createSampleNodeEntry()
@@ -968,7 +970,7 @@ func TestVolumeEntryCreateCheckingClustersForSpace(t *testing.T) {
 				node.DeviceAdd(device.Id())
 
 				// update allocator
-				err := app.Allocator().AddDevice(cluster, node, device)
+				err := alloc.AddDevice(cluster, node, device)
 				if err != nil {
 					return nil
 				}

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -46,7 +46,7 @@ func setupSampleDbWithTopology(app *App,
 		for c := 0; c < clusters; c++ {
 			cluster := createSampleClusterEntry()
 
-			if err := app.allocator.AddCluster(cluster.Info.Id); err != nil {
+			if err := app.Allocator().AddCluster(cluster.Info.Id); err != nil {
 				return err
 			}
 
@@ -62,7 +62,7 @@ func setupSampleDbWithTopology(app *App,
 					node.DeviceAdd(device.Id())
 
 					// Update allocator
-					err := app.allocator.AddDevice(cluster, node, device)
+					err := app.Allocator().AddDevice(cluster, node, device)
 					if err != nil {
 						return nil
 					}
@@ -968,7 +968,7 @@ func TestVolumeEntryCreateCheckingClustersForSpace(t *testing.T) {
 				node.DeviceAdd(device.Id())
 
 				// update allocator
-				err := app.allocator.AddDevice(cluster, node, device)
+				err := app.Allocator().AddDevice(cluster, node, device)
 				if err != nil {
 					return nil
 				}

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -497,7 +497,7 @@ func TestVolumeEntryCreateMissingCluster(t *testing.T) {
 	})
 	tests.Assert(t, err == nil)
 
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == ErrNoSpace)
 
 }
@@ -522,7 +522,7 @@ func TestVolumeEntryCreateRunOutOfSpaceMinBrickSizeLimit(t *testing.T) {
 	// Create a 100 GB volume
 	// Shouldn't be able to break it down enough to allocate volume
 	v := createSampleReplicaVolumeEntry(100, 2)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == ErrNoSpace)
 	tests.Assert(t, v.Info.Cluster == "")
 
@@ -570,7 +570,7 @@ func TestVolumeEntryCreateRunOutOfSpaceMaxBrickLimit(t *testing.T) {
 	// Create a volume who will be broken down to
 	// Shouldn't be able to break it down enough to allocate volume
 	v := createSampleReplicaVolumeEntry(BrickMaxNum*2*int(BrickMinSize/GB), 2)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == ErrNoSpace)
 
 	// Check database volume does not exist
@@ -636,7 +636,7 @@ func TestVolumeEntryCreateTwoBricks(t *testing.T) {
 	// Set a GID
 	v.Info.Gid = gid
 
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil, err)
 	tests.Assert(t, brickCreateCount == 2)
 
@@ -742,7 +742,7 @@ func TestVolumeEntryCreateBrickDivision(t *testing.T) {
 	// Create a volume which is so big that it does
 	// not fit into a single replica set
 	v := createSampleReplicaVolumeEntry(2000, 2)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	var info *api.VolumeInfoResponse
@@ -823,7 +823,7 @@ func TestVolumeEntryCreateMaxBrickSize(t *testing.T) {
 
 	// Create a volume whose bricks must be at most BrickMaxSize
 	v := createSampleReplicaVolumeEntry(int(BrickMaxSize/GB*4), 2)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Get volume information
@@ -887,7 +887,7 @@ func TestVolumeEntryCreateOnClustersRequested(t *testing.T) {
 	v.Info.Clusters = []string{clusters[0]}
 
 	// Create volume
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Check database volume does not exist
@@ -913,7 +913,7 @@ func TestVolumeEntryCreateOnClustersRequested(t *testing.T) {
 	clusterset := clusters[2:5]
 	v = createSampleReplicaVolumeEntry(1024, 2)
 	v.Info.Clusters = clusterset
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Check database volume exists
@@ -996,7 +996,7 @@ func TestVolumeEntryCreateCheckingClustersForSpace(t *testing.T) {
 	v := createSampleReplicaVolumeEntry(1024, 2)
 
 	// Create volume
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Check database volume exists
@@ -1043,7 +1043,7 @@ func TestVolumeEntryCreateWithSnapshot(t *testing.T) {
 	v.Info.Snapshot.Enable = true
 	v.Info.Snapshot.Factor = 1.5
 
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Check database volume exists
@@ -1108,7 +1108,7 @@ func TestVolumeEntryCreateBrickCreationFailure(t *testing.T) {
 	// For a 200G vol, it would get a brick size of 100G, with a thin pool
 	// size of 100G * 1.5 = 150GB.
 	v := createSampleReplicaVolumeEntry(200, 2)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == mockerror, err, mockerror)
 
 	// Check database is still clean. No bricks and No volumes
@@ -1162,7 +1162,7 @@ func TestVolumeEntryCreateVolumeCreationFailure(t *testing.T) {
 	// For a 200G vol, it would get a brick size of 100G, with a thin pool
 	// size of 100G * 1.5 = 150GB.
 	v := createSampleReplicaVolumeEntry(200, 2)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == mockerror)
 
 	// Check database is still clean. No bricks and No volumes
@@ -1213,7 +1213,7 @@ func TestVolumeEntryDestroy(t *testing.T) {
 	v.Info.Snapshot.Enable = true
 	v.Info.Snapshot.Factor = 1.5
 
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Destroy the volume
@@ -1298,7 +1298,7 @@ func TestVolumeEntryExpandNoSpace(t *testing.T) {
 
 	// Create large volume
 	v := createSampleReplicaVolumeEntry(1190, 2)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Save a copy of the volume before expansion
@@ -1306,11 +1306,11 @@ func TestVolumeEntryExpandNoSpace(t *testing.T) {
 	*vcopy = *v
 
 	// Asking for a large amount will require too many little bricks
-	err = v.Expand(app.db, app.executor, app.allocator, 5000)
+	err = v.Expand(app.db, app.executor, app.Allocator(), 5000)
 	tests.Assert(t, err == ErrMaxBricks, err)
 
 	// Asking for a small amount will set the bricks too small
-	err = v.Expand(app.db, app.executor, app.allocator, 10)
+	err = v.Expand(app.db, app.executor, app.Allocator(), 10)
 	tests.Assert(t, err == ErrMinimumBrickSize, err)
 
 	// Check db is the same as before expansion
@@ -1344,7 +1344,7 @@ func TestVolumeEntryExpandMaxBrickLimit(t *testing.T) {
 
 	// Create large volume
 	v := createSampleReplicaVolumeEntry(100, 2)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Add a bunch of bricks until the limit
@@ -1353,7 +1353,7 @@ func TestVolumeEntryExpandMaxBrickLimit(t *testing.T) {
 
 	// Try to expand the volume, but it will return that the max number
 	// of bricks has been reached
-	err = v.Expand(app.db, app.executor, app.allocator, 100)
+	err = v.Expand(app.db, app.executor, app.Allocator(), 100)
 	tests.Assert(t, err == ErrMaxBricks, err)
 }
 
@@ -1376,7 +1376,7 @@ func TestVolumeEntryExpandCreateBricksFailure(t *testing.T) {
 
 	// Create volume
 	v := createSampleReplicaVolumeEntry(100, 2)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Save a copy of the volume before expansion
@@ -1390,7 +1390,7 @@ func TestVolumeEntryExpandCreateBricksFailure(t *testing.T) {
 	}
 
 	// Expand volume
-	err = v.Expand(app.db, app.executor, app.allocator, 500)
+	err = v.Expand(app.db, app.executor, app.Allocator(), 500)
 	tests.Assert(t, err == ErrMock)
 
 	// Check db is the same as before expansion
@@ -1424,13 +1424,13 @@ func TestVolumeEntryExpand(t *testing.T) {
 
 	// Create volume
 	v := createSampleReplicaVolumeEntry(1024, 2)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 	tests.Assert(t, v.Info.Size == 1024)
 	tests.Assert(t, len(v.Bricks) == 2)
 
 	// Expand volume
-	err = v.Expand(app.db, app.executor, app.allocator, 1234)
+	err = v.Expand(app.db, app.executor, app.Allocator(), 1234)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, v.Info.Size == 1024+1234)
 	tests.Assert(t, len(v.Bricks) == 4)
@@ -1467,12 +1467,12 @@ func TestVolumeEntryDoNotAllowDeviceOnSameNode(t *testing.T) {
 
 	// Create volume
 	v := createSampleReplicaVolumeEntry(100, 2)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err != nil, err)
 	tests.Assert(t, err == ErrNoSpace)
 
 	v = createSampleReplicaVolumeEntry(10000, 2)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err != nil, err)
 	tests.Assert(t, err == ErrNoSpace)
 }
@@ -1501,7 +1501,7 @@ func TestVolumeEntryDestroyCheck(t *testing.T) {
 	v.Info.Snapshot.Enable = true
 	v.Info.Snapshot.Factor = 1.5
 
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Test that a volume that is sharing space in a thin pool
@@ -1552,13 +1552,13 @@ func TestVolumeEntryNameConflictSingleCluster(t *testing.T) {
 	// Create volume
 	v := createSampleReplicaVolumeEntry(1024, 2)
 	v.Info.Name = "myvol"
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil)
 
 	// Create another volume same name
 	v = createSampleReplicaVolumeEntry(10000, 2)
 	v.Info.Name = "myvol"
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err != nil, err)
 }
 
@@ -1583,7 +1583,7 @@ func TestVolumeEntryNameConflictMultiCluster(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		v := createSampleReplicaVolumeEntry(1024, 2)
 		v.Info.Name = "myvol"
-		err = v.Create(app.db, app.executor, app.allocator)
+		err = v.Create(app.db, app.executor, app.Allocator())
 		logger.Info("%v", v.Info.Cluster)
 		tests.Assert(t, err == nil, err)
 	}
@@ -1591,7 +1591,7 @@ func TestVolumeEntryNameConflictMultiCluster(t *testing.T) {
 	// Create another volume same name
 	v := createSampleReplicaVolumeEntry(10000, 2)
 	v.Info.Name = "myvol"
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err != nil, err)
 }
 
@@ -1613,7 +1613,7 @@ func TestReplaceBrickInVolume(t *testing.T) {
 
 	v := createSampleReplicaVolumeEntry(100, 3)
 
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil, err)
 	var brickNames []string
 	var be *BrickEntry
@@ -1666,7 +1666,7 @@ func TestReplaceBrickInVolume(t *testing.T) {
 		return h, nil
 	}
 	brickId := be.Id()
-	err = v.replaceBrickInVolume(app.db, app.executor, app.allocator, brickId)
+	err = v.replaceBrickInVolume(app.db, app.executor, app.Allocator(), brickId)
 	tests.Assert(t, err == nil, err)
 
 	oldNode := be.Info.NodeId
@@ -1726,7 +1726,7 @@ func TestNewVolumeEntryWithVolumeOptions(t *testing.T) {
 	tests.Assert(t, len(v.Bricks) == 0)
 	tests.Assert(t, v.GlusterVolumeOptions[0] == "test-option")
 
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	logger.Info("%v", v.Info.Cluster)
 	tests.Assert(t, err == nil, err)
 
@@ -1767,7 +1767,7 @@ func TestNewVolumeEntryWithTSPForMountHosts(t *testing.T) {
 	tests.Assert(t, len(v.Info.Id) != 0)
 	tests.Assert(t, len(v.Bricks) == 0)
 
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	logger.Info("%v", v.Info.Cluster)
 	tests.Assert(t, err == nil, err)
 
@@ -1801,7 +1801,7 @@ func TestReplaceBrickInVolumeSelfHeal1(t *testing.T) {
 
 	v := createSampleReplicaVolumeEntry(100, 3)
 
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil, err)
 	var brickNames []string
 	var be *BrickEntry
@@ -1852,7 +1852,7 @@ func TestReplaceBrickInVolumeSelfHeal1(t *testing.T) {
 		return h, nil
 	}
 	brickId := be.Id()
-	err = v.replaceBrickInVolume(app.db, app.executor, app.allocator, brickId)
+	err = v.replaceBrickInVolume(app.db, app.executor, app.Allocator(), brickId)
 	tests.Assert(t, err == nil, err)
 
 	oldNode := be.Info.NodeId
@@ -1902,7 +1902,7 @@ func TestReplaceBrickInVolumeSelfHeal2(t *testing.T) {
 
 	v := createSampleReplicaVolumeEntry(100, 3)
 
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil, err)
 	var brickNames []string
 	var be *BrickEntry
@@ -1956,7 +1956,7 @@ func TestReplaceBrickInVolumeSelfHeal2(t *testing.T) {
 		return h, nil
 	}
 	brickId := be.Id()
-	err = v.replaceBrickInVolume(app.db, app.executor, app.allocator, brickId)
+	err = v.replaceBrickInVolume(app.db, app.executor, app.Allocator(), brickId)
 	tests.Assert(t, err != nil, err)
 
 	oldNode := be.Info.NodeId
@@ -2006,7 +2006,7 @@ func TestReplaceBrickInVolumeSelfHealQuorumNotMet(t *testing.T) {
 
 	v := createSampleReplicaVolumeEntry(100, 3)
 
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	tests.Assert(t, err == nil, err)
 	var brickNames []string
 	var be *BrickEntry
@@ -2057,7 +2057,7 @@ func TestReplaceBrickInVolumeSelfHealQuorumNotMet(t *testing.T) {
 		return h, nil
 	}
 	brickId := be.Id()
-	err = v.replaceBrickInVolume(app.db, app.executor, app.allocator, brickId)
+	err = v.replaceBrickInVolume(app.db, app.executor, app.Allocator(), brickId)
 	tests.Assert(t, err != nil, err)
 
 	oldNode := be.Info.NodeId


### PR DESCRIPTION
Before this series the app constructing the allocator once and persisting it across the lifetime of the heketi process. This series transitions the app to dynamically creating the allocator on request. A few hooks are also added to support temporarily persisting a custom allocator for tests.