### PR TITLE
tests: just use full length "uuids" instead of truncating them

### DIFF
--- a/apps/glusterfs/node_entry_test.go
+++ b/apps/glusterfs/node_entry_test.go
@@ -21,12 +21,11 @@ import (
 )
 
 func createSampleNodeEntry() *NodeEntry {
-	g := utils.GenUUID()
 	req := &api.NodeAddRequest{
 		ClusterId: "123",
 		Hostnames: api.HostAddresses{
-			Manage:  []string{"manage" + g[:4] + g[24:]},
-			Storage: []string{"storage" + g[:4] + g[24:]},
+			Manage:  []string{"manage" + utils.GenUUID()},
+			Storage: []string{"storage" + utils.GenUUID()},
 		},
 		Zone: 99,
 	}

--- a/client/api/go-client/client_test.go
+++ b/client/api/go-client/client_test.go
@@ -132,13 +132,12 @@ func TestTopology(t *testing.T) {
 		// Create a device request
 		sg := utils.NewStatusGroup()
 		for i := 0; i < 50; i++ {
-			b := utils.GenUUID()
 			sg.Add(1)
 			go func() {
 				defer sg.Done()
 
 				deviceReq := &api.DeviceAddRequest{}
-				deviceReq.Name = "/sd" + b[:4] + b[24:]
+				deviceReq.Name = "/sd" + utils.GenUUID()
 				deviceReq.NodeId = node.Id
 
 				// Create device
@@ -552,13 +551,12 @@ func TestClientVolume(t *testing.T) {
 		// Create a device request
 		sg := utils.NewStatusGroup()
 		for i := 0; i < 50; i++ {
-			b := utils.GenUUID()
 			sg.Add(1)
 			go func() {
 				defer sg.Done()
 
 				deviceReq := &api.DeviceAddRequest{}
-				deviceReq.Name = "/sd" + b[:4] + b[24:]
+				deviceReq.Name = "/sd" + utils.GenUUID()
 				deviceReq.NodeId = node.Id
 
 				// Create device


### PR DESCRIPTION
The previous methods were either non-functional when using the fake
uuid generator or a bit more complex than needed for simple unit
test fake-data generation. Units test pass with these full-length ids.

Signed-off-by: John Mulligan <jmulligan@redhat.com>