### PR TITLE
support database abstraction and encapsulation

### DIFF
--- a/apps/glusterfs/allocator_mock.go
+++ b/apps/glusterfs/allocator_mock.go
@@ -14,15 +14,17 @@ import (
 	"github.com/heketi/heketi/pkg/utils"
 	"sort"
 	"sync"
+
+	wdb "github.com/heketi/heketi/pkg/db"
 )
 
 type MockAllocator struct {
 	clustermap map[string]sort.StringSlice
 	lock       sync.Mutex
-	db         bolt.DB
+	db         wdb.RODB
 }
 
-func NewMockAllocator(db *bolt.DB) *MockAllocator {
+func NewMockAllocator(db wdb.RODB) *MockAllocator {
 	d := &MockAllocator{}
 	d.clustermap = make(map[string]sort.StringSlice)
 

--- a/apps/glusterfs/allocator_simple.go
+++ b/apps/glusterfs/allocator_simple.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	"github.com/boltdb/bolt"
+	wdb "github.com/heketi/heketi/pkg/db"
 )
 
 // Simple allocator contains a map to rings of clusters
@@ -29,7 +30,7 @@ func NewSimpleAllocator() *SimpleAllocator {
 }
 
 // Create a new simple allocator and initialize it with data from the db
-func NewSimpleAllocatorFromDb(db *bolt.DB) *SimpleAllocator {
+func NewSimpleAllocatorFromDb(db wdb.RODB) *SimpleAllocator {
 
 	s := NewSimpleAllocator()
 

--- a/apps/glusterfs/app_middleware_test.go
+++ b/apps/glusterfs/app_middleware_test.go
@@ -18,7 +18,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/boltdb/bolt"
+	//"github.com/boltdb/bolt"
+	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/heketi/tests"
 )
@@ -101,7 +102,7 @@ func TestBackupToKubeSecretBackupOnNonGet(t *testing.T) {
 	defer app.Close()
 
 	incluster_count := 0
-	defer tests.Patch(&kubeBackupDbToSecret, func(db *bolt.DB) error {
+	defer tests.Patch(&kubeBackupDbToSecret, func(db wdb.RODB) error {
 		incluster_count++
 		return nil
 	}).Restore()
@@ -143,7 +144,7 @@ func TestBackupToKubeSecretBackupOnGet(t *testing.T) {
 	defer app.Close()
 
 	incluster_count := 0
-	defer tests.Patch(&kubeBackupDbToSecret, func(db *bolt.DB) error {
+	defer tests.Patch(&kubeBackupDbToSecret, func(db wdb.RODB) error {
 		incluster_count++
 		return nil
 	}).Restore()

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/heketi/heketi/executors"
+	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/lpabon/godbc"
@@ -34,7 +35,7 @@ func BlockVolumeList(tx *bolt.Tx) ([]string, error) {
 }
 
 // Creates a File volume to host block volumes
-func CreateBlockHostingVolume(db *bolt.DB, executor executors.Executor, allocator Allocator, clusters []string) (*VolumeEntry, error) {
+func CreateBlockHostingVolume(db wdb.DB, executor executors.Executor, allocator Allocator, clusters []string) (*VolumeEntry, error) {
 	var msg api.VolumeCreateRequest
 	var err error
 
@@ -151,7 +152,7 @@ func (v *BlockVolumeEntry) Unmarshal(buffer []byte) error {
 	return nil
 }
 
-func (v *BlockVolumeEntry) Create(db *bolt.DB,
+func (v *BlockVolumeEntry) Create(db wdb.DB,
 	executor executors.Executor,
 	allocator Allocator) (e error) {
 
@@ -344,7 +345,7 @@ func (v *BlockVolumeEntry) Create(db *bolt.DB,
 	return nil
 }
 
-func (v *BlockVolumeEntry) Destroy(db *bolt.DB, executor executors.Executor) error {
+func (v *BlockVolumeEntry) Destroy(db wdb.DB, executor executors.Executor) error {
 	logger.Info("Destroying volume %v", v.Info.Id)
 
 	var blockHostingVolumeName string

--- a/apps/glusterfs/block_volume_entry_create.go
+++ b/apps/glusterfs/block_volume_entry_create.go
@@ -14,11 +14,12 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/heketi/heketi/executors"
+	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/lpabon/godbc"
 )
 
 // Creates a block volume
-func (v *BlockVolumeEntry) createBlockVolume(db *bolt.DB,
+func (v *BlockVolumeEntry) createBlockVolume(db wdb.RODB,
 	executor executors.Executor, blockHostingVolumeId string) error {
 
 	godbc.Require(db != nil)
@@ -46,7 +47,7 @@ func (v *BlockVolumeEntry) createBlockVolume(db *bolt.DB,
 	return nil
 }
 
-func (v *BlockVolumeEntry) createBlockVolumeRequest(db *bolt.DB,
+func (v *BlockVolumeEntry) createBlockVolumeRequest(db wdb.RODB,
 	executor executors.Executor,
 	blockHostingVolumeId string) (*executors.BlockVolumeRequest, string, error) {
 	godbc.Require(db != nil)

--- a/apps/glusterfs/brick_create.go
+++ b/apps/glusterfs/brick_create.go
@@ -10,8 +10,8 @@
 package glusterfs
 
 import (
-	"github.com/boltdb/bolt"
 	"github.com/heketi/heketi/executors"
+	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/utils"
 )
 
@@ -22,7 +22,7 @@ const (
 	CREATOR_DESTROY
 )
 
-func createDestroyConcurrently(db *bolt.DB,
+func createDestroyConcurrently(db wdb.DB,
 	executor executors.Executor,
 	brick_entries []*BrickEntry,
 	create_type CreateType) error {
@@ -56,10 +56,10 @@ func createDestroyConcurrently(db *bolt.DB,
 	return err
 }
 
-func CreateBricks(db *bolt.DB, executor executors.Executor, brick_entries []*BrickEntry) error {
+func CreateBricks(db wdb.DB, executor executors.Executor, brick_entries []*BrickEntry) error {
 	return createDestroyConcurrently(db, executor, brick_entries, CREATOR_CREATE)
 }
 
-func DestroyBricks(db *bolt.DB, executor executors.Executor, brick_entries []*BrickEntry) error {
+func DestroyBricks(db wdb.DB, executor executors.Executor, brick_entries []*BrickEntry) error {
 	return createDestroyConcurrently(db, executor, brick_entries, CREATOR_DESTROY)
 }

--- a/apps/glusterfs/brick_entry.go
+++ b/apps/glusterfs/brick_entry.go
@@ -208,7 +208,7 @@ func (b *BrickEntry) Destroy(db wdb.RODB, executor executors.Executor) error {
 	return nil
 }
 
-func (b *BrickEntry) DestroyCheck(db *bolt.DB, executor executors.Executor) error {
+func (b *BrickEntry) DestroyCheck(db wdb.RODB, executor executors.Executor) error {
 	godbc.Require(db != nil)
 	godbc.Require(b.TpSize > 0)
 	godbc.Require(b.Info.Size > 0)

--- a/apps/glusterfs/brick_entry.go
+++ b/apps/glusterfs/brick_entry.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/heketi/heketi/executors"
+	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/lpabon/godbc"
@@ -123,7 +124,7 @@ func (b *BrickEntry) Unmarshal(buffer []byte) error {
 	return nil
 }
 
-func (b *BrickEntry) Create(db *bolt.DB, executor executors.Executor) error {
+func (b *BrickEntry) Create(db wdb.RODB, executor executors.Executor) error {
 	godbc.Require(db != nil)
 	godbc.Require(b.TpSize > 0)
 	godbc.Require(b.Info.Size > 0)
@@ -167,7 +168,7 @@ func (b *BrickEntry) Create(db *bolt.DB, executor executors.Executor) error {
 	return nil
 }
 
-func (b *BrickEntry) Destroy(db *bolt.DB, executor executors.Executor) error {
+func (b *BrickEntry) Destroy(db wdb.RODB, executor executors.Executor) error {
 
 	godbc.Require(db != nil)
 	godbc.Require(b.TpSize > 0)

--- a/apps/glusterfs/device_entry.go
+++ b/apps/glusterfs/device_entry.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/heketi/heketi/executors"
+	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/lpabon/godbc"
@@ -203,7 +204,7 @@ func (d *DeviceEntry) addDeviceToRing(tx *bolt.Tx,
 	return a.AddDevice(cluster, node, d)
 }
 
-func (d *DeviceEntry) SetState(db *bolt.DB,
+func (d *DeviceEntry) SetState(db wdb.DB,
 	e executors.Executor,
 	a Allocator,
 	s api.EntryState) error {
@@ -435,7 +436,7 @@ func (d *DeviceEntry) poolMetadataSize(tpsize uint64) uint64 {
 }
 
 // Moves all the bricks from the device to one or more other devices
-func (d *DeviceEntry) Remove(db *bolt.DB,
+func (d *DeviceEntry) Remove(db wdb.DB,
 	executor executors.Executor,
 	allocator Allocator) (e error) {
 

--- a/apps/glusterfs/node_entry.go
+++ b/apps/glusterfs/node_entry.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/heketi/heketi/executors"
+	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/lpabon/godbc"
@@ -70,7 +71,7 @@ func (n *NodeEntry) registerStorageKey(host string) string {
 }
 
 // Verify gluster process in the node and return the manage hostname of a node in the cluster
-func GetVerifiedManageHostname(db *bolt.DB, e executors.Executor, clusterId string) (string, error) {
+func GetVerifiedManageHostname(db wdb.RODB, e executors.Executor, clusterId string) (string, error) {
 	godbc.Require(clusterId != "")
 	var cluster *ClusterEntry
 	var node *NodeEntry

--- a/apps/glusterfs/node_entry.go
+++ b/apps/glusterfs/node_entry.go
@@ -330,7 +330,7 @@ func (n *NodeEntry) addAllDisksToRing(tx *bolt.Tx,
 	return nil
 }
 
-func (n *NodeEntry) SetState(db *bolt.DB, e executors.Executor,
+func (n *NodeEntry) SetState(db wdb.DB, e executors.Executor,
 	a Allocator,
 	s api.EntryState) error {
 

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/heketi/heketi/executors"
+	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/lpabon/godbc"
@@ -224,7 +225,7 @@ func (v *VolumeEntry) BrickDelete(id string) {
 	v.Bricks = utils.SortedStringsDelete(v.Bricks, id)
 }
 
-func (v *VolumeEntry) Create(db *bolt.DB,
+func (v *VolumeEntry) Create(db wdb.DB,
 	executor executors.Executor,
 	allocator Allocator) (e error) {
 
@@ -385,7 +386,7 @@ func (v *VolumeEntry) Create(db *bolt.DB,
 
 }
 
-func (v *VolumeEntry) Destroy(db *bolt.DB, executor executors.Executor) error {
+func (v *VolumeEntry) Destroy(db wdb.DB, executor executors.Executor) error {
 	logger.Info("Destroying volume %v", v.Info.Id)
 
 	// Get the entries from the database
@@ -476,7 +477,7 @@ func (v *VolumeEntry) Destroy(db *bolt.DB, executor executors.Executor) error {
 	return err
 }
 
-func (v *VolumeEntry) Expand(db *bolt.DB,
+func (v *VolumeEntry) Expand(db wdb.DB,
 	executor executors.Executor,
 	allocator Allocator,
 	sizeGB int) (e error) {
@@ -559,7 +560,7 @@ func (v *VolumeEntry) BricksIds() sort.StringSlice {
 	return ids
 }
 
-func (v *VolumeEntry) checkBricksCanBeDestroyed(db *bolt.DB,
+func (v *VolumeEntry) checkBricksCanBeDestroyed(db wdb.RODB,
 	executor executors.Executor,
 	brick_entries []*BrickEntry) error {
 
@@ -596,7 +597,7 @@ func (v *VolumeEntry) BlockVolumeDelete(id string) {
 	v.Info.BlockInfo.BlockVolumes = utils.SortedStringsDelete(v.Info.BlockInfo.BlockVolumes, id)
 }
 
-func eligibleClusters(db *bolt.DB, v *VolumeEntry,
+func eligibleClusters(db wdb.RODB, v *VolumeEntry,
 	possibleClusters []string) ([]string, error) {
 	//
 	// If the request carries the Block flag, consider only

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -14,11 +14,12 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/heketi/heketi/executors"
+	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
 )
 
-func (v *VolumeEntry) allocBricksInCluster(db *bolt.DB,
+func (v *VolumeEntry) allocBricksInCluster(db wdb.DB,
 	allocator Allocator,
 	cluster string,
 	gbsize int) ([]*BrickEntry, error) {
@@ -67,7 +68,7 @@ func (v *VolumeEntry) allocBricksInCluster(db *bolt.DB,
 	}
 }
 
-func (v *VolumeEntry) getBrickEntryfromBrickName(db *bolt.DB, brickname string) (brickEntry *BrickEntry, e error) {
+func (v *VolumeEntry) getBrickEntryfromBrickName(db wdb.RODB, brickname string) (brickEntry *BrickEntry, e error) {
 
 	var nodeEntry *NodeEntry
 	for _, brickid := range v.BricksIds() {
@@ -96,7 +97,7 @@ func (v *VolumeEntry) getBrickEntryfromBrickName(db *bolt.DB, brickname string) 
 	return nil, ErrNotFound
 }
 
-func (v *VolumeEntry) replaceBrickInVolume(db *bolt.DB, executor executors.Executor,
+func (v *VolumeEntry) replaceBrickInVolume(db wdb.DB, executor executors.Executor,
 	allocator Allocator,
 	oldBrickId string) (e error) {
 
@@ -389,7 +390,7 @@ func (v *VolumeEntry) replaceBrickInVolume(db *bolt.DB, executor executors.Execu
 }
 
 func (v *VolumeEntry) allocBricks(
-	db *bolt.DB,
+	db wdb.DB,
 	allocator Allocator,
 	cluster string,
 	bricksets int,

--- a/apps/glusterfs/volume_entry_create.go
+++ b/apps/glusterfs/volume_entry_create.go
@@ -15,10 +15,11 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/heketi/heketi/executors"
+	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/lpabon/godbc"
 )
 
-func (v *VolumeEntry) createVolume(db *bolt.DB,
+func (v *VolumeEntry) createVolume(db wdb.RODB,
 	executor executors.Executor,
 	brick_entries []*BrickEntry) error {
 
@@ -71,7 +72,7 @@ func (v *VolumeEntry) createVolume(db *bolt.DB,
 	return nil
 }
 
-func (v *VolumeEntry) createVolumeRequest(db *bolt.DB,
+func (v *VolumeEntry) createVolumeRequest(db wdb.RODB,
 	brick_entries []*BrickEntry) (*executors.VolumeRequest, string, error) {
 	godbc.Require(db != nil)
 	godbc.Require(brick_entries != nil)

--- a/pkg/db/wrap.go
+++ b/pkg/db/wrap.go
@@ -1,0 +1,139 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package db
+
+import (
+	"errors"
+
+	"github.com/boltdb/bolt"
+)
+
+// RODB provides an abstraction for all types of db connection that
+// support Read-Only transactions.
+type RODB interface {
+	View(func(*bolt.Tx) error) error
+}
+
+// DB provides an abstraction for all types of db connection that
+// support both read and write transactions.
+type DB interface {
+	RODB
+	Update(func(*bolt.Tx) error) error
+}
+
+// DBWrap encapsulates a bolt DB object in a minimal interface
+// with additional run-time hooks and checks.
+type DBWrap struct {
+	db       *bolt.DB
+	readOnly bool
+}
+
+// NewDBWrap creates a new DBWrap that is defaulted to read/write mode.
+func NewDBWrap(db *bolt.DB) *DBWrap {
+	return &DBWrap{db, false}
+}
+
+// View wraps a read-only transaction.
+func (w *DBWrap) View(cb func(*bolt.Tx) error) error {
+	return w.db.View(func(tx *bolt.Tx) error {
+		return cb(tx)
+	})
+}
+
+// Update wraps a read-write transaction.
+// If Update is called on a read-only DBWrap it panics.
+func (w *DBWrap) Update(cb func(*bolt.Tx) error) error {
+	if w.readOnly {
+		panic(errors.New("Can not update a read-only DBWrap"))
+	}
+	return w.db.Update(func(tx *bolt.Tx) error {
+		return cb(tx)
+	})
+}
+
+// ReadOnly returns a new DBWrap object, based on the same connection as
+// the current object, set for read-only mode.
+func (w *DBWrap) ReadOnly() *DBWrap {
+	return &DBWrap{w.db, true}
+}
+
+// TxWrap encapsulates a bolt DB Tx object in a wrapper that implements
+// the RODB and DB interfaces. This is useful when defining a function
+// that can be used inside a transcation or start a transcation.
+type TxWrap struct {
+	tx       *bolt.Tx
+	readOnly bool
+}
+
+// View fakes a read-only transaction. The function signature of a read-only
+// transaction is supported but no new transaction is started.
+func (w *TxWrap) View(cb func(*bolt.Tx) error) error {
+	return cb(w.tx)
+}
+
+// Update fakes a read-write transaction. The function signature of a read-write
+// transaction is supported but no new transaction is started.
+func (w *TxWrap) Update(cb func(*bolt.Tx) error) error {
+	if w.readOnly {
+		panic(errors.New("Can not update a read-only TxWrap"))
+	}
+	return cb(w.tx)
+}
+
+// WrapReadWrite wraps a db object when applicible. If db is
+// already in a capsule the original object is returned (type cast).
+// Panics if the type is not valid for read-write encapsulation.
+func WrapReadWrite(db DB) *DBWrap {
+	switch db.(type) {
+	case *bolt.DB:
+		return NewDBWrap(db.(*bolt.DB))
+	case *DBWrap:
+		w := db.(*DBWrap)
+		if w.readOnly {
+			panic(errors.New("read-only DBWrap may not be wrapped as read-write"))
+		}
+		return w
+	default:
+		panic(errors.New("type can not be wrapped in a db capsule"))
+	}
+}
+
+// WrapReadOnly wraps a db object when applicible. If db is
+// already in a capsule the original object is returned (type cast).
+// Panics if the type is not valid for read-only encapsulation.
+func WrapReadOnly(db DB) *DBWrap {
+	switch db.(type) {
+	case *bolt.DB:
+		return NewDBWrap(db.(*bolt.DB)).ReadOnly()
+	case *DBWrap:
+		w := db.(*DBWrap)
+		if w.readOnly {
+			return w
+		}
+		return w.ReadOnly()
+	default:
+		panic(errors.New("type can not be wrapped in a read only db capsule"))
+	}
+}
+
+// WrapTx takes a bolt db transaction object and return a TxWrap object.
+// This new object can now be used where the DB or RODB interfaces are
+// used without starting a new transaction.
+func WrapTx(tx *bolt.Tx) *TxWrap {
+	return &TxWrap{tx, false}
+}
+
+// WrapTx takes a bolt db transaction object and return a TxWrap object.
+// This new object can now be used where the DB or RODB interfaces are
+// used without starting a new transaction.
+// This wrapper will panic is .Update is called at runtime.
+func WrapTxReadOnly(tx *bolt.Tx) *TxWrap {
+	return &TxWrap{tx, true}
+}

--- a/pkg/db/wrap_test.go
+++ b/pkg/db/wrap_test.go
@@ -1,0 +1,298 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package db
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/boltdb/bolt"
+	"github.com/heketi/tests"
+)
+
+func TestMinimalDBWrap(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create a db
+	db, err := bolt.Open(tmpfile, 0600, &bolt.Options{Timeout: 3 * time.Second})
+	tests.Assert(t, err == nil, "expected (bolt.Open) err == nil, got:", err)
+	tests.Assert(t, db != nil, "expected (bolt.Open) db != nil, got:", err)
+
+	w := NewDBWrap(db)
+	tests.Assert(t, !w.readOnly, "expected w.readOnly to be false, got:", w.readOnly)
+
+	wasCalled := false
+	w.View(func(tx *bolt.Tx) error {
+		wasCalled = true
+		return nil
+	})
+	tests.Assert(t, wasCalled, "expected wasCalled to be true, got:", wasCalled)
+
+	wasCalled = false
+	w.Update(func(tx *bolt.Tx) error {
+		wasCalled = true
+		return nil
+	})
+	tests.Assert(t, wasCalled, "expected wasCalled to be true, got:", wasCalled)
+}
+
+func TestDBWrapping(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create a db
+	db, err := bolt.Open(tmpfile, 0600, &bolt.Options{Timeout: 3 * time.Second})
+	tests.Assert(t, err == nil, "expected (bolt.Open) err == nil, got:", err)
+	tests.Assert(t, db != nil, "expected (bolt.Open) db != nil, got:", err)
+
+	w := WrapReadWrite(db)
+	tests.Assert(t, !w.readOnly, "expected w.readOnly to be false, got:", w.readOnly)
+
+	w2 := WrapReadWrite(w)
+	tests.Assert(t, !w2.readOnly, "expected w.readOnly to be false, got:", w.readOnly)
+
+	tests.Assert(t, w == w2, "expected w == w2, got:", w, w2)
+}
+
+func TestDBWrapToReadOnly(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create a db
+	db, err := bolt.Open(tmpfile, 0600, &bolt.Options{Timeout: 3 * time.Second})
+	tests.Assert(t, err == nil, "expected (bolt.Open) err == nil, got:", err)
+	tests.Assert(t, db != nil, "expected (bolt.Open) db != nil, got:", err)
+
+	w := WrapReadWrite(db)
+	tests.Assert(t, !w.readOnly, "expected w.readOnly to be false, got:", w.readOnly)
+
+	w2 := w.ReadOnly()
+	tests.Assert(t, w2.readOnly, "expected w2.readOnly to be true, got:", w2.readOnly)
+}
+
+func TestDBWrappingReadOnly(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create a db
+	db, err := bolt.Open(tmpfile, 0600, &bolt.Options{Timeout: 3 * time.Second})
+	tests.Assert(t, err == nil, "expected (bolt.Open) err == nil, got:", err)
+	tests.Assert(t, db != nil, "expected (bolt.Open) db != nil, got:", err)
+
+	w := WrapReadOnly(db)
+	tests.Assert(t, w.readOnly, "expected w.readOnly to be true, got:", w.readOnly)
+
+	w2 := WrapReadOnly(w)
+	tests.Assert(t, w2.readOnly, "expected w.readOnly to be true, got:", w.readOnly)
+
+	tests.Assert(t, w == w2, "expected w == w2, got:", w, w2)
+}
+
+func TestDBWrappingConvertToReadOnly(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create a db
+	db, err := bolt.Open(tmpfile, 0600, &bolt.Options{Timeout: 3 * time.Second})
+	tests.Assert(t, err == nil, "expected (bolt.Open) err == nil, got:", err)
+	tests.Assert(t, db != nil, "expected (bolt.Open) db != nil, got:", err)
+
+	w := WrapReadWrite(db)
+	tests.Assert(t, !w.readOnly, "expected w.readOnly to be false, got:", !w.readOnly)
+
+	w2 := WrapReadOnly(w)
+	tests.Assert(t, w2.readOnly, "expected w.readOnly to be true, got:", w.readOnly)
+
+	tests.Assert(t, w != w2, "expected w != w2, got:", w, w2)
+}
+
+func TestDBWrappingInvalidConverToReadWrite(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create a db
+	db, err := bolt.Open(tmpfile, 0600, &bolt.Options{Timeout: 3 * time.Second})
+	tests.Assert(t, err == nil, "expected (bolt.Open) err == nil, got:", err)
+	tests.Assert(t, db != nil, "expected (bolt.Open) db != nil, got:", err)
+
+	w := WrapReadOnly(db)
+	tests.Assert(t, w.readOnly, "expected w.readOnly to be true, got:", w.readOnly)
+
+	defer func() {
+		e := recover()
+		tests.Assert(t, e != nil, "expected e != nil, got", e)
+	}()
+	WrapReadWrite(w)
+	t.Fatalf("should not reach this line")
+}
+
+func TestDBWrapPanicOnUpdateReadOnly(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create a db
+	db, err := bolt.Open(tmpfile, 0600, &bolt.Options{Timeout: 3 * time.Second})
+	tests.Assert(t, err == nil, "expected (bolt.Open) err == nil, got:", err)
+	tests.Assert(t, db != nil, "expected (bolt.Open) db != nil, got:", err)
+
+	w := WrapReadOnly(db)
+	tests.Assert(t, w.readOnly, "expected w.readOnly to be true, got:", w.readOnly)
+
+	defer func() {
+		e := recover()
+		tests.Assert(t, e != nil, "expected e != nil, got", e)
+	}()
+	w.Update(func(tx *bolt.Tx) error {
+		t.Fatalf("should never get called")
+		return nil
+	})
+	t.Fatalf("should not reach this line")
+}
+
+type junkDB struct {
+	Foo int
+}
+
+func (j junkDB) View(func(tx *bolt.Tx) error) error {
+	return nil
+}
+
+func (j junkDB) Update(func(tx *bolt.Tx) error) error {
+	return nil
+}
+
+func TestDBWrappingBadType(t *testing.T) {
+
+	defer func() {
+		e := recover()
+		tests.Assert(t, e != nil, "expected e != nil, got", e)
+	}()
+
+	WrapReadWrite(junkDB{})
+	t.Fatalf("should not reach this line")
+}
+
+func TestDBWrappingROBadType(t *testing.T) {
+
+	defer func() {
+		e := recover()
+		tests.Assert(t, e != nil, "expected e != nil, got", e)
+	}()
+
+	WrapReadOnly(junkDB{})
+	t.Fatalf("should not reach this line")
+}
+
+func TestTxWrapNestView(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create a db
+	db, err := bolt.Open(tmpfile, 0600, &bolt.Options{Timeout: 3 * time.Second})
+	tests.Assert(t, err == nil, "expected (bolt.Open) err == nil, got:", err)
+	tests.Assert(t, db != nil, "expected (bolt.Open) db != nil, got:", err)
+
+	stuff := 0
+	// f mimics a standalone function that wants a DB object but we want
+	// to use it within an existing transaction
+	f := func(db RODB) error {
+		stuff++
+		db.View(func(tx *bolt.Tx) error {
+			stuff++
+			return nil
+		})
+		stuff++
+		return nil
+	}
+
+	db.View(func(tx *bolt.Tx) error {
+		stuff++
+		f(WrapTxReadOnly(tx))
+		stuff++
+		return nil
+	})
+
+	tests.Assert(t, stuff == 5, "expected stuff == 5, got:", 5)
+}
+
+func TestTxWrapNestUpdate(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create a db
+	db, err := bolt.Open(tmpfile, 0600, &bolt.Options{Timeout: 3 * time.Second})
+	tests.Assert(t, err == nil, "expected (bolt.Open) err == nil, got:", err)
+	tests.Assert(t, db != nil, "expected (bolt.Open) db != nil, got:", err)
+
+	stuff := 0
+	// f mimics a standalone function that wants a DB object but we want
+	// to use it within an existing transaction
+	f := func(db DB) error {
+		stuff++
+		db.Update(func(tx *bolt.Tx) error {
+			stuff++
+			return nil
+		})
+		stuff++
+		return nil
+	}
+
+	db.Update(func(tx *bolt.Tx) error {
+		stuff++
+		f(WrapTx(tx))
+		stuff++
+		return nil
+	})
+
+	tests.Assert(t, stuff == 5, "expected stuff == 5, got:", 5)
+}
+
+func TestTxWrapFailUpdateOnRO(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create a db
+	db, err := bolt.Open(tmpfile, 0600, &bolt.Options{Timeout: 3 * time.Second})
+	tests.Assert(t, err == nil, "expected (bolt.Open) err == nil, got:", err)
+	tests.Assert(t, db != nil, "expected (bolt.Open) db != nil, got:", err)
+
+	stuff := 0
+	// f mimics a standalone function that wants a DB object but we want
+	// to use it within an existing transaction
+	f := func(db DB) error {
+		stuff++
+		db.Update(func(tx *bolt.Tx) error {
+			stuff++
+			return nil
+		})
+		stuff++
+		return nil
+	}
+
+	defer func() {
+		e := recover()
+		tests.Assert(t, e != nil, "expected e != nil, got", e)
+		tests.Assert(t, stuff == 2, "expected stuff == 2, got:", stuff)
+	}()
+
+	// generally you would want to correctly use DB or RODB so that the type
+	// system can catch errors. However we have extra runtime guards against
+	// calling a write method on a R/O TxWrap.
+	db.Update(func(tx *bolt.Tx) error {
+		stuff++
+		f(WrapTxReadOnly(tx))
+		stuff++
+		return nil
+	})
+
+	t.Fatalf("should not reach this line")
+}

--- a/pkg/kubernetes/backupdb.go
+++ b/pkg/kubernetes/backupdb.go
@@ -16,6 +16,7 @@ import (
 	"os"
 
 	"github.com/boltdb/bolt"
+	wdb "github.com/heketi/heketi/pkg/db"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	restclient "k8s.io/client-go/rest"
@@ -32,7 +33,7 @@ var (
 	dbSecretName = "heketi-db-backup"
 )
 
-func KubeBackupDbToSecret(db *bolt.DB) error {
+func KubeBackupDbToSecret(db wdb.RODB) error {
 
 	// Check if we should use another name for the heketi backup secret
 	env := os.Getenv("HEKETI_KUBE_DB_SECRET_NAME")


### PR DESCRIPTION
As part of the effort to untangle db write operations and command execution I found it difficult to incrementally refactor code that might be called in two or more code-paths. I might want to be able to call a function within an existing DB transaction or standalone. These change allow us to:

a) provide clean interface based function arguments, abstracting away the exact database object in use

b) provide wrapper objects that let us build our own hooks on top of boltdb behavior without needing changes to bolt and encapsulating existing transactions in mock db interface objects