### PR TITLE
register types with gob during init

### DIFF
--- a/apps/glusterfs/app_db.go
+++ b/apps/glusterfs/app_db.go
@@ -10,7 +10,6 @@
 package glusterfs
 
 import (
-	"encoding/gob"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -242,16 +241,6 @@ func DbCreate(jsonfile string, dbfile string, debug bool) error {
 	if debug {
 		logger.SetLevel(utils.LEVEL_DEBUG)
 	}
-
-	// we use gob package to serialize entries before writing to db
-	// to serialize an interface type, it needs to be registered with gob.
-	// this should ideally be done during volume bucket creation
-	// but it is done during first VolumeEntry creation in current code
-	// TODO: create wrapper for volume bucket creation and type registration
-	gob.Register(&NoneDurability{})
-	gob.Register(&VolumeReplicaDurability{})
-	gob.Register(&VolumeDisperseDurability{})
-	logger.Debug("interface type registration complete")
 
 	var dump Db
 

--- a/apps/glusterfs/volume_durability_ec.go
+++ b/apps/glusterfs/volume_durability_ec.go
@@ -10,9 +10,21 @@
 package glusterfs
 
 import (
+	"encoding/gob"
+
 	"github.com/heketi/heketi/executors"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
+
+func init() {
+	// Volume Entry has VolumeDurability interface as a member.
+	// Serialization tools need to know the types that satisfy this
+	// interface. gob is used to serialize entries for db. Strictly
+	// speaking, it is not required to store VolumeDurability member in db
+	// as it can be recreated from volumeInfo. But removing it now would
+	// break backward with db.
+	gob.Register(&VolumeDisperseDurability{})
+}
 
 type VolumeDisperseDurability struct {
 	api.DisperseDurability

--- a/apps/glusterfs/volume_durability_none.go
+++ b/apps/glusterfs/volume_durability_none.go
@@ -10,8 +10,20 @@
 package glusterfs
 
 import (
+	"encoding/gob"
+
 	"github.com/heketi/heketi/executors"
 )
+
+func init() {
+	// Volume Entry has VolumeDurability interface as a member.
+	// Serialization tools need to know the types that satisfy this
+	// interface. gob is used to serialize entries for db. Strictly
+	// speaking, it is not required to store VolumeDurability member in db
+	// as it can be recreated from volumeInfo. But removing it now would
+	// break backward with db.
+	gob.Register(&NoneDurability{})
+}
 
 type NoneDurability struct {
 	VolumeReplicaDurability

--- a/apps/glusterfs/volume_durability_replica.go
+++ b/apps/glusterfs/volume_durability_replica.go
@@ -10,9 +10,21 @@
 package glusterfs
 
 import (
+	"encoding/gob"
+
 	"github.com/heketi/heketi/executors"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
+
+func init() {
+	// Volume Entry has VolumeDurability interface as a member.
+	// Serialization tools need to know the types that satisfy this
+	// interface. gob is used to serialize entries for db. Strictly
+	// speaking, it is not required to store VolumeDurability member in db
+	// as it can be recreated from volumeInfo. But removing it now would
+	// break backward with db.
+	gob.Register(&VolumeReplicaDurability{})
+}
 
 type VolumeReplicaDurability struct {
 	api.ReplicaDurability

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -66,10 +66,6 @@ func NewVolumeEntry() *VolumeEntry {
 	entry := &VolumeEntry{}
 	entry.Bricks = make(sort.StringSlice, 0)
 
-	gob.Register(&NoneDurability{})
-	gob.Register(&VolumeReplicaDurability{})
-	gob.Register(&VolumeDisperseDurability{})
-
 	return entry
 }
 


### PR DESCRIPTION
Remove duplication in code by moving gob registration to more logical
place.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>