### PR TITLE
fix functional test errors due to vagrant-libvirt

### DIFF
--- a/tests/functional/TestManyBricksVolume/vagrant/Vagrantfile
+++ b/tests/functional/TestManyBricksVolume/vagrant/Vagrantfile
@@ -10,6 +10,14 @@ Vagrant.configure("2") do |config|
     config.ssh.insert_key = false
     config.vm.box = "centos/7"
     config.vm.synced_folder '.', '/home/vagrant/sync', disabled: true
+    # change cpu mode to passthrough as workaround, refer bugs:
+    #https://bugzilla.redhat.com/show_bug.cgi?id=1467599
+    #https://bugzilla.redhat.com/show_bug.cgi?id=1386223#c10
+    #vagrant-libvirt/vagrant-libvirt#667
+    config.vm.provider :libvirt do |v|
+        v.cpu_mode = 'host-passthrough'
+    end
+
 
     # Make the glusterfs cluster, each with DISKS number of drives
     (0..NODES-1).each do |i|

--- a/tests/functional/TestSmokeTest/vagrant/Vagrantfile
+++ b/tests/functional/TestSmokeTest/vagrant/Vagrantfile
@@ -11,6 +11,11 @@ Vagrant.configure("2") do |config|
     config.vm.provider :libvirt do |v,override|
         override.vm.box = "centos/7"
         override.vm.synced_folder '.', '/home/vagrant/sync', disabled: true
+        # change cpu mode to passthrough as workaround, refer bugs:
+        #https://bugzilla.redhat.com/show_bug.cgi?id=1467599
+        #https://bugzilla.redhat.com/show_bug.cgi?id=1386223#c10
+        #vagrant-libvirt/vagrant-libvirt#667
+        v.cpu_mode = 'host-passthrough'
     end
     config.vm.provider :virtualbox do |v|
         config.vm.box = "bento/centos-7.1"

--- a/tests/functional/TestVolumeNotDeletedWhenNodeIsDown/vagrant/Vagrantfile
+++ b/tests/functional/TestVolumeNotDeletedWhenNodeIsDown/vagrant/Vagrantfile
@@ -11,6 +11,11 @@ Vagrant.configure("2") do |config|
     config.vm.provider :libvirt do |v,override|
         override.vm.box = "centos/7"
         override.vm.synced_folder '.', '/home/vagrant/sync', disabled: true
+        # change cpu mode to passthrough as workaround, refer bugs:
+        #https://bugzilla.redhat.com/show_bug.cgi?id=1467599
+        #https://bugzilla.redhat.com/show_bug.cgi?id=1386223#c10
+        #vagrant-libvirt/vagrant-libvirt#667
+        v.cpu_mode = 'host-passthrough'
     end
 
     # Make the glusterfs cluster, each with DISKS number of drives

--- a/tests/functional/TestVolumeSnapshotBehavior/vagrant/Vagrantfile
+++ b/tests/functional/TestVolumeSnapshotBehavior/vagrant/Vagrantfile
@@ -11,6 +11,11 @@ Vagrant.configure("2") do |config|
     config.vm.provider :libvirt do |v,override|
         override.vm.box = "centos/7"
         override.vm.synced_folder '.', '/home/vagrant/sync', disabled: true
+        # change cpu mode to passthrough as workaround, refer bugs:
+        #https://bugzilla.redhat.com/show_bug.cgi?id=1467599
+        #https://bugzilla.redhat.com/show_bug.cgi?id=1386223#c10
+        #vagrant-libvirt/vagrant-libvirt#667
+        v.cpu_mode = 'host-passthrough'
     end
 
     # Make the glusterfs cluster, each with DISKS number of drives


### PR DESCRIPTION
Functional tests sometimes error out with error "virDomainCreateWithFlags
failed: the CPU is incompatible with host CPU: Host CPU does not provide
required features: svm". Using cpu_mode='host-passthrough' solves the
problem by disabling cpu emulation and using host cpu in passthrough
mode.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>