### PR TITLE
apps:glusterfs: fix VolumeEntry Flags tests after Allocator patches

### DIFF
--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -2129,7 +2129,7 @@ func TestVolumeEntryNoMatchingFlags(t *testing.T) {
 	v.Info.Name = "blockhead"
 	// request block volume
 	v.Info.Block = true
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	// expect no space error due to no clusters able to satifsy block volume
 	tests.Assert(t, err == ErrNoSpace)
 }
@@ -2170,7 +2170,7 @@ func TestVolumeEntryMissingFlags(t *testing.T) {
 
 	// Create volume
 	v := createSampleReplicaVolumeEntry(1024, 2)
-	err = v.Create(app.db, app.executor, app.allocator)
+	err = v.Create(app.db, app.executor, app.Allocator())
 	// expect no space error due to no clusters able to satifsy block volume
 	tests.Assert(t, err == ErrNoSpace)
 }


### PR DESCRIPTION
The patch that introduced TestVolumeEntryNoMatchingFlags and
TestVolumeEntryMissingFlags was written before the patch that
refactored the allocator code for lazy initialization.

But they were merged almost at the same time. Since we don't
trigger CI runs after rebasing before merging, this error
got unnoticed until CI was run after merge...

Signed-off-by: Michael Adam <obnox@redhat.com>