### PR TITLE
apps: make a common bucket init function

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -113,50 +113,9 @@ func NewApp(configIo io.Reader) *App {
 		app.dbReadOnly = true
 	} else {
 		err = app.db.Update(func(tx *bolt.Tx) error {
-			// Create Cluster Bucket
-			_, err := tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_CLUSTER))
+			err := initializeBuckets(tx)
 			if err != nil {
-				logger.LogError("Unable to create cluster bucket in DB")
-				return err
-			}
-
-			// Create Node Bucket
-			_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_NODE))
-			if err != nil {
-				logger.LogError("Unable to create node bucket in DB")
-				return err
-			}
-
-			// Create Volume Bucket
-			_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_VOLUME))
-			if err != nil {
-				logger.LogError("Unable to create volume bucket in DB")
-				return err
-			}
-
-			// Create Device Bucket
-			_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_DEVICE))
-			if err != nil {
-				logger.LogError("Unable to create device bucket in DB")
-				return err
-			}
-
-			// Create Brick Bucket
-			_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_BRICK))
-			if err != nil {
-				logger.LogError("Unable to create brick bucket in DB")
-				return err
-			}
-
-			_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_BLOCKVOLUME))
-			if err != nil {
-				logger.LogError("Unable to create blockvolume bucket in DB")
-				return err
-			}
-
-			_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_DBATTRIBUTE))
-			if err != nil {
-				logger.LogError("Unable to create dbattribute bucket in DB")
+				logger.LogError("Unable to initialize buckets")
 				return err
 			}
 

--- a/apps/glusterfs/app_db.go
+++ b/apps/glusterfs/app_db.go
@@ -283,55 +283,7 @@ func DbCreate(jsonfile string, dbfile string, debug bool) error {
 	}
 
 	err = dbhandle.Update(func(tx *bolt.Tx) error {
-		// Create Cluster Bucket
-		_, err := tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_CLUSTER))
-		if err != nil {
-			logger.Debug("Unable to create cluster bucket in DB")
-			return err
-		}
-
-		// Create Node Bucket
-		_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_NODE))
-		if err != nil {
-			logger.Debug("Unable to create node bucket in DB")
-			return err
-		}
-
-		// Create Volume Bucket
-		_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_VOLUME))
-		if err != nil {
-			logger.Debug("Unable to create volume bucket in DB")
-			return err
-		}
-
-		// Create Device Bucket
-		_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_DEVICE))
-		if err != nil {
-			logger.Debug("Unable to create device bucket in DB")
-			return err
-		}
-
-		// Create Brick Bucket
-		_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_BRICK))
-		if err != nil {
-			logger.Debug("Unable to create brick bucket in DB")
-			return err
-		}
-
-		_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_BLOCKVOLUME))
-		if err != nil {
-			logger.Debug("Unable to create blockvolume bucket in DB")
-			return err
-		}
-
-		_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_DBATTRIBUTE))
-		if err != nil {
-			logger.Debug("Unable to create dbattribute bucket in DB")
-			return err
-		}
-
-		return nil
-
+		return initializeBuckets(tx)
 	})
 	if err != nil {
 		logger.Err(err)

--- a/apps/glusterfs/dbcommon.go
+++ b/apps/glusterfs/dbcommon.go
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"github.com/boltdb/bolt"
+)
+
+func initializeBuckets(tx *bolt.Tx) error {
+	// Create Cluster Bucket
+	_, err := tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_CLUSTER))
+	if err != nil {
+		logger.LogError("Unable to create cluster bucket in DB")
+		return err
+	}
+
+	// Create Node Bucket
+	_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_NODE))
+	if err != nil {
+		logger.LogError("Unable to create node bucket in DB")
+		return err
+	}
+
+	// Create Volume Bucket
+	_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_VOLUME))
+	if err != nil {
+		logger.LogError("Unable to create volume bucket in DB")
+		return err
+	}
+
+	// Create Device Bucket
+	_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_DEVICE))
+	if err != nil {
+		logger.LogError("Unable to create device bucket in DB")
+		return err
+	}
+
+	// Create Brick Bucket
+	_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_BRICK))
+	if err != nil {
+		logger.LogError("Unable to create brick bucket in DB")
+		return err
+	}
+
+	_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_BLOCKVOLUME))
+	if err != nil {
+		logger.LogError("Unable to create blockvolume bucket in DB")
+		return err
+	}
+
+	_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_DBATTRIBUTE))
+	if err != nil {
+		logger.LogError("Unable to create dbattribute bucket in DB")
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Create a single common function for setting up the buckets in the db. This way we don't have to change multiple places in the code if we add a new bucket. This also starts a new file where we can add more common db related stuff.