### PR TITLE
apps: add pending operations support

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -200,6 +200,12 @@ func (a *App) Upgrade(tx *bolt.Tx) error {
 		return err
 	}
 
+	err = PendingOperationUpgrade(tx)
+	if err != nil {
+		logger.LogError("Failed to upgrade db for pending operations: %v", err)
+		return err
+	}
+
 	return nil
 }
 

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -23,7 +23,8 @@ import (
 )
 
 type BlockVolumeEntry struct {
-	Info api.BlockVolumeInfo
+	Info    api.BlockVolumeInfo
+	Pending PendingItem
 }
 
 func BlockVolumeList(tx *bolt.Tx) ([]string, error) {

--- a/apps/glusterfs/brick_entry.go
+++ b/apps/glusterfs/brick_entry.go
@@ -26,6 +26,7 @@ type BrickEntry struct {
 	TpSize           uint64
 	PoolMetadataSize uint64
 	gidRequested     int64
+	Pending          PendingItem
 }
 
 func BrickList(tx *bolt.Tx) ([]string, error) {

--- a/apps/glusterfs/dbcommon.go
+++ b/apps/glusterfs/dbcommon.go
@@ -61,5 +61,11 @@ func initializeBuckets(tx *bolt.Tx) error {
 		return err
 	}
 
+	_, err = tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_PENDING_OPS))
+	if err != nil {
+		logger.LogError("Unable to create pending ops bucket in DB")
+		return err
+	}
+
 	return nil
 }

--- a/apps/glusterfs/pendingop.go
+++ b/apps/glusterfs/pendingop.go
@@ -1,0 +1,87 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"fmt"
+)
+
+// The pendingop.go file defines the basic structures needed to track
+// life-cycle of database entries w/in Heketi. There are generally two
+// levels of objects which we track: the pending operation a higher-level
+// operation that should roughly correspond to an action in the Heketi API,
+// and lower level change tracking where individual object creates, deletes,
+// and modifications are logged. Note that objects such as bricks and
+// volumes are still managed in their own buckets. The pending operation
+// metadata tracks the IDs of these objects and these objects have references
+// back to their associated pending operations (via IDs).
+
+// PendingOperationType identifies what kind of high-level operation a
+// PendingOperation will be.
+type PendingOperationType int
+
+const (
+	OperationUnknown PendingOperationType = iota
+	OperationCreateVolume
+	OperationDeleteVolume
+	OperationExpandVolume
+	OperationCreateBlockVolume
+	OperationDeleteBlockVolume
+)
+
+// PendingChangeType identifies what kind of lower-level new item or change
+// is being made to the system as part of a higher-level pending operation.
+type PendingChangeType int
+
+const (
+	OpUnknown PendingChangeType = iota
+	OpAddBrick
+	OpAddVolume
+	OpDeleteBrick
+	OpDeleteVolume
+	OpExpandVolume
+	OpAddBlockVolume
+	OpDeleteBlockVolume
+)
+
+// PendingOperationAction tracks individual changes to entries within the
+// heketi db. It consists of a required change type and (heketi uuid) id,
+// as well as an optional delta object for extra metadata.
+type PendingOperationAction struct {
+	Change PendingChangeType
+	Id     string
+	Delta  interface{}
+}
+
+// PendingItem encapsulates the common pending item ID field.
+type PendingItem struct {
+	Id string
+}
+
+// PendingOperation tracks higher-level changes to the heketi system, such
+// as volume creation or deletion.
+type PendingOperation struct {
+	PendingItem
+	Timestamp int64
+	Type      PendingOperationType
+	Actions   []PendingOperationAction
+}
+
+// ExpandSize extracts an int value for a pending size expansion from the
+// PendingOperationAction if the change type is correct. If the type is
+// not correct error will be non-nil.
+func (a PendingOperationAction) ExpandSize() (int, error) {
+	if a.Change == OpExpandVolume {
+		if v, ok := a.Delta.(int); ok {
+			return v, nil
+		}
+	}
+	return 0, fmt.Errorf("Action delta for ExpandSize is missing/invalid")
+}

--- a/apps/glusterfs/pendingop_entry.go
+++ b/apps/glusterfs/pendingop_entry.go
@@ -1,0 +1,265 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"bytes"
+	"encoding/gob"
+	"time"
+
+	"github.com/boltdb/bolt"
+	wdb "github.com/heketi/heketi/pkg/db"
+	"github.com/heketi/heketi/pkg/utils"
+	"github.com/lpabon/godbc"
+)
+
+const (
+	NEW_ID                    = ""
+	BOLTDB_BUCKET_PENDING_OPS = "PENDING_OPERATIONS"
+	DB_HAS_PENDING_OPS_BUCKET = "DB_HAS_PENDING_OPS_BUCKET"
+)
+
+var (
+	// support unit test dep. injection for custom timestamps
+	operationTimestamp = func() int64 { return time.Now().Unix() }
+)
+
+// PendingOperationEntry tracks pending operations within the Heketi db.
+type PendingOperationEntry struct {
+	PendingOperation
+}
+
+// PendingOperationList returns the IDs of all pending operation entries
+// currently in the Heketi db.
+func PendingOperationList(tx *bolt.Tx) ([]string, error) {
+	list := EntryKeys(tx, BOLTDB_BUCKET_PENDING_OPS)
+	if list == nil {
+		return nil, ErrAccessList
+	}
+	return list, nil
+}
+
+// HasPendingOperations returns true if the db contains one or more pending
+// operation entries. If the db cannot be read the function panics.
+func HasPendingOperations(db wdb.RODB) bool {
+	var pending bool
+	if err := db.View(func(tx *bolt.Tx) error {
+		l, err := PendingOperationList(tx)
+		if err != nil {
+			return err
+		}
+		pending = (len(l) > 0)
+		return nil
+	}); err != nil {
+		panic(err)
+	}
+	return pending
+}
+
+// BucketName returns the name of the db bucket for pending operation entries.
+func (p *PendingOperationEntry) BucketName() string {
+	return BOLTDB_BUCKET_PENDING_OPS
+}
+
+// NewPendingOperationEntry returns a newly constructed pending operation entry.
+// If id is a non-zero-length string then that value will be used as the ID of
+// the object. Otherwise pass NEW_ID to have a new uuid be automatically allocated
+// for the new object.
+func NewPendingOperationEntry(id string) *PendingOperationEntry {
+	if id == NEW_ID {
+		id = utils.GenUUID()
+	}
+	entry := &PendingOperationEntry{PendingOperation{
+		PendingItem: PendingItem{id},
+		Timestamp:   operationTimestamp(),
+		Actions:     []PendingOperationAction{},
+	}}
+	return entry
+}
+
+// NewPendingOperationEntryFromId fetches an existing pending operation entry
+// from the heketi db based on the provided id.
+func NewPendingOperationEntryFromId(tx *bolt.Tx, id string) (
+	*PendingOperationEntry, error) {
+	godbc.Require(tx != nil)
+	godbc.Require(id != "")
+
+	entry := &PendingOperationEntry{}
+	err := EntryLoad(tx, entry, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if entry.Actions == nil {
+		entry.Actions = []PendingOperationAction{}
+	}
+
+	return entry, nil
+}
+
+// Save records the pending operation entry object in the db, keyed by the
+// value of its ID.
+func (p *PendingOperationEntry) Save(tx *bolt.Tx) error {
+	godbc.Require(tx != nil)
+	godbc.Require(p.Id != "")
+
+	return EntrySave(tx, p, p.Id)
+}
+
+// Delete removes a pending operation entry from the db.
+func (p *PendingOperationEntry) Delete(tx *bolt.Tx) error {
+	return EntryDelete(tx, p, p.Id)
+}
+
+// Marshal serializes the object for storage in the db.
+func (p *PendingOperationEntry) Marshal() ([]byte, error) {
+	var buffer bytes.Buffer
+	enc := gob.NewEncoder(&buffer)
+	err := enc.Encode(*p)
+
+	return buffer.Bytes(), err
+}
+
+// Unmarshal de-serializes the object from the db.
+func (p *PendingOperationEntry) Unmarshal(buffer []byte) error {
+	dec := gob.NewDecoder(bytes.NewReader(buffer))
+	err := dec.Decode(p)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// recordChange is a helper function to reduce some of the boilerplate around
+// adding a new change action item to the pending operation entry.
+func (p *PendingOperationEntry) recordChange(c PendingChangeType, id string) {
+	godbc.Require(p.Id != "")
+	godbc.Require(id != "")
+	p.Actions = append(p.Actions, PendingOperationAction{Change: c, Id: id})
+}
+
+// recordSizeChange is a helper function to reduce some of the boilerplate around
+// adding a new change action item that includes a size change to the entry.
+func (p *PendingOperationEntry) recordSizeChange(c PendingChangeType,
+	id string,
+	sizeDelta int) {
+
+	godbc.Require(p.Id != "")
+	godbc.Require(id != "")
+	p.Actions = append(p.Actions,
+		PendingOperationAction{
+			Change: c,
+			Id:     id,
+			Delta:  sizeDelta,
+		})
+}
+
+// RecordAddVolume adds tracking metadata for a new volume to the
+// PendingOperationEntry and VolumeEntry.
+func (p *PendingOperationEntry) RecordAddVolume(v *VolumeEntry) {
+	// track which volume this op is created
+	p.recordChange(OpAddVolume, v.Info.Id)
+	p.Type = OperationCreateVolume
+	// link back from "temporary" object to op
+	v.Pending.Id = p.Id
+}
+
+// FinalizeVolume removes tracking metadata from the volume entry.
+// This means that the volume is no longer pending.
+func (p *PendingOperationEntry) FinalizeVolume(v *VolumeEntry) {
+	v.Pending.Id = ""
+	return
+}
+
+// RecordAddVolume adds tracking metadata for a new brick to the
+// PendingOperationEntry and BrickEntry.
+func (p *PendingOperationEntry) RecordAddBrick(b *BrickEntry) {
+	p.recordChange(OpAddBrick, b.Info.Id)
+	// link back from the temporary object to the op
+	b.Pending.Id = p.Id
+}
+
+// RecordDeleteBrick adds tracking metadata for a to-be-deleted brick
+// to the PendingOperationEntry and BrickEntry.
+func (p *PendingOperationEntry) RecordDeleteBrick(b *BrickEntry) {
+	p.recordChange(OpDeleteBrick, b.Info.Id)
+	b.Pending.Id = p.Id
+}
+
+// FinalizeVolume removes tracking metadata from the brick entry.
+// This means that the brick is no longer pending.
+func (p *PendingOperationEntry) FinalizeBrick(b *BrickEntry) {
+	b.Pending.Id = ""
+	return
+}
+
+// RecordExpandVolume adds tracking metadata for a volume that is being
+// expanded to the PendingOperationEntry and VolumeEntry.
+func (p *PendingOperationEntry) RecordExpandVolume(v *VolumeEntry, sizeGB int) {
+	p.recordSizeChange(OpExpandVolume, v.Info.Id, sizeGB)
+	p.Type = OperationExpandVolume
+}
+
+// RecordDeleteVolume adds tracking metadata for a to-be-deleted volume
+// to the PendingOperationEntry and BrickEntry.
+func (p *PendingOperationEntry) RecordDeleteVolume(v *VolumeEntry) {
+	p.recordChange(OpDeleteVolume, v.Info.Id)
+	p.Type = OperationDeleteVolume
+	v.Pending.Id = p.Id
+}
+
+// RecordAddHostingVolume adds tracking metadata for a file volume that hosts
+// a block volume
+func (p *PendingOperationEntry) RecordAddHostingVolume(v *VolumeEntry) {
+	p.recordChange(OpAddVolume, v.Info.Id)
+	v.Pending.Id = p.Id
+}
+
+// RecordAddBlockVolume adds tracking metadata for a new block volume.
+func (p *PendingOperationEntry) RecordAddBlockVolume(bv *BlockVolumeEntry) {
+	p.recordChange(OpAddBlockVolume, bv.Info.Id)
+	p.Type = OperationCreateBlockVolume
+	bv.Pending.Id = p.Id
+}
+
+// FinalizeBlockVolume removes tracking metadata from a block volume entry.
+func (p *PendingOperationEntry) FinalizeBlockVolume(bv *BlockVolumeEntry) {
+	bv.Pending.Id = ""
+}
+
+// RecordDeleteBlockVolume adds tracking metadata for a to-be-deleted
+// block volume.
+func (p *PendingOperationEntry) RecordDeleteBlockVolume(bv *BlockVolumeEntry) {
+	p.recordChange(OpDeleteBlockVolume, bv.Info.Id)
+	p.Type = OperationDeleteBlockVolume
+	bv.Pending.Id = p.Id
+}
+
+// PendingOperationUpgrade updates the heketi db with metadata needed to
+// support pending operation entries.
+func PendingOperationUpgrade(tx *bolt.Tx) error {
+	entry, err := NewDbAttributeEntryFromKey(tx, DB_HAS_PENDING_OPS_BUCKET)
+	switch err {
+	case ErrNotFound:
+		entry = NewDbAttributeEntry()
+		entry.Key = DB_HAS_PENDING_OPS_BUCKET
+		entry.Value = "yes"
+	case nil:
+		entry.Value = "yes"
+	default:
+		return err
+	}
+
+	// there are no data changes related to enabling Pending Ops in the db
+	// so simply save the entry to record that this db now has them
+	//return entry.Save(tx)
+	return nil // disable it for now
+}

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -51,6 +51,7 @@ type VolumeEntry struct {
 	Bricks               sort.StringSlice
 	Durability           VolumeDurability `json:"-"`
 	GlusterVolumeOptions []string
+	Pending              PendingItem
 }
 
 func VolumeList(tx *bolt.Tx) ([]string, error) {


### PR DESCRIPTION
Depends on pr #1026 atm.

This is a cleaned up version of what's in my untangle3a branch with regards to defining the data structures and db entries for pending operations.

I have tests for the patch "add basic support for db import/export of pending op entries" but those tests depend on implementation of volume create operation code in the other branch so I left it out for now.