### PR TITLE
Some further cleanups after introduction of CmdExec

### DIFF
--- a/executors/cmdexec/cmdexec.go
+++ b/executors/cmdexec/cmdexec.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	logger = utils.NewLogger("[sshexec]", utils.LEVEL_DEBUG)
+	logger = utils.NewLogger("[cmdexec]", utils.LEVEL_DEBUG)
 )
 
 type RemoteCommandTransport interface {

--- a/executors/cmdexec/config.go
+++ b/executors/cmdexec/config.go
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package cmdexec
+
+type CmdConfig struct {
+	Fstab         string `json:"fstab"`
+	Sudo          bool   `json:"sudo"`
+	SnapShotLimit int    `json:"snapshot_limit"`
+
+	// Experimental Settings
+	RebalanceOnExpansion bool `json:"rebalance_on_expansion"`
+}

--- a/executors/kubeexec/config.go
+++ b/executors/kubeexec/config.go
@@ -10,11 +10,12 @@
 package kubeexec
 
 import (
-	"github.com/heketi/heketi/executors/sshexec"
+	"github.com/heketi/heketi/executors/cmdexec"
 )
 
 type KubeConfig struct {
-	sshexec.CLICommandConfig
+	cmdexec.CmdConfig
+
 	Namespace        string `json:"namespace"`
 	GlusterDaemonSet bool   `json:"gluster_daemonset"`
 

--- a/executors/kubeexec/kubeexec.go
+++ b/executors/kubeexec/kubeexec.go
@@ -35,7 +35,6 @@ const (
 )
 
 type KubeExecutor struct {
-	// Embed all sshexecutor functions
 	cmdexec.CmdExecutor
 
 	// save kube configuration

--- a/executors/kubeexec/kubeexec_test.go
+++ b/executors/kubeexec/kubeexec_test.go
@@ -15,7 +15,7 @@ import (
 
 	restclient "k8s.io/client-go/rest"
 
-	"github.com/heketi/heketi/executors/sshexec"
+	"github.com/heketi/heketi/executors/cmdexec"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/heketi/tests"
 )
@@ -29,7 +29,7 @@ func init() {
 
 func TestNewKubeExecutor(t *testing.T) {
 	config := &KubeConfig{
-		CLICommandConfig: sshexec.CLICommandConfig{
+		CmdConfig: cmdexec.CmdConfig{
 			Fstab: "myfstab",
 		},
 		Namespace: "mynamespace",
@@ -44,7 +44,7 @@ func TestNewKubeExecutor(t *testing.T) {
 
 func TestNewKubeExecutorNoNamespace(t *testing.T) {
 	config := &KubeConfig{
-		CLICommandConfig: sshexec.CLICommandConfig{
+		CmdConfig: cmdexec.CmdConfig{
 			Fstab: "myfstab",
 		},
 	}
@@ -60,7 +60,7 @@ func TestNewKubeExecutorRebalanceOnExpansion(t *testing.T) {
 	// from the sshconfig exector
 
 	config := &KubeConfig{
-		CLICommandConfig: sshexec.CLICommandConfig{
+		CmdConfig: cmdexec.CmdConfig{
 			Fstab: "myfstab",
 		},
 		Namespace: "mynamespace",
@@ -74,7 +74,7 @@ func TestNewKubeExecutorRebalanceOnExpansion(t *testing.T) {
 	tests.Assert(t, k.RebalanceOnExpansion() == false)
 
 	config = &KubeConfig{
-		CLICommandConfig: sshexec.CLICommandConfig{
+		CmdConfig: cmdexec.CmdConfig{
 			Fstab:                "myfstab",
 			RebalanceOnExpansion: true,
 		},
@@ -101,7 +101,7 @@ func TestKubeExecutorEnvVariables(t *testing.T) {
 	defer os.Unsetenv("HEKETI_FSTAB")
 
 	config := &KubeConfig{
-		CLICommandConfig: sshexec.CLICommandConfig{
+		CmdConfig: cmdexec.CmdConfig{
 			Fstab: "myfstab",
 		},
 		Namespace: "mynamespace",

--- a/executors/sshexec/config.go
+++ b/executors/sshexec/config.go
@@ -9,17 +9,13 @@
 
 package sshexec
 
-type CLICommandConfig struct {
-	Fstab         string `json:"fstab"`
-	Sudo          bool   `json:"sudo"`
-	SnapShotLimit int    `json:"snapshot_limit"`
-
-	// Experimental Settings
-	RebalanceOnExpansion bool `json:"rebalance_on_expansion"`
-}
+import (
+	"github.com/heketi/heketi/executors/cmdexec"
+)
 
 type SshConfig struct {
-	CLICommandConfig
+	cmdexec.CmdConfig
+
 	PrivateKeyFile string `json:"keyfile"`
 	User           string `json:"user"`
 	Port           string `json:"port"`

--- a/executors/sshexec/sshexec_test.go
+++ b/executors/sshexec/sshexec_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/heketi/heketi/executors/cmdexec"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/heketi/tests"
 )
@@ -58,7 +59,7 @@ func TestNewSshExec(t *testing.T) {
 		PrivateKeyFile: "xkeyfile",
 		User:           "xuser",
 		Port:           "100",
-		CLICommandConfig: CLICommandConfig{
+		CmdConfig: cmdexec.CmdConfig{
 			Fstab: "xfstab",
 		},
 	}
@@ -85,7 +86,7 @@ func TestSshExecRebalanceOnExpansion(t *testing.T) {
 		PrivateKeyFile: "xkeyfile",
 		User:           "xuser",
 		Port:           "100",
-		CLICommandConfig: CLICommandConfig{
+		CmdConfig: cmdexec.CmdConfig{
 			Fstab: "xfstab",
 		},
 	}
@@ -104,7 +105,7 @@ func TestSshExecRebalanceOnExpansion(t *testing.T) {
 		PrivateKeyFile: "xkeyfile",
 		User:           "xuser",
 		Port:           "100",
-		CLICommandConfig: CLICommandConfig{
+		CmdConfig: cmdexec.CmdConfig{
 			Fstab:                "xfstab",
 			RebalanceOnExpansion: true,
 		},
@@ -185,7 +186,7 @@ func TestSshExecutorEnvVariables(t *testing.T) {
 		PrivateKeyFile: "xkeyfile",
 		User:           "xuser",
 		Port:           "100",
-		CLICommandConfig: CLICommandConfig{
+		CmdConfig: cmdexec.CmdConfig{
 			Fstab: "xfstab",
 		},
 	}


### PR DESCRIPTION
Remove some outdated references to sshexec and refactor the common config from sshexec into cmdexec.