### PR TITLE
apps: split brick allocation logic into db r/o and r/w parts

### DIFF
--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -36,6 +36,8 @@ func allocateBricks(
 		Devices: []*DeviceEntry{},
 	}
 
+	devcache := map[string](*DeviceEntry){}
+
 	// Determine allocation for each brick required for this volume
 	for brick_num := 0; brick_num < bricksets; brick_num++ {
 		logger.Info("brick_num: %v", brick_num)
@@ -60,15 +62,21 @@ func allocateBricks(
 
 			// Do the work in the database context so that the cluster
 			// data does not change while determining brick location
-			err := db.Update(func(tx *bolt.Tx) error {
+			err := db.View(func(tx *bolt.Tx) error {
 
 				// Check the ring for devices to place the brick
 				for deviceId := range deviceCh {
 
-					// Get device entry
-					device, err := NewDeviceEntryFromId(tx, deviceId)
-					if err != nil {
-						return err
+					// Get device entry from cache if possible
+					device, ok := devcache[deviceId]
+					if !ok {
+						// Get device entry from db otherwise
+						var err error
+						device, err = NewDeviceEntryFromId(tx, deviceId)
+						if err != nil {
+							return err
+						}
+						devcache[deviceId] = device
 					}
 
 					// Do not allow a device from the same node to be
@@ -109,17 +117,6 @@ func allocateBricks(
 
 						// Add brick to volume
 						v.BrickAdd(brick.Id())
-
-						// Save values
-						err := brick.Save(tx)
-						if err != nil {
-							return err
-						}
-
-						err = device.Save(tx)
-						if err != nil {
-							return err
-						}
 
 						return nil
 					}
@@ -535,7 +532,26 @@ func (v *VolumeEntry) allocBricks(
 	}()
 
 	r, e := allocateBricks(db, allocator, cluster, v, bricksets, brick_size)
+	// mimic the previous unconditional db update behavior
+	err := db.Update(func(tx *bolt.Tx) error {
+		for _, x := range r.Bricks {
+			err := x.Save(tx)
+			if err != nil {
+				return err
+			}
+		}
+		for _, x := range r.Devices {
+			err := x.Save(tx)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 	brick_entries = r.Bricks
+	if e == nil && err != nil {
+		e = err
+	}
 
 	return brick_entries, e
 }

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -18,6 +18,122 @@ import (
 	"github.com/heketi/heketi/pkg/utils"
 )
 
+func allocateBricks(
+	db *bolt.DB,
+	allocator Allocator,
+	cluster string,
+	v *VolumeEntry,
+	bricksets int,
+	brick_size uint64) ([]*BrickEntry, error) {
+
+	// Initialize brick_entries
+	brick_entries := make([]*BrickEntry, 0)
+
+	// Determine allocation for each brick required for this volume
+	for brick_num := 0; brick_num < bricksets; brick_num++ {
+		logger.Info("brick_num: %v", brick_num)
+
+		// Create a brick set list to later make sure that the
+		// proposed bricks and devices are acceptable
+		setlist := make([]*BrickEntry, 0)
+
+		// Generate an id for the brick
+		brickId := utils.GenUUID()
+
+		// Get allocator generator
+		// The same generator should be used for the brick and its replicas
+		deviceCh, done, errc := allocator.GetNodes(cluster, brickId)
+		defer func() {
+			close(done)
+		}()
+
+		// Check location has space for each brick and its replicas
+		for i := 0; i < v.Durability.BricksInSet(); i++ {
+			logger.Debug("%v / %v", i, v.Durability.BricksInSet())
+
+			// Do the work in the database context so that the cluster
+			// data does not change while determining brick location
+			err := db.Update(func(tx *bolt.Tx) error {
+
+				// Check the ring for devices to place the brick
+				for deviceId := range deviceCh {
+
+					// Get device entry
+					device, err := NewDeviceEntryFromId(tx, deviceId)
+					if err != nil {
+						return err
+					}
+
+					// Do not allow a device from the same node to be
+					// in the set
+					deviceOk := true
+					for _, brickInSet := range setlist {
+						if brickInSet.Info.NodeId == device.NodeId {
+							deviceOk = false
+						}
+					}
+
+					if !deviceOk {
+						continue
+					}
+
+					// Try to allocate a brick on this device
+					brick := device.NewBrickEntry(brick_size,
+						float64(v.Info.Snapshot.Factor),
+						v.Info.Gid, v.Info.Id)
+
+					// Determine if it was successful
+					if brick != nil {
+
+						// If the first in the set, the reset the id
+						if i == 0 {
+							brick.SetId(brickId)
+						}
+
+						// Save the brick entry to create later
+						brick_entries = append(brick_entries, brick)
+
+						// Add to set list
+						setlist = append(setlist, brick)
+
+						// Add brick to device
+						device.BrickAdd(brick.Id())
+
+						// Add brick to volume
+						v.BrickAdd(brick.Id())
+
+						// Save values
+						err := brick.Save(tx)
+						if err != nil {
+							return err
+						}
+
+						err = device.Save(tx)
+						if err != nil {
+							return err
+						}
+
+						return nil
+					}
+				}
+
+				// Check if allocator returned an error
+				if err := <-errc; err != nil {
+					return err
+				}
+
+				// No devices found
+				return ErrNoSpace
+
+			})
+			if err != nil {
+				return brick_entries, err
+			}
+		}
+	}
+	return brick_entries, nil
+}
+
 func (v *VolumeEntry) allocBricksInCluster(db *bolt.DB,
 	allocator Allocator,
 	cluster string,
@@ -410,114 +526,9 @@ func (v *VolumeEntry) allocBricks(
 		}
 	}()
 
-	// Initialize brick_entries
-	brick_entries = make([]*BrickEntry, 0)
+	brick_entries, e = allocateBricks(db, allocator, cluster, v, bricksets, brick_size)
 
-	// Determine allocation for each brick required for this volume
-	for brick_num := 0; brick_num < bricksets; brick_num++ {
-		logger.Info("brick_num: %v", brick_num)
-
-		// Create a brick set list to later make sure that the
-		// proposed bricks and devices are acceptable
-		setlist := make([]*BrickEntry, 0)
-
-		// Generate an id for the brick
-		brickId := utils.GenUUID()
-
-		// Get allocator generator
-		// The same generator should be used for the brick and its replicas
-		deviceCh, done, errc := allocator.GetNodes(cluster, brickId)
-		defer func() {
-			close(done)
-		}()
-
-		// Check location has space for each brick and its replicas
-		for i := 0; i < v.Durability.BricksInSet(); i++ {
-			logger.Debug("%v / %v", i, v.Durability.BricksInSet())
-
-			// Do the work in the database context so that the cluster
-			// data does not change while determining brick location
-			err := db.Update(func(tx *bolt.Tx) error {
-
-				// Check the ring for devices to place the brick
-				for deviceId := range deviceCh {
-
-					// Get device entry
-					device, err := NewDeviceEntryFromId(tx, deviceId)
-					if err != nil {
-						return err
-					}
-
-					// Do not allow a device from the same node to be
-					// in the set
-					deviceOk := true
-					for _, brickInSet := range setlist {
-						if brickInSet.Info.NodeId == device.NodeId {
-							deviceOk = false
-						}
-					}
-
-					if !deviceOk {
-						continue
-					}
-
-					// Try to allocate a brick on this device
-					brick := device.NewBrickEntry(brick_size,
-						float64(v.Info.Snapshot.Factor),
-						v.Info.Gid, v.Info.Id)
-
-					// Determine if it was successful
-					if brick != nil {
-
-						// If the first in the set, the reset the id
-						if i == 0 {
-							brick.SetId(brickId)
-						}
-
-						// Save the brick entry to create later
-						brick_entries = append(brick_entries, brick)
-
-						// Add to set list
-						setlist = append(setlist, brick)
-
-						// Add brick to device
-						device.BrickAdd(brick.Id())
-
-						// Add brick to volume
-						v.BrickAdd(brick.Id())
-
-						// Save values
-						err := brick.Save(tx)
-						if err != nil {
-							return err
-						}
-
-						err = device.Save(tx)
-						if err != nil {
-							return err
-						}
-
-						return nil
-					}
-				}
-
-				// Check if allocator returned an error
-				if err := <-errc; err != nil {
-					return err
-				}
-
-				// No devices found
-				return ErrNoSpace
-
-			})
-			if err != nil {
-				return brick_entries, err
-			}
-		}
-	}
-
-	return brick_entries, nil
-
+	return brick_entries, e
 }
 
 func (v *VolumeEntry) removeBrickFromDb(tx *bolt.Tx, brick *BrickEntry) error {

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -18,16 +18,23 @@ import (
 	"github.com/heketi/heketi/pkg/utils"
 )
 
+type BrickAllocation struct {
+	Bricks  []*BrickEntry
+	Devices []*DeviceEntry
+}
+
 func allocateBricks(
 	db *bolt.DB,
 	allocator Allocator,
 	cluster string,
 	v *VolumeEntry,
 	bricksets int,
-	brick_size uint64) ([]*BrickEntry, error) {
+	brick_size uint64) (*BrickAllocation, error) {
 
-	// Initialize brick_entries
-	brick_entries := make([]*BrickEntry, 0)
+	r := &BrickAllocation{
+		Bricks:  []*BrickEntry{},
+		Devices: []*DeviceEntry{},
+	}
 
 	// Determine allocation for each brick required for this volume
 	for brick_num := 0; brick_num < bricksets; brick_num++ {
@@ -91,7 +98,8 @@ func allocateBricks(
 						}
 
 						// Save the brick entry to create later
-						brick_entries = append(brick_entries, brick)
+						r.Bricks = append(r.Bricks, brick)
+						r.Devices = append(r.Devices, device)
 
 						// Add to set list
 						setlist = append(setlist, brick)
@@ -127,11 +135,11 @@ func allocateBricks(
 
 			})
 			if err != nil {
-				return brick_entries, err
+				return r, err
 			}
 		}
 	}
-	return brick_entries, nil
+	return r, nil
 }
 
 func (v *VolumeEntry) allocBricksInCluster(db *bolt.DB,
@@ -526,7 +534,8 @@ func (v *VolumeEntry) allocBricks(
 		}
 	}()
 
-	brick_entries, e = allocateBricks(db, allocator, cluster, v, bricksets, brick_size)
+	r, e := allocateBricks(db, allocator, cluster, v, bricksets, brick_size)
+	brick_entries = r.Bricks
 
 	return brick_entries, e
 }


### PR DESCRIPTION
As a precursor to the db update/exec untangle work separate the code that allocates bricks on devices into parts that access the db in a read-only fashion from those that write to the db.