### PR TITLE
heketi-cli: remove a wrong comment

### DIFF
--- a/client/cli/go/cmds/cluster.go
+++ b/client/cli/go/cmds/cluster.go
@@ -142,7 +142,6 @@ var clusterInfoCommand = &cobra.Command{
 		// Create a client to talk to Heketi
 		heketi := client.NewClient(options.Url, options.User, options.Key)
 
-		// Create cluster
 		info, err := heketi.ClusterInfo(clusterId)
 		if err != nil {
 			return err


### PR DESCRIPTION
Probably a copy-and-paste error

Signed-off-by: Michael Adam <obnox@redhat.com>