### PR TITLE
Further cleanup simple allocator code

### DIFF
--- a/apps/glusterfs/allocator.go
+++ b/apps/glusterfs/allocator.go
@@ -11,18 +11,6 @@ package glusterfs
 
 type Allocator interface {
 
-	// Inform the brick allocator to include device
-	AddDevice(c *ClusterEntry, n *NodeEntry, d *DeviceEntry) error
-
-	// Inform the brick allocator to not use the specified device
-	RemoveDevice(c *ClusterEntry, n *NodeEntry, d *DeviceEntry) error
-
-	// Add cluster information from allocator.
-	AddCluster(clusterId string) error
-
-	// Remove cluster information from allocator
-	RemoveCluster(clusterId string) error
-
 	// Returns a generator, done, and error channel.
 	// The generator returns the location for the brick, then the possible locations
 	// of its replicas. The caller must close() the done channel when it no longer

--- a/apps/glusterfs/allocator.go
+++ b/apps/glusterfs/allocator.go
@@ -30,9 +30,6 @@ type Allocator interface {
 	GetNodes(clusterId, brickId string) (<-chan string,
 		chan<- struct{}, <-chan error)
 
-	// Check whether a node is currently considered by the allocator
-	HasNode(clusterId string, zone int, nodeId string) bool
-
 	// Check whether a device is currently considered by the allocator
 	HasDevice(clusterId string, zone int, nodeId, deviceId string) bool
 }

--- a/apps/glusterfs/allocator.go
+++ b/apps/glusterfs/allocator.go
@@ -29,7 +29,4 @@ type Allocator interface {
 	// needs to read from the generator.
 	GetNodes(clusterId, brickId string) (<-chan string,
 		chan<- struct{}, <-chan error)
-
-	// Check whether a device is currently considered by the allocator
-	HasDevice(clusterId string, zone int, nodeId, deviceId string) bool
 }

--- a/apps/glusterfs/allocator_simple.go
+++ b/apps/glusterfs/allocator_simple.go
@@ -47,7 +47,7 @@ func NewSimpleAllocatorFromDb(db wdb.RODB) *SimpleAllocator {
 			}
 
 			// Add Cluster to ring
-			if err = s.AddCluster(cluster.Info.Id); err != nil {
+			if err = s.addCluster(cluster.Info.Id); err != nil {
 				return err
 			}
 
@@ -74,7 +74,7 @@ func NewSimpleAllocatorFromDb(db wdb.RODB) *SimpleAllocator {
 					}
 
 					// Add device to ring
-					err = s.AddDevice(cluster, node, device)
+					err = s.addDevice(cluster, node, device)
 					if err != nil {
 						return err
 					}
@@ -92,7 +92,7 @@ func NewSimpleAllocatorFromDb(db wdb.RODB) *SimpleAllocator {
 
 }
 
-func (s *SimpleAllocator) AddDevice(cluster *ClusterEntry,
+func (s *SimpleAllocator) addDevice(cluster *ClusterEntry,
 	node *NodeEntry,
 	device *DeviceEntry) error {
 
@@ -116,7 +116,7 @@ func (s *SimpleAllocator) AddDevice(cluster *ClusterEntry,
 
 }
 
-func (s *SimpleAllocator) RemoveDevice(cluster *ClusterEntry,
+func (s *SimpleAllocator) removeDevice(cluster *ClusterEntry,
 	node *NodeEntry,
 	device *DeviceEntry) error {
 
@@ -140,9 +140,9 @@ func (s *SimpleAllocator) RemoveDevice(cluster *ClusterEntry,
 	return nil
 }
 
-// AddCluster adds an entry to the rings map. Must be called before AddDevice so
+// addCluster adds an entry to the rings map. Must be called before addDevice so
 // that the entry exists.
-func (s *SimpleAllocator) AddCluster(clusterId string) error {
+func (s *SimpleAllocator) addCluster(clusterId string) error {
 
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -158,7 +158,7 @@ func (s *SimpleAllocator) AddCluster(clusterId string) error {
 	return nil
 }
 
-func (s *SimpleAllocator) RemoveCluster(clusterId string) error {
+func (s *SimpleAllocator) removeCluster(clusterId string) error {
 
 	s.lock.Lock()
 	defer s.lock.Unlock()

--- a/apps/glusterfs/allocator_simple.go
+++ b/apps/glusterfs/allocator_simple.go
@@ -231,20 +231,6 @@ func (s *SimpleAllocator) GetNodes(clusterId, brickId string) (<-chan string,
 	return device, done, errc
 }
 
-func (s *SimpleAllocator) HasNode(clusterId string, zone int,
-	nodeId string) bool {
-
-	if _, ok := s.rings[clusterId]; !ok {
-		return false
-	}
-
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	ring := s.rings[clusterId]
-
-	return ring.HasNode(zone, nodeId)
-}
 func (s *SimpleAllocator) HasDevice(clusterId string, zone int,
 	nodeId, deviceId string) bool {
 

--- a/apps/glusterfs/allocator_simple.go
+++ b/apps/glusterfs/allocator_simple.go
@@ -116,30 +116,6 @@ func (s *SimpleAllocator) addDevice(cluster *ClusterEntry,
 
 }
 
-func (s *SimpleAllocator) removeDevice(cluster *ClusterEntry,
-	node *NodeEntry,
-	device *DeviceEntry) error {
-
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	// Check the cluster id is in the map
-	clusterId := cluster.Info.Id
-	if _, ok := s.rings[clusterId]; !ok {
-		logger.LogError("Unknown cluster id requested: %v", clusterId)
-		return ErrNotFound
-	}
-
-	// Remove device from ring
-	s.rings[clusterId].Remove(&SimpleDevice{
-		zone:     node.Info.Zone,
-		nodeId:   node.Info.Id,
-		deviceId: device.Info.Id,
-	})
-
-	return nil
-}
-
 // addCluster adds an entry to the rings map. Must be called before addDevice so
 // that the entry exists.
 func (s *SimpleAllocator) addCluster(clusterId string) error {
@@ -154,23 +130,6 @@ func (s *SimpleAllocator) addCluster(clusterId string) error {
 
 	// Add cluster to map
 	s.rings[clusterId] = NewSimpleAllocatorRing()
-
-	return nil
-}
-
-func (s *SimpleAllocator) removeCluster(clusterId string) error {
-
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	// Check the cluster id is in the map
-	if _, ok := s.rings[clusterId]; !ok {
-		logger.LogError("Unknown cluster id requested: %v", clusterId)
-		return ErrNotFound
-	}
-
-	// Remove cluster from map
-	delete(s.rings, clusterId)
 
 	return nil
 }

--- a/apps/glusterfs/allocator_simple.go
+++ b/apps/glusterfs/allocator_simple.go
@@ -230,18 +230,3 @@ func (s *SimpleAllocator) GetNodes(clusterId, brickId string) (<-chan string,
 
 	return device, done, errc
 }
-
-func (s *SimpleAllocator) HasDevice(clusterId string, zone int,
-	nodeId, deviceId string) bool {
-
-	if _, ok := s.rings[clusterId]; !ok {
-		return false
-	}
-
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	ring := s.rings[clusterId]
-
-	return ring.HasDevice(zone, nodeId, deviceId)
-}

--- a/apps/glusterfs/allocator_simple_ring.go
+++ b/apps/glusterfs/allocator_simple_ring.go
@@ -90,30 +90,6 @@ func (s *SimpleAllocatorRing) Add(d *SimpleDevice) {
 	s.balancedList = nil
 }
 
-// Remove device from the ring map
-func (s *SimpleAllocatorRing) Remove(d *SimpleDevice) {
-
-	if nodes, ok := s.ring[d.zone]; ok {
-		if devices, ok := nodes[d.nodeId]; ok {
-			for index, device := range devices {
-				if device.deviceId == d.deviceId {
-					// Found device, now delete it from the ring map
-					nodes[d.nodeId] = append(nodes[d.nodeId][:index], nodes[d.nodeId][index+1:]...)
-
-					if len(nodes[d.nodeId]) == 0 {
-						delete(nodes, d.nodeId)
-					}
-					if len(s.ring[d.zone]) == 0 {
-						delete(s.ring, d.zone)
-					}
-				}
-			}
-		}
-	}
-
-	s.balancedList = nil
-}
-
 // Rebalance the ring and place the rebalanced list
 // into balancedList.
 // The idea is to setup an array/slice where each continguous SimpleDevice

--- a/apps/glusterfs/allocator_simple_ring.go
+++ b/apps/glusterfs/allocator_simple_ring.go
@@ -190,25 +190,3 @@ func (s *SimpleAllocatorRing) GetDeviceList(uuid string) SimpleDevices {
 	return append(devices[index:], devices[:index]...)
 
 }
-
-func (s *SimpleAllocatorRing) HasDevice(zone int,
-	nodeId, deviceId string) bool {
-
-	nodes, ok := s.ring[zone]
-	if !ok {
-		return false
-	}
-
-	devices, ok := nodes[nodeId]
-	if !ok {
-		return false
-	}
-
-	for _, device := range devices {
-		if device.deviceId == deviceId {
-			return true
-		}
-	}
-
-	return false
-}

--- a/apps/glusterfs/allocator_simple_ring.go
+++ b/apps/glusterfs/allocator_simple_ring.go
@@ -191,19 +191,6 @@ func (s *SimpleAllocatorRing) GetDeviceList(uuid string) SimpleDevices {
 
 }
 
-func (s *SimpleAllocatorRing) HasNode(zone int, nodeId string) bool {
-	nodes, ok := s.ring[zone]
-	if !ok {
-		return false
-	}
-
-	if _, ok := nodes[nodeId]; !ok {
-		return false
-	}
-
-	return true
-}
-
 func (s *SimpleAllocatorRing) HasDevice(zone int,
 	nodeId, deviceId string) bool {
 

--- a/apps/glusterfs/allocator_simple_ring_test.go
+++ b/apps/glusterfs/allocator_simple_ring_test.go
@@ -22,7 +22,7 @@ func TestNewSimpleAllocatorRing(t *testing.T) {
 	tests.Assert(t, r.ring != nil)
 }
 
-func TestSimpleAllocatorRingAddRemove(t *testing.T) {
+func TestSimpleAllocatorRingAdd(t *testing.T) {
 	r := NewSimpleAllocatorRing()
 	tests.Assert(t, r != nil)
 
@@ -72,35 +72,6 @@ func TestSimpleAllocatorRingAddRemove(t *testing.T) {
 	tests.Assert(t, r.ring[sd2.zone][sd3.nodeId][1] == sd4)
 	tests.Assert(t, len(r.ring[sd2.zone][sd3.nodeId]) == 2)
 	tests.Assert(t, r.balancedList == nil)
-
-	// Remove sd4
-	r.Remove(sd4)
-	tests.Assert(t, r.ring[sd.zone][sd.nodeId][0] == sd)
-	tests.Assert(t, r.ring[sd2.zone][sd2.nodeId][0] == sd2)
-	tests.Assert(t, r.ring[sd2.zone][sd3.nodeId][0] == sd3)
-	tests.Assert(t, len(r.ring[sd2.zone][sd3.nodeId]) == 1)
-	tests.Assert(t, len(r.ring[sd2.zone]) == 2)
-	tests.Assert(t, r.balancedList == nil)
-
-	// Remove sd3
-	r.Remove(sd3)
-	tests.Assert(t, r.ring[sd.zone][sd.nodeId][0] == sd)
-	tests.Assert(t, r.ring[sd2.zone][sd2.nodeId][0] == sd2)
-	tests.Assert(t, len(r.ring[sd2.zone]) == 1)
-	tests.Assert(t, len(r.ring) == 2)
-	tests.Assert(t, r.balancedList == nil)
-
-	// Remove sd2
-	r.Remove(sd2)
-	tests.Assert(t, r.ring[sd.zone][sd.nodeId][0] == sd)
-	tests.Assert(t, len(r.ring) == 1)
-	tests.Assert(t, r.balancedList == nil)
-
-	// Remove sd
-	r.Remove(sd)
-	tests.Assert(t, len(r.ring) == 0)
-	tests.Assert(t, r.balancedList == nil)
-
 }
 
 func TestSimpleAllocatorCreateZoneLists(t *testing.T) {

--- a/apps/glusterfs/allocator_simple_test.go
+++ b/apps/glusterfs/allocator_simple_test.go
@@ -38,6 +38,11 @@ func TestSimpleAllocatorEmpty(t *testing.T) {
 
 	err = a.removeCluster("aaa")
 	tests.Assert(t, err == ErrNotFound)
+}
+
+func TestSimpleAllocatorGetNodesEmpty(t *testing.T) {
+	a := NewSimpleAllocator()
+	tests.Assert(t, a != nil)
 
 	ch, _, errc := a.GetNodes(utils.GenUUID(), utils.GenUUID())
 	for d := range ch {

--- a/apps/glusterfs/allocator_simple_test.go
+++ b/apps/glusterfs/allocator_simple_test.go
@@ -27,19 +27,6 @@ func TestNewSimpleAllocator(t *testing.T) {
 
 }
 
-func TestSimpleAllocatorEmpty(t *testing.T) {
-	a := NewSimpleAllocator()
-	tests.Assert(t, a != nil)
-
-	err := a.removeDevice(createSampleClusterEntry(),
-		createSampleNodeEntry(),
-		createSampleDeviceEntry("aaa", 10))
-	tests.Assert(t, err == ErrNotFound)
-
-	err = a.removeCluster("aaa")
-	tests.Assert(t, err == ErrNotFound)
-}
-
 func TestSimpleAllocatorGetNodesEmpty(t *testing.T) {
 	a := NewSimpleAllocator()
 	tests.Assert(t, a != nil)
@@ -48,11 +35,11 @@ func TestSimpleAllocatorGetNodesEmpty(t *testing.T) {
 	for d := range ch {
 		tests.Assert(t, false, d)
 	}
-	err = <-errc
+	err := <-errc
 	tests.Assert(t, err == ErrNotFound)
 }
 
-func TestSimpleAllocatorAddRemoveDevice(t *testing.T) {
+func TestSimpleAllocatorAddDevice(t *testing.T) {
 	a := NewSimpleAllocator()
 	tests.Assert(t, a != nil)
 
@@ -79,24 +66,6 @@ func TestSimpleAllocatorAddRemoveDevice(t *testing.T) {
 	err = <-errc
 	tests.Assert(t, devices == 1)
 	tests.Assert(t, err == nil)
-
-	// Now remove the device
-	err = a.removeDevice(cluster, node, device)
-	tests.Assert(t, err == nil)
-	tests.Assert(t, len(a.rings) == 1)
-
-	// Get the nodes from the ring
-	ch, _, errc = a.GetNodes(cluster.Info.Id, utils.GenUUID())
-
-	devices = 0
-	for d := range ch {
-		devices++
-		tests.Assert(t, false, d)
-	}
-	err = <-errc
-	tests.Assert(t, devices == 0)
-	tests.Assert(t, err == nil)
-
 }
 
 func TestSimpleAllocatorInitFromDb(t *testing.T) {

--- a/apps/glusterfs/allocator_simple_test.go
+++ b/apps/glusterfs/allocator_simple_test.go
@@ -31,12 +31,12 @@ func TestSimpleAllocatorEmpty(t *testing.T) {
 	a := NewSimpleAllocator()
 	tests.Assert(t, a != nil)
 
-	err := a.RemoveDevice(createSampleClusterEntry(),
+	err := a.removeDevice(createSampleClusterEntry(),
 		createSampleNodeEntry(),
 		createSampleDeviceEntry("aaa", 10))
 	tests.Assert(t, err == ErrNotFound)
 
-	err = a.RemoveCluster("aaa")
+	err = a.removeCluster("aaa")
 	tests.Assert(t, err == ErrNotFound)
 
 	ch, _, errc := a.GetNodes(utils.GenUUID(), utils.GenUUID())
@@ -57,8 +57,8 @@ func TestSimpleAllocatorAddRemoveDevice(t *testing.T) {
 	device := createSampleDeviceEntry(node.Info.Id, 10000)
 
 	tests.Assert(t, len(a.rings) == 0)
-	tests.Assert(t, a.AddCluster(cluster.Info.Id) == nil)
-	err := a.AddDevice(cluster, node, device)
+	tests.Assert(t, a.addCluster(cluster.Info.Id) == nil)
+	err := a.addDevice(cluster, node, device)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, len(a.rings) == 1)
 	tests.Assert(t, a.rings[cluster.Info.Id] != nil)
@@ -76,7 +76,7 @@ func TestSimpleAllocatorAddRemoveDevice(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Now remove the device
-	err = a.RemoveDevice(cluster, node, device)
+	err = a.removeDevice(cluster, node, device)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, len(a.rings) == 1)
 

--- a/apps/glusterfs/app_device_test.go
+++ b/apps/glusterfs/app_device_test.go
@@ -608,10 +608,6 @@ func TestDeviceState(t *testing.T) {
 	tests.Assert(t, err == nil)
 	tests.Assert(t, deviceInfo.State == "online")
 
-	// Check that the device is in the ring
-	tests.Assert(t, app.Allocator().HasDevice(cluster.Id, node.Zone,
-		node.Id, device.Id))
-
 	// Set offline
 	request := []byte(`{
 				"state" : "offline"
@@ -636,9 +632,6 @@ func TestDeviceState(t *testing.T) {
 			break
 		}
 	}
-	// Check it was removed from the ring
-	tests.Assert(t, !app.Allocator().HasDevice(cluster.Id, node.Zone,
-		node.Id, device.Id))
 
 	// Get Device Info
 	r, err = http.Get(ts.URL + "/devices/" + device.Id)
@@ -679,10 +672,6 @@ func TestDeviceState(t *testing.T) {
 		}
 	}
 
-	// Check that the device is in the ring
-	tests.Assert(t, app.Allocator().HasDevice(cluster.Id, node.Zone,
-		node.Id, device.Id))
-
 	// Get Device Info
 	r, err = http.Get(ts.URL + "/devices/" + device.Id)
 	tests.Assert(t, err == nil)
@@ -705,10 +694,6 @@ func TestDeviceState(t *testing.T) {
 		"application/json", bytes.NewBuffer(request))
 	tests.Assert(t, err == nil)
 	tests.Assert(t, r.StatusCode == http.StatusBadRequest, r.StatusCode)
-
-	// Check that the device is still in the ring
-	tests.Assert(t, app.Allocator().HasDevice(cluster.Id, node.Zone,
-		node.Id, device.Id))
 
 	// Make sure the state did not change
 	r, err = http.Get(ts.URL + "/devices/" + device.Id)

--- a/apps/glusterfs/app_node_test.go
+++ b/apps/glusterfs/app_node_test.go
@@ -1087,11 +1087,6 @@ func TestNodeState(t *testing.T) {
 	tests.Assert(t, err == nil)
 	tests.Assert(t, deviceInfo.State == "online")
 
-	// Check that the device is in the ring
-	alloc := app.Allocator()
-	tests.Assert(t, alloc.HasDevice(cluster.Id, node.Zone,
-		node.Id, device.Id))
-
 	// Set node offline
 	request := []byte(`{
 				"state" : "offline"
@@ -1117,10 +1112,6 @@ func TestNodeState(t *testing.T) {
 		}
 	}
 
-	// Check it was removed from the ring
-	tests.Assert(t, !app.Allocator().HasDevice(cluster.Id, node.Zone,
-		node.Id, device.Id))
-
 	// Get node info
 	node, err = c.NodeInfo(node.Id)
 	tests.Assert(t, err == nil)
@@ -1134,10 +1125,6 @@ func TestNodeState(t *testing.T) {
 		"application/json", bytes.NewBuffer(request))
 	tests.Assert(t, err == nil)
 	tests.Assert(t, r.StatusCode == http.StatusAccepted)
-
-	// Check it was removed from the ring
-	tests.Assert(t, !app.Allocator().HasDevice(cluster.Id, node.Zone,
-		node.Id, device.Id))
 
 	// Get node info
 	node, err = c.NodeInfo(node.Id)
@@ -1169,10 +1156,6 @@ func TestNodeState(t *testing.T) {
 		}
 	}
 
-	// Check that the device is in the ring
-	tests.Assert(t, app.Allocator().HasDevice(cluster.Id, node.Zone,
-		node.Id, device.Id))
-
 	// Set online again, should succeed
 	request = []byte(`{
 				"state" : "online"
@@ -1198,10 +1181,6 @@ func TestNodeState(t *testing.T) {
 		}
 	}
 
-	// Check that the device is in the ring
-	tests.Assert(t, app.Allocator().HasDevice(cluster.Id, node.Zone,
-		node.Id, device.Id))
-
 	// Get node info
 	node, err = c.NodeInfo(node.Id)
 	tests.Assert(t, err == nil)
@@ -1215,10 +1194,6 @@ func TestNodeState(t *testing.T) {
 		"application/json", bytes.NewBuffer(request))
 	tests.Assert(t, err == nil)
 	tests.Assert(t, r.StatusCode == http.StatusBadRequest)
-
-	// Check that the device is still in the ring
-	tests.Assert(t, app.Allocator().HasDevice(cluster.Id, node.Zone,
-		node.Id, device.Id))
 
 	// Check node is still online
 	node, err = c.NodeInfo(node.Id)
@@ -1250,10 +1225,6 @@ func TestNodeState(t *testing.T) {
 		}
 	}
 
-	// Check it was removed from the ring
-	tests.Assert(t, !app.Allocator().HasDevice(cluster.Id, node.Zone,
-		node.Id, device.Id))
-
 	// Set Node offline
 	request = []byte(`{
 				"state" : "offline"
@@ -1278,10 +1249,6 @@ func TestNodeState(t *testing.T) {
 			break
 		}
 	}
-
-	// Check it was removed from the ring
-	tests.Assert(t, !app.Allocator().HasDevice(cluster.Id, node.Zone,
-		node.Id, device.Id))
 
 	// Set Node online -- Device is still offline and should not be added
 	request = []byte(`{
@@ -1308,10 +1275,6 @@ func TestNodeState(t *testing.T) {
 		}
 	}
 
-	// Check device is not in ring
-	tests.Assert(t, !app.Allocator().HasDevice(cluster.Id, node.Zone,
-		node.Id, device.Id))
-
 	// Now make device online
 	request = []byte(`{
 				"state" : "online"
@@ -1336,11 +1299,6 @@ func TestNodeState(t *testing.T) {
 			break
 		}
 	}
-
-	// Now it should be back in the ring
-	tests.Assert(t, app.Allocator().HasDevice(cluster.Id, node.Zone,
-		node.Id, device.Id))
-
 }
 
 func TestNodeInfoAfterDelete(t *testing.T) {

--- a/apps/glusterfs/app_node_test.go
+++ b/apps/glusterfs/app_node_test.go
@@ -1411,10 +1411,6 @@ func TestNodeInfoAfterDelete(t *testing.T) {
 		}
 	}
 
-	// Check it was removed from the ring
-	tests.Assert(t, !app.Allocator().HasNode(cluster.Id, node.Zone,
-		node.Id))
-
 	// Get node info
 	node, err = c.NodeInfo(node.Id)
 	tests.Assert(t, err == nil)

--- a/apps/glusterfs/device_entry_test.go
+++ b/apps/glusterfs/device_entry_test.go
@@ -633,23 +633,15 @@ func TestDeviceSetStateFailed(t *testing.T) {
 		return nil
 	})
 
-	// Check ring
-	tests.Assert(t, app.Allocator().HasDevice(c.Info.Id,
-		n.Info.Zone, n.Info.Id, d.Info.Id))
-
 	// Set offline
 	err := d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
 	tests.Assert(t, d.State == api.EntryStateOffline)
 	tests.Assert(t, err == nil, err)
-	tests.Assert(t, !app.Allocator().HasDevice(c.Info.Id, n.Info.Zone,
-		n.Info.Id, d.Info.Id))
 
 	// Set failed, Note: this requires the current state to be offline
 	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateFailed)
 	tests.Assert(t, d.State == api.EntryStateFailed)
 	tests.Assert(t, err == nil)
-	tests.Assert(t, !app.Allocator().HasDevice(c.Info.Id, n.Info.Zone,
-		n.Info.Id, d.Info.Id))
 
 	// Set failed again
 	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateFailed)
@@ -660,15 +652,11 @@ func TestDeviceSetStateFailed(t *testing.T) {
 	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
 	tests.Assert(t, d.State == api.EntryStateFailed)
 	tests.Assert(t, err != nil)
-	tests.Assert(t, !app.Allocator().HasDevice(c.Info.Id, n.Info.Zone,
-		n.Info.Id, d.Info.Id))
 
 	// Set online
 	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOnline)
 	tests.Assert(t, d.State == api.EntryStateFailed)
 	tests.Assert(t, err != nil)
-	tests.Assert(t, !app.Allocator().HasDevice(c.Info.Id, n.Info.Zone,
-		n.Info.Id, d.Info.Id))
 }
 
 func TestDeviceSetStateOfflineOnline(t *testing.T) {
@@ -716,18 +704,10 @@ func TestDeviceSetStateOfflineOnline(t *testing.T) {
 		return nil
 	})
 
-	// Check ring
-	tests.Assert(t, app.Allocator().HasDevice(c.Info.Id, n.Info.Zone,
-		n.Info.Id, d.Info.Id))
-
 	// Set offline
 	err := d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
 	tests.Assert(t, d.State == api.EntryStateOffline)
 	tests.Assert(t, err == nil)
-
-	// Check it was removed from ring
-	tests.Assert(t, !app.Allocator().HasDevice(c.Info.Id, n.Info.Zone,
-		n.Info.Id, d.Info.Id))
 
 	// Set offline again
 	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
@@ -738,6 +718,4 @@ func TestDeviceSetStateOfflineOnline(t *testing.T) {
 	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOnline)
 	tests.Assert(t, d.State == api.EntryStateOnline)
 	tests.Assert(t, err == nil)
-	tests.Assert(t, app.Allocator().HasDevice(c.Info.Id, n.Info.Zone,
-		n.Info.Id, d.Info.Id))
 }

--- a/apps/glusterfs/node_entry_test.go
+++ b/apps/glusterfs/node_entry_test.go
@@ -525,10 +525,6 @@ func TestNodeSetStateFailed(t *testing.T) {
 		return nil
 	})
 
-	// Check ring
-	tests.Assert(t, app.Allocator().HasDevice(c.Info.Id, n.Info.Zone,
-		n.Info.Id, d.Info.Id))
-
 	// Set failed
 	err := n.SetState(app.db, app.executor, app.Allocator(), api.EntryStateFailed)
 	tests.Assert(t, n.State == api.EntryStateOnline)
@@ -539,10 +535,6 @@ func TestNodeSetStateFailed(t *testing.T) {
 	tests.Assert(t, n.State == api.EntryStateOffline)
 	tests.Assert(t, err == nil)
 
-	// Check it was removed from ring
-	tests.Assert(t, !app.Allocator().HasDevice(c.Info.Id, n.Info.Zone,
-		n.Info.Id, d.Info.Id))
-
 	// Set failed
 	err = n.SetState(app.db, app.executor, app.Allocator(), api.EntryStateFailed)
 	tests.Assert(t, n.State == api.EntryStateFailed)
@@ -552,15 +544,11 @@ func TestNodeSetStateFailed(t *testing.T) {
 	err = n.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
 	tests.Assert(t, n.State == api.EntryStateFailed)
 	tests.Assert(t, err != nil)
-	tests.Assert(t, !app.Allocator().HasDevice(c.Info.Id, n.Info.Zone,
-		n.Info.Id, d.Info.Id))
 
 	// Set online
 	err = n.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOnline)
 	tests.Assert(t, n.State == api.EntryStateFailed)
 	tests.Assert(t, err != nil)
-	tests.Assert(t, !app.Allocator().HasDevice(c.Info.Id, n.Info.Zone,
-		n.Info.Id, d.Info.Id))
 }
 
 func TestNodeSetStateOfflineOnline(t *testing.T) {
@@ -607,18 +595,10 @@ func TestNodeSetStateOfflineOnline(t *testing.T) {
 		return nil
 	})
 
-	// Check ring
-	tests.Assert(t, app.Allocator().HasDevice(c.Info.Id, n.Info.Zone,
-		n.Info.Id, d.Info.Id))
-
 	// Set offline
 	err := n.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
 	tests.Assert(t, n.State == api.EntryStateOffline)
 	tests.Assert(t, err == nil)
-
-	// Check it was removed from ring
-	tests.Assert(t, !app.Allocator().HasDevice(c.Info.Id, n.Info.Zone,
-		n.Info.Id, d.Info.Id))
 
 	// Set offline again
 	err = n.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
@@ -629,8 +609,6 @@ func TestNodeSetStateOfflineOnline(t *testing.T) {
 	err = n.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOnline)
 	tests.Assert(t, n.State == api.EntryStateOnline)
 	tests.Assert(t, err == nil)
-	tests.Assert(t, app.Allocator().HasDevice(c.Info.Id, n.Info.Zone,
-		n.Info.Id, d.Info.Id))
 }
 
 func TestGetVerifiedManageHostname(t *testing.T) {


### PR DESCRIPTION
This patchset removes the unused removeFoo and hasBar methods and makes the AddCluster and AddDevice methods private (removes them from the allocator interface). 

The result is that the GetNodes method is now the only method in the allocator interface.