### PR TITLE
tests: fail faster on vagrant errors

### DIFF
--- a/tests/functional/TestManyBricksVolume/vagrant/up.sh
+++ b/tests/functional/TestManyBricksVolume/vagrant/up.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
+set -e
 vagrant up --no-provision "$@"
 vagrant provision

--- a/tests/functional/TestSmokeTest/vagrant/up.sh
+++ b/tests/functional/TestSmokeTest/vagrant/up.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
+set -e
 vagrant up --no-provision "$@"
 vagrant provision

--- a/tests/functional/TestVolumeNotDeletedWhenNodeIsDown/vagrant/up.sh
+++ b/tests/functional/TestVolumeNotDeletedWhenNodeIsDown/vagrant/up.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
+set -e
 vagrant up --no-provision "$@"
 vagrant provision

--- a/tests/functional/TestVolumeSnapshotBehavior/vagrant/up.sh
+++ b/tests/functional/TestVolumeSnapshotBehavior/vagrant/up.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
+set -e
 vagrant up --no-provision "$@"
 vagrant provision


### PR DESCRIPTION
Add boilerplate to the various up.sh scripts to always exit on first
failure.

Signed-off-by: John Mulligan <jmulligan@redhat.com>