### PR TITLE
sshexec: restrict sudo to required commands

### DIFF
--- a/executors/cmdexec/brick.go
+++ b/executors/cmdexec/brick.go
@@ -66,7 +66,7 @@ func (s *CmdExecutor) BrickCreate(host string,
 		fmt.Sprintf("mkfs.xfs -i size=512 -n size=8192 %v", devnode),
 
 		// Fstab
-		fmt.Sprintf("echo \"%v %v xfs rw,inode64,noatime,nouuid 1 2\" | tee -a %v > /dev/null ",
+		fmt.Sprintf("awk \"BEGIN {print \\\"%v %v xfs rw,inode64,noatime,nouuid 1 2\\\" >> \\\"%v\\\"}\"",
 			devnode,
 			mountPath,
 			s.Fstab),

--- a/executors/cmdexec/brick_test.go
+++ b/executors/cmdexec/brick_test.go
@@ -63,10 +63,10 @@ func TestSshExecBrickCreate(t *testing.T) {
 
 			case 3:
 				tests.Assert(t,
-					cmd == "echo \"/dev/mapper/vg_xvgid-brick_id "+
+					cmd == "awk \"BEGIN {print \\\"/dev/mapper/vg_xvgid-brick_id "+
 						"/var/lib/heketi/mounts/vg_xvgid/brick_id "+
-						"xfs rw,inode64,noatime,nouuid 1 2\" | "+
-						"tee -a /my/fstab > /dev/null", cmd)
+						"xfs rw,inode64,noatime,nouuid 1 2\\\" "+
+						">> \\\"/my/fstab\\\"}\"", cmd)
 
 			case 4:
 				tests.Assert(t,
@@ -136,10 +136,10 @@ func TestSshExecBrickCreateWithGid(t *testing.T) {
 
 			case 3:
 				tests.Assert(t,
-					cmd == "echo \"/dev/mapper/vg_xvgid-brick_id "+
+					cmd == "awk \"BEGIN {print \\\"/dev/mapper/vg_xvgid-brick_id "+
 						"/var/lib/heketi/mounts/vg_xvgid/brick_id "+
-						"xfs rw,inode64,noatime,nouuid 1 2\" | "+
-						"tee -a /my/fstab > /dev/null", cmd)
+						"xfs rw,inode64,noatime,nouuid 1 2\\\" "+
+						">> \\\"/my/fstab\\\"}\"", cmd)
 
 			case 4:
 				tests.Assert(t,
@@ -220,10 +220,10 @@ func TestSshExecBrickCreateSudo(t *testing.T) {
 
 			case 3:
 				tests.Assert(t,
-					cmd == "echo \"/dev/mapper/vg_xvgid-brick_id "+
+					cmd == "awk \"BEGIN {print \\\"/dev/mapper/vg_xvgid-brick_id "+
 						"/var/lib/heketi/mounts/vg_xvgid/brick_id "+
-						"xfs rw,inode64,noatime,nouuid 1 2\" | "+
-						"tee -a /my/fstab > /dev/null", cmd)
+						"xfs rw,inode64,noatime,nouuid 1 2\\\" "+
+						">> \\\"/my/fstab\\\"}\"", cmd)
 
 			case 4:
 				tests.Assert(t,

--- a/executors/cmdexec/volume.go
+++ b/executors/cmdexec/volume.go
@@ -195,7 +195,9 @@ func (s *CmdExecutor) createAddBrickCommands(volume *executors.VolumeRequest,
 	}
 
 	// Add the last add-brick command to the command list
-	commands = append(commands, cmd)
+	if cmd != "" {
+		commands = append(commands, cmd)
+	}
 
 	return commands
 }

--- a/pkg/utils/ssh/ssh.go
+++ b/pkg/utils/ssh/ssh.go
@@ -142,13 +142,11 @@ func (s *SshExec) ConnectAndExec(host string, commands []string, timeoutMinutes 
 		session.Stdout = &b
 		session.Stderr = &berr
 
-		// Execute command in a shell
-		command = "/bin/bash -c '" + command + "'"
-
-		// Check if we need to use sudo for the entire command
 		if useSudo {
 			command = "sudo " + command
 		}
+		// Execute command in a shell
+		command = "/bin/bash -c '" + command + "'"
 
 		// Execute command
 		err = session.Start(command)


### PR DESCRIPTION
ssh executor starts bash with sudo if useSudo is set to true. Instead,
if only the command is executed with sudo permissions it will allow
admins to restrict sudo access using visudo.

Closes #958

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>