### PR TITLE
tests: make logging in unit tests consistent

### DIFF
--- a/apps/glusterfs/app_cluster_test.go
+++ b/apps/glusterfs/app_cluster_test.go
@@ -25,11 +25,6 @@ import (
 	"github.com/heketi/tests"
 )
 
-func init() {
-	// turn off logging
-	logger.SetLevel(utils.LEVEL_NOLOG)
-}
-
 func TestClusterCreate(t *testing.T) {
 	tmpfile := tests.Tempfile()
 	defer os.Remove(tmpfile)

--- a/apps/glusterfs/app_device_test.go
+++ b/apps/glusterfs/app_device_test.go
@@ -27,11 +27,6 @@ import (
 	"github.com/heketi/tests"
 )
 
-func init() {
-	// turn off logging
-	logger.SetLevel(utils.LEVEL_NOLOG)
-}
-
 func TestDeviceAddBadRequests(t *testing.T) {
 	tmpfile := tests.Tempfile()
 	defer os.Remove(tmpfile)

--- a/apps/glusterfs/app_middleware_test.go
+++ b/apps/glusterfs/app_middleware_test.go
@@ -20,13 +20,8 @@ import (
 
 	//"github.com/boltdb/bolt"
 	wdb "github.com/heketi/heketi/pkg/db"
-	"github.com/heketi/heketi/pkg/utils"
 	"github.com/heketi/tests"
 )
-
-func init() {
-	logger.SetLevel(utils.LEVEL_NOLOG)
-}
 
 func TestBackupToKubeSecretMaxSize(t *testing.T) {
 	tmpfile := tests.Tempfile()

--- a/apps/glusterfs/app_node_test.go
+++ b/apps/glusterfs/app_node_test.go
@@ -28,11 +28,6 @@ import (
 	"github.com/heketi/tests"
 )
 
-func init() {
-	// turn off logging
-	logger.SetLevel(utils.LEVEL_NOLOG)
-}
-
 func TestNodeAddBadRequests(t *testing.T) {
 	tmpfile := tests.Tempfile()
 	defer os.Remove(tmpfile)

--- a/apps/glusterfs/app_volume_test.go
+++ b/apps/glusterfs/app_volume_test.go
@@ -33,11 +33,6 @@ import (
 	"github.com/heketi/tests"
 )
 
-func init() {
-	// turn off logging
-	logger.SetLevel(utils.LEVEL_NOLOG)
-}
-
 func TestVolumeCreateBadGid(t *testing.T) {
 	tmpfile := tests.Tempfile()
 	defer os.Remove(tmpfile)


### PR DESCRIPTION
Some tests were disabling logs and some were not. Based on the
discussion in #792, changing everywhere to default logging.

As per https://github.com/golang/go/issues/21461, the logs won't
pollute the output if all tests pass.

If a test fails then all logs from the package are shown. This is
something which can be fixed later. It would be useful to limit logs of
that particular test instead of package.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>