### PR TITLE
apps: add initial support for hiding certain items from apis

### DIFF
--- a/apps/glusterfs/app_block_volume.go
+++ b/apps/glusterfs/app_block_volume.go
@@ -98,7 +98,7 @@ func (a *App) BlockVolumeList(w http.ResponseWriter, r *http.Request) {
 	err := a.db.View(func(tx *bolt.Tx) error {
 		var err error
 
-		list.BlockVolumes, err = BlockVolumeList(tx)
+		list.BlockVolumes, err = ListCompleteBlockVolumes(tx)
 		if err != nil {
 			return err
 		}
@@ -129,9 +129,9 @@ func (a *App) BlockVolumeInfo(w http.ResponseWriter, r *http.Request) {
 	var info *api.BlockVolumeInfoResponse
 	err := a.db.View(func(tx *bolt.Tx) error {
 		entry, err := NewBlockVolumeEntryFromId(tx, id)
-		if err == ErrNotFound {
+		if err == ErrNotFound || !entry.Visible() {
 			http.Error(w, "Id not found", http.StatusNotFound)
-			return err
+			return ErrNotFound
 		} else if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return err

--- a/apps/glusterfs/app_cluster.go
+++ b/apps/glusterfs/app_cluster.go
@@ -150,6 +150,10 @@ func (a *App) ClusterInfo(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			return err
 		}
+		err = UpdateClusterInfoComplete(tx, info)
+		if err != nil {
+			return err
+		}
 
 		return nil
 	})

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -108,6 +108,11 @@ func (v *BlockVolumeEntry) BucketName() string {
 	return BOLTDB_BUCKET_BLOCKVOLUME
 }
 
+func (v *BlockVolumeEntry) Visible() bool {
+	// currently all block volumes are always visible
+	return true
+}
+
 func (v *BlockVolumeEntry) Save(tx *bolt.Tx) error {
 	godbc.Require(tx != nil)
 	godbc.Require(len(v.Info.Id) > 0)

--- a/apps/glusterfs/listing.go
+++ b/apps/glusterfs/listing.go
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"github.com/boltdb/bolt"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+)
+
+// ListCompleteVolumes returns a list of volume ID strings for volumes
+// that are not pending.
+func ListCompleteVolumes(tx *bolt.Tx) ([]string, error) {
+	return VolumeList(tx)
+}
+
+// ListCompleteBlockVolumes returns a list of block volume ID strings for bricks
+// that are not pending.
+func ListCompleteBlockVolumes(tx *bolt.Tx) ([]string, error) {
+	return BlockVolumeList(tx)
+}
+
+// UpdateClusterInfoComplete updates the given ClusterInfoResponse object so
+// that it only contains references to complete volumes, etc.
+func UpdateClusterInfoComplete(tx *bolt.Tx, ci *api.ClusterInfoResponse) error {
+	// currently this is a no-op because we have nothing to filter out
+	return nil
+}

--- a/apps/glusterfs/listing_test.go
+++ b/apps/glusterfs/listing_test.go
@@ -1,0 +1,110 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"os"
+	"testing"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+
+	"github.com/boltdb/bolt"
+	"github.com/heketi/tests"
+)
+
+func TestListCompleteVolumes(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		1,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	req := &api.VolumeCreateRequest{}
+	req.Size = 1024
+	req.Durability.Type = api.DurabilityReplicate
+	req.Durability.Replicate.Replica = 3
+
+	vol := NewVolumeEntryFromRequest(req)
+	err = vol.Create(app.db, app.executor, app.Allocator())
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	app.db.View(func(tx *bolt.Tx) error {
+		vols, err := ListCompleteVolumes(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(vols) == 1, "expected len(vols) == 1, got:", len(vols))
+
+		// this next bit just tickles test coverage for now
+		cids, err := ClusterList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(cids) == 1, "expected len(cids) == 1, got:", len(cids))
+		ce, err := NewClusterEntryFromId(tx, cids[0])
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		info, err := ce.NewClusterInfoResponse(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		err = UpdateClusterInfoComplete(tx, info)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(info.Volumes) == 1,
+			"expected len(info.Volumes) == 1, got:", len(info.Volumes))
+		return nil
+	})
+}
+
+func TestListCompleteBlockVolumes(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		1,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	req := &api.BlockVolumeCreateRequest{}
+	req.Size = 1024
+
+	vol := NewBlockVolumeEntryFromRequest(req)
+	err = vol.Create(app.db, app.executor, app.Allocator())
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	app.db.View(func(tx *bolt.Tx) error {
+		vols, err := ListCompleteBlockVolumes(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(vols) == 1, "expected len(vols) == 1, got:", len(vols))
+
+		// this next bit just tickles test coverage for now
+		cids, err := ClusterList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(cids) == 1, "expected len(cids) == 1, got:", len(cids))
+		ce, err := NewClusterEntryFromId(tx, cids[0])
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		info, err := ce.NewClusterInfoResponse(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		err = UpdateClusterInfoComplete(tx, info)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(info.BlockVolumes) == 1,
+			"expected len(info.BlockVolumes) == 1, got:", len(info.BlockVolumes))
+		return nil
+	})
+}

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -605,6 +605,13 @@ func (v *VolumeEntry) BlockVolumeDelete(id string) {
 	v.Info.BlockInfo.BlockVolumes = utils.SortedStringsDelete(v.Info.BlockInfo.BlockVolumes, id)
 }
 
+// Visible returns true if this volume is meant to be visible to
+// API calls.
+func (v *VolumeEntry) Visible() bool {
+	// right now volumes are always visible, this won't always be true
+	return true
+}
+
 func eligibleClusters(db wdb.RODB, v *VolumeEntry,
 	possibleClusters []string) ([]string, error) {
 	//


### PR DESCRIPTION
Add the initial support for hiding certain items from api requests. Specifically, it adds the ability to hide volumes from the volume list, volume info, and cluster info requests. Nothing is actually hidden yet, this is just the framework. 