### PR TITLE
predetermine brick path on brick db entries

### DIFF
--- a/apps/glusterfs/brick_entry.go
+++ b/apps/glusterfs/brick_entry.go
@@ -153,7 +153,7 @@ func (b *BrickEntry) Create(db wdb.RODB, executor executors.Executor) error {
 	req.TpSize = b.TpSize
 	req.VgId = b.Info.DeviceId
 	req.PoolMetadataSize = b.PoolMetadataSize
-	req.Path = utils.BrickMountPoint(req.VgId, req.Name)
+	req.Path = utils.BrickPath(req.VgId, req.Name)
 
 	// Create brick on node
 	logger.Info("Creating brick %v", b.Info.Id)

--- a/apps/glusterfs/brick_entry.go
+++ b/apps/glusterfs/brick_entry.go
@@ -196,7 +196,6 @@ func (b *BrickEntry) Destroy(db wdb.RODB, executor executors.Executor) error {
 	req.Size = b.Info.Size
 	req.TpSize = b.TpSize
 	req.VgId = b.Info.DeviceId
-	req.Path = utils.BrickMountPoint(req.VgId, req.Name)
 
 	// Delete brick on node
 	logger.Info("Deleting brick %v", b.Info.Id)
@@ -235,7 +234,6 @@ func (b *BrickEntry) DestroyCheck(db wdb.RODB, executor executors.Executor) erro
 	req.Size = b.Info.Size
 	req.TpSize = b.TpSize
 	req.VgId = b.Info.DeviceId
-	req.Path = utils.BrickMountPoint(req.VgId, req.Name)
 
 	// Check brick on node
 	return executor.BrickDestroyCheck(host, req)

--- a/executors/cmdexec/brick.go
+++ b/executors/cmdexec/brick.go
@@ -33,6 +33,7 @@ func (s *CmdExecutor) BrickCreate(host string,
 	// make local vars with more accurate names to cut down on name confusion
 	// and make future refactoring easier
 	mountPath := brick.Path
+	brickPath := fmt.Sprintf("%v/brick", mountPath)
 
 	// Create command set to execute on the node
 	devnode := utils.BrickDevNode(brick.VgId, brick.Name)
@@ -74,7 +75,7 @@ func (s *CmdExecutor) BrickCreate(host string,
 		fmt.Sprintf("mount -o rw,inode64,noatime,nouuid %v %v", devnode, mountPath),
 
 		// Create a directory inside the formated volume for GlusterFS
-		fmt.Sprintf("mkdir %v/brick", mountPath),
+		fmt.Sprintf("mkdir %v", brickPath),
 	}
 
 	// Only set the GID if the value is other than root(gid 0).
@@ -82,10 +83,10 @@ func (s *CmdExecutor) BrickCreate(host string,
 	if 0 != brick.Gid {
 		commands = append(commands, []string{
 			// Set GID on brick
-			fmt.Sprintf("chown :%v %v/brick", brick.Gid, mountPath),
+			fmt.Sprintf("chown :%v %v", brick.Gid, brickPath),
 
 			// Set writable by GID and UID
-			fmt.Sprintf("chmod 2775 %v/brick", mountPath),
+			fmt.Sprintf("chmod 2775 %v", brickPath),
 		}...)
 	}
 
@@ -99,7 +100,7 @@ func (s *CmdExecutor) BrickCreate(host string,
 
 	// Save brick location
 	b := &executors.BrickInfo{
-		Path: fmt.Sprintf("%v/brick", mountPath),
+		Path: brickPath,
 	}
 	return b, nil
 }

--- a/executors/cmdexec/brick.go
+++ b/executors/cmdexec/brick.go
@@ -32,8 +32,8 @@ func (s *CmdExecutor) BrickCreate(host string,
 
 	// make local vars with more accurate names to cut down on name confusion
 	// and make future refactoring easier
-	mountPath := brick.Path
-	brickPath := fmt.Sprintf("%v/brick", mountPath)
+	brickPath := brick.Path
+	mountPath := utils.BrickMountFromPath(brickPath)
 
 	// Create command set to execute on the node
 	devnode := utils.BrickDevNode(brick.VgId, brick.Name)

--- a/executors/cmdexec/brick_test.go
+++ b/executors/cmdexec/brick_test.go
@@ -32,7 +32,7 @@ func TestSshExecBrickCreate(t *testing.T) {
 		TpSize:           100,
 		Size:             10,
 		PoolMetadataSize: 5,
-		Path:             utils.BrickMountPoint("xvgid", "id"),
+		Path:             utils.BrickPath("xvgid", "id"),
 	}
 
 	// Mock ssh function
@@ -105,7 +105,7 @@ func TestSshExecBrickCreateWithGid(t *testing.T) {
 		Size:             10,
 		PoolMetadataSize: 5,
 		Gid:              1234,
-		Path:             utils.BrickMountPoint("xvgid", "id"),
+		Path:             utils.BrickPath("xvgid", "id"),
 	}
 
 	// Mock ssh function
@@ -188,7 +188,7 @@ func TestSshExecBrickCreateSudo(t *testing.T) {
 		TpSize:           100,
 		Size:             10,
 		PoolMetadataSize: 5,
-		Path:             utils.BrickMountPoint("xvgid", "id"),
+		Path:             utils.BrickPath("xvgid", "id"),
 	}
 
 	// Mock ssh function
@@ -261,7 +261,7 @@ func TestSshExecBrickDestroy(t *testing.T) {
 		TpSize:           100,
 		Size:             10,
 		PoolMetadataSize: 5,
-		Path:             utils.BrickMountPoint("xvgid", "id"),
+		Path:             utils.BrickPath("xvgid", "id"),
 	}
 
 	// Mock ssh function

--- a/pkg/utils/paths.go
+++ b/pkg/utils/paths.go
@@ -10,6 +10,7 @@
 package utils
 
 import (
+	"errors"
 	"path"
 )
 
@@ -34,6 +35,27 @@ func BrickIdToName(brickId string) string {
 // a LVM thin-pool name for a given brick id.
 func BrickIdToThinPoolName(brickId string) string {
 	return "tp_" + brickId
+}
+
+// BrickPath returns the "full" path to a brick.
+func BrickPath(vgId, brickId string) string {
+	return path.Join(
+		BrickMountPoint(vgId, brickId),
+		"brick")
+}
+
+// BrickMountFromPath returns the mount point of the brick given
+// the brick's full path. This is a convenience method that assumes
+// you have the brick path but not necessarily have the vgId and brickId
+// used to create the "dynamic" portions of the path.
+// Will panic if unexpected path components are encountered.
+func BrickMountFromPath(brickPath string) string {
+	p, rest := path.Split(path.Clean(brickPath))
+	if rest != "brick" {
+		// be super picky about validity to shake out any issues early
+		panic(errors.New("Unexpected path component: " + rest))
+	}
+	return path.Clean(p)
 }
 
 // BrickMountPoint returns the path of a directory

--- a/pkg/utils/paths_test.go
+++ b/pkg/utils/paths_test.go
@@ -67,3 +67,25 @@ func TestBrickDevNode(t *testing.T) {
 		`calling BrickDevNode("asdf", "fireplace"), expected`,
 		expected, "got", result)
 }
+
+func TestBrickMountFromPath(t *testing.T) {
+	p := "/var/lib/heketi/mounts/vg_asdf/brick_fireplace/brick"
+	expected := "/var/lib/heketi/mounts/vg_asdf/brick_fireplace"
+	result := BrickMountFromPath(p)
+	tests.Assert(t, expected == result,
+		"expected", expected, "got", result)
+
+	tests.Assert(t,
+		BrickMountPoint("abc", "def") == BrickMountFromPath(BrickPath("abc", "def")),
+		`expected BrickMountPoint("abc", "def") == BrickMountFromPath(BrickPath("abc", "def")), got:`,
+		BrickMountPoint("abc", "def"), BrickMountFromPath(BrickPath("abc", "def")))
+}
+
+func TestBrickMountFromPathIsStrict(t *testing.T) {
+	defer func() {
+		err := recover()
+		tests.Assert(t, err != nil, "epxected err != nil")
+	}()
+	BrickMountFromPath("asdf")
+	t.Fatalf("should not be reached")
+}


### PR DESCRIPTION
As a followup to PR #955, this series of changes prepares the executor to accept the brick path, rather than the brick mount-point (path). It then moves the origination of the path to when the brick entry is first created and uses that path for all subsequent operations (with an extra check left in the code intentionally since the lack of it was biting me hard during testing).