### PR TITLE
Untangle / Operations Pt. I

### DIFF
--- a/apps/glusterfs/app_block_volume_test.go
+++ b/apps/glusterfs/app_block_volume_test.go
@@ -204,22 +204,9 @@ func TestBlockVolumeLargerThanBlockHostingVolume(t *testing.T) {
     }`)
 	r, err = http.Post(ts.URL+"/blockvolumes", "application/json", bytes.NewBuffer(request))
 	tests.Assert(t, err == nil)
-	tests.Assert(t, r.StatusCode == http.StatusAccepted)
-	location, err = r.Location()
-	tests.Assert(t, err == nil)
-
-	for {
-		r, err = http.Get(location.String())
-		tests.Assert(t, err == nil)
-		if r.Header.Get("X-Pending") == "true" {
-			tests.Assert(t, r.StatusCode == http.StatusOK)
-			time.Sleep(time.Millisecond * 10)
-		} else {
-			tests.Assert(t, r.StatusCode == http.StatusInternalServerError, "got", r.StatusCode)
-			break
-		}
-	}
-
+	// NOTE: as of the pending operations work this now fails faster with
+	// an out of space error on the submission, not in the async reply
+	tests.Assert(t, r.StatusCode == http.StatusInternalServerError)
 	body, err := ioutil.ReadAll(io.LimitReader(r.Body, r.ContentLength))
 	tests.Assert(t, err == nil)
 	r.Body.Close()

--- a/apps/glusterfs/app_test.go
+++ b/apps/glusterfs/app_test.go
@@ -251,3 +251,36 @@ func TestAppBlockSettings(t *testing.T) {
 	tests.Assert(t, CreateBlockHostingVolumes == true)
 	tests.Assert(t, BlockHostingVolumeSize == 500)
 }
+
+func TestCannotStartWhenPendingOperations(t *testing.T) {
+	dbfile := tests.Tempfile()
+	defer os.Remove(dbfile)
+
+	// create a app that will only be used to set up the test
+	app := NewTestApp(dbfile)
+	tests.Assert(t, app != nil)
+
+	// populate the db with a "dummy" pending op entry. this should
+	// trigger a panic the next time an app is instantiated
+	err := app.db.Update(func(tx *bolt.Tx) error {
+		op := NewPendingOperationEntry(NEW_ID)
+		op.Save(tx)
+		return nil
+	})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	app.Close()
+
+	defer func() {
+		// check that we (a) panicked (b) had the right error message
+		r := recover()
+		tests.Assert(t, r != nil, "expected r != nil, got:", r)
+		tests.Assert(t,
+			strings.Contains(r.(error).Error(), "pending operations are present"),
+			`expected "pending operations are present" in r.Error(), got:`,
+			r.(error).Error())
+	}()
+	// now creating a new app should panic
+	app = NewTestApp(dbfile)
+
+	t.Fatalf("Test should not reach this line")
+}

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -269,14 +269,6 @@ func (v *BlockVolumeEntry) Create(db wdb.DB,
 
 	logger.Debug("Using block hosting volume id[%v]", blockHostingVolume)
 
-	defer func() {
-		if e != nil {
-			db.Update(func(tx *bolt.Tx) error {
-				// removal of stuff that was created in the db
-				return nil
-			})
-		}
-	}()
 	// Create the block volume on the block hosting volume specified
 	err := v.createBlockVolume(db, executor, blockHostingVolume)
 	if err != nil {

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -240,6 +240,18 @@ func (v *BlockVolumeEntry) eligibleClustersAndVolumes(db wdb.RODB) (
 	return
 }
 
+func (v *BlockVolumeEntry) cleanupBlockVolumeCreate(db wdb.DB,
+	executor executors.Executor) error {
+
+	if e := v.Destroy(db, executor); e != nil {
+		return e
+	}
+	return db.Update(func(tx *bolt.Tx) error {
+		v.Delete(tx)
+		return nil
+	})
+}
+
 func (v *BlockVolumeEntry) Create(db wdb.DB,
 	executor executors.Executor,
 	allocator Allocator) (e error) {

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -283,10 +283,14 @@ func (v *BlockVolumeEntry) Create(db wdb.DB,
 		}
 	}()
 
-	err = db.Update(func(tx *bolt.Tx) error {
-		v.Info.BlockHostingVolume = blockHostingVolume
+	v.Info.BlockHostingVolume = blockHostingVolume
+	return v.saveCreateBlockVolume(db)
+}
 
-		err = v.Save(tx)
+func (v *BlockVolumeEntry) saveCreateBlockVolume(db wdb.DB) error {
+	return db.Update(func(tx *bolt.Tx) error {
+
+		err := v.Save(tx)
 		if err != nil {
 			return err
 		}
@@ -303,7 +307,7 @@ func (v *BlockVolumeEntry) Create(db wdb.DB,
 			return err
 		}
 
-		volume, err := NewVolumeEntryFromId(tx, blockHostingVolume)
+		volume, err := NewVolumeEntryFromId(tx, v.Info.BlockHostingVolume)
 		if err != nil {
 			return err
 		}
@@ -318,11 +322,6 @@ func (v *BlockVolumeEntry) Create(db wdb.DB,
 
 		return err
 	})
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (v *BlockVolumeEntry) Destroy(db wdb.DB, executor executors.Executor) error {

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -376,17 +376,10 @@ func (v *BlockVolumeEntry) removeComponents(db wdb.DB) error {
 func (v *BlockVolumeEntry) Destroy(db wdb.DB, executor executors.Executor) error {
 	logger.Info("Destroying volume %v", v.Info.Id)
 
-	hvname, err:= v.blockHostingVolumeName(db)
-	if err != nil {
-		return err
-	}
-	logger.Debug("Using blockosting volume name[%v]", hvname)
-
-	if e := v.deleteBlockVolumeExec(db, hvname, executor); e != nil {
-		return e
-	}
-
-	return v.removeComponents(db)
+	return RunOperation(
+		NewBlockVolumeDeleteOperation(v, db),
+		nil,
+		executor)
 }
 
 // canHostBlockVolume returns true if the existing volume entry object

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -117,8 +117,7 @@ func (v *BlockVolumeEntry) BucketName() string {
 }
 
 func (v *BlockVolumeEntry) Visible() bool {
-	// currently all block volumes are always visible
-	return true
+	return v.Pending.Id == ""
 }
 
 func (v *BlockVolumeEntry) Save(tx *bolt.Tx) error {

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -35,11 +35,8 @@ func BlockVolumeList(tx *bolt.Tx) ([]string, error) {
 	return list, nil
 }
 
-// Creates a File volume to host block volumes
-func CreateBlockHostingVolume(db wdb.DB, executor executors.Executor, allocator Allocator, clusters []string) (*VolumeEntry, error) {
+func NewVolumeEntryForBlockHosting(clusters []string) (*VolumeEntry, error) {
 	var msg api.VolumeCreateRequest
-	var err error
-
 	msg.Clusters = clusters
 	msg.Durability.Type = api.DurabilityReplicate
 	msg.Size = BlockHostingVolumeSize
@@ -53,6 +50,16 @@ func CreateBlockHostingVolume(db wdb.DB, executor executors.Executor, allocator 
 		return nil, fmt.Errorf("Requested volume size (%v GB) is "+
 			"smaller than the minimum supported volume size (%v)",
 			msg.Size, vol.Durability.MinVolumeSize())
+	}
+	return vol, nil
+}
+
+// Creates a File volume to host block volumes
+func CreateBlockHostingVolume(db wdb.DB, executor executors.Executor, allocator Allocator, clusters []string) (*VolumeEntry, error) {
+
+	vol, err := NewVolumeEntryForBlockHosting(clusters)
+	if err != nil {
+		return nil, err
 	}
 
 	err = vol.Create(db, executor, allocator)

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -243,13 +243,15 @@ func (v *BlockVolumeEntry) eligibleClustersAndVolumes(db wdb.RODB) (
 func (v *BlockVolumeEntry) cleanupBlockVolumeCreate(db wdb.DB,
 	executor executors.Executor) error {
 
-	if e := v.Destroy(db, executor); e != nil {
-		return e
+	hvname, err := v.blockHostingVolumeName(db)
+	if err != nil {
+		return err
 	}
-	return db.Update(func(tx *bolt.Tx) error {
-		v.Delete(tx)
-		return nil
-	})
+
+	// best effort removal of anything on system
+	v.deleteBlockVolumeExec(db, hvname, executor)
+
+	return v.removeComponents(db)
 }
 
 func (v *BlockVolumeEntry) Create(db wdb.DB,

--- a/apps/glusterfs/brick_create.go
+++ b/apps/glusterfs/brick_create.go
@@ -22,7 +22,7 @@ const (
 	CREATOR_DESTROY
 )
 
-func createDestroyConcurrently(db wdb.DB,
+func createDestroyConcurrently(db wdb.RODB,
 	executor executors.Executor,
 	brick_entries []*BrickEntry,
 	create_type CreateType) error {
@@ -56,10 +56,10 @@ func createDestroyConcurrently(db wdb.DB,
 	return err
 }
 
-func CreateBricks(db wdb.DB, executor executors.Executor, brick_entries []*BrickEntry) error {
+func CreateBricks(db wdb.RODB, executor executors.Executor, brick_entries []*BrickEntry) error {
 	return createDestroyConcurrently(db, executor, brick_entries, CREATOR_CREATE)
 }
 
-func DestroyBricks(db wdb.DB, executor executors.Executor, brick_entries []*BrickEntry) error {
+func DestroyBricks(db wdb.RODB, executor executors.Executor, brick_entries []*BrickEntry) error {
 	return createDestroyConcurrently(db, executor, brick_entries, CREATOR_DESTROY)
 }

--- a/apps/glusterfs/dbexamples.go
+++ b/apps/glusterfs/dbexamples.go
@@ -1,0 +1,136 @@
+// +build dbexamples
+
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/boltdb/bolt"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/tests"
+)
+
+func buildCluster(app *App) {
+	app.db.Update(func(tx *bolt.Tx) error {
+		// create a cluster
+		cluster_req := &api.ClusterCreateRequest{
+			ClusterFlags: api.ClusterFlags{
+				Block: true,
+				File:  true,
+			},
+		}
+		c := NewClusterEntryFromRequest(cluster_req)
+		// create three nodes
+		for i := 0; i < 3; i++ {
+			node_req := &api.NodeAddRequest{
+				ClusterId: "asdf",
+				Zone:      1,
+				Hostnames: api.HostAddresses{
+					Manage:  []string{fmt.Sprintf("mng%v", i)},
+					Storage: []string{fmt.Sprintf("stor%v", i)},
+				},
+			}
+			n := NewNodeEntryFromRequest(node_req)
+			n.Info.ClusterId = c.Info.Id
+			c.NodeAdd(n.Info.Id)
+
+			// create three 1TB devices
+			for j := 0; j < 3; j++ {
+				dev_req := &api.DeviceAddRequest{
+					NodeId: n.Info.Id,
+				}
+				dev_req.Name = fmt.Sprintf("/dev/id%v", j)
+				d := NewDeviceEntryFromRequest(dev_req)
+				d.StorageSet(1 << 30)
+				n.DeviceAdd(d.Id())
+				if err := d.Save(tx); err != nil {
+					return err
+				}
+			}
+			if err := n.Save(tx); err != nil {
+				return err
+			}
+		}
+		if err := c.Save(tx); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func BuildSimpleCluster(t *testing.T, filename string) {
+	app := NewTestApp(filename)
+	defer app.Close()
+
+	buildCluster(app)
+}
+
+func LeakPendingVolumeCreate(t *testing.T, filename string) {
+
+	app := NewTestApp(filename)
+	defer app.Close()
+
+	buildCluster(app)
+
+	req := &api.VolumeCreateRequest{}
+	req.Size = 10
+	req.Durability.Type = api.DurabilityReplicate
+	req.Durability.Replicate.Replica = 3
+
+	vol := NewVolumeEntryFromRequest(req)
+	vc := NewVolumeCreateOperation(vol, app.db)
+
+	// verify that there are no volumes, bricks or pending operations
+	app.db.View(func(tx *bolt.Tx) error {
+		vl, e := VolumeList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(vl) == 0, "expected len(vl) == 0, got", len(vl))
+		bl, e := BrickList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(bl) == 0, "expected len(bl) == 0, got", len(bl))
+		pol, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(pol) == 0, "expected len(pol) == 0, got", len(pol))
+		return nil
+	})
+
+	e := vc.Build(app.Allocator())
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	// verify volumes, bricks, & pending ops exist
+	app.db.View(func(tx *bolt.Tx) error {
+		vl, e := VolumeList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(vl) == 1, "expected len(vl) == 1, got", len(vl))
+		bl, e := BrickList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(bl) == 3, "expected len(bl) == 3, got", len(bl))
+		pol, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(pol) == 1, "expected len(pol) == 1, got", len(pol))
+
+		for _, vid := range vl {
+			v, e := NewVolumeEntryFromId(tx, vid)
+			tests.Assert(t, e == nil, "expected e == nil, got", e)
+			tests.Assert(t, v.Pending.Id == pol[0],
+				"expected v.Pending.Id == pol[0], got:", v.Pending.Id, pol[0])
+		}
+		for _, bid := range bl {
+			b, e := NewBrickEntryFromId(tx, bid)
+			tests.Assert(t, e == nil, "expected e == nil, got", e)
+			tests.Assert(t, b.Pending.Id == pol[0],
+				"expected b.Pending.Id == pol[0], got:", b.Pending.Id, pol[0])
+		}
+		return nil
+	})
+}

--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -414,6 +414,25 @@ func bricksFromOp(db wdb.RODB,
 	return brick_entries, err
 }
 
+func volumesFromOp(db wdb.RODB,
+	op *PendingOperationEntry) ([]*VolumeEntry, error) {
+
+	volume_entries := []*VolumeEntry{}
+	err := db.View(func(tx *bolt.Tx) error {
+		for _, a := range op.Actions {
+			if a.Change == OpAddVolume {
+				brick, err := NewVolumeEntryFromId(tx, a.Id)
+				if err != nil {
+					return err
+				}
+				volume_entries = append(volume_entries, brick)
+			}
+		}
+		return nil
+	})
+	return volume_entries, err
+}
+
 // expandSizeFromOp returns the size of a volume expand operation assuming
 // the given pending operation entry includes a volume expand change item.
 // If the operation is of the wrong type error will be non-nil.

--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -388,6 +388,219 @@ func (vdel *VolumeDeleteOperation) Finalize() error {
 	})
 }
 
+// BlockVolumeCreateOperation  implements the operation functions used to
+// create a new volume.
+type BlockVolumeCreateOperation struct {
+	OperationManager
+	bvol *BlockVolumeEntry
+	//vol *VolumeEntry
+}
+
+// NewBlockVolumeCreateOperation  returns a new BlockVolumeCreateOperation  populated
+// with the given volume entry and db connection and allocates a new
+// pending operation entry.
+func NewBlockVolumeCreateOperation(
+	bv *BlockVolumeEntry, db wdb.DB) *BlockVolumeCreateOperation {
+
+	return &BlockVolumeCreateOperation{
+		OperationManager: OperationManager{
+			db: db,
+			op: NewPendingOperationEntry(NEW_ID),
+		},
+		bvol: bv,
+	}
+}
+
+func (bvc *BlockVolumeCreateOperation) Label() string {
+	return "Create Block Volume"
+}
+
+func (bvc *BlockVolumeCreateOperation) ResourceUrl() string {
+	return fmt.Sprintf("/blockvolumes/%v", bvc.bvol.Info.Id)
+}
+
+// Build allocates and saves new volume and brick entries (tagged as pending)
+// in the db.
+func (bvc *BlockVolumeCreateOperation) Build(allocator Allocator) error {
+	return bvc.db.Update(func(tx *bolt.Tx) error {
+		txdb := wdb.WrapTx(tx)
+		clusters, volumes, err := bvc.bvol.eligibleClustersAndVolumes(txdb)
+		if err != nil {
+			return err
+		}
+
+		if len(volumes) > 0 {
+			bvc.bvol.Info.BlockHostingVolume = volumes[0]
+		} else {
+			vol, err := NewVolumeEntryForBlockHosting(clusters)
+			if err != nil {
+				return err
+			}
+			brick_entries, err := vol.createVolumeComponents(txdb, allocator)
+			if err != nil {
+				return err
+			}
+			// we just allocated a new volume and bricks, we need to record
+			// these in the op
+			for _, brick := range brick_entries {
+				bvc.op.RecordAddBrick(brick)
+				if e := brick.Save(tx); e != nil {
+					return e
+				}
+			}
+			bvc.op.RecordAddHostingVolume(vol)
+			if e := bvc.bvol.Save(tx); e != nil {
+				return e
+			}
+			bvc.bvol.Info.BlockHostingVolume = vol.Info.Id
+		}
+
+		// we've figured out what block-volume, hosting volume, and bricks we
+		// will be using for the next phase of the operation, save our pending sate
+		bvc.op.RecordAddBlockVolume(bvc.bvol)
+		if e := bvc.bvol.Save(tx); e != nil {
+			return e
+		}
+
+		if e := bvc.op.Save(tx); e != nil {
+			return e
+		}
+		return nil
+	})
+}
+
+func (bvc *BlockVolumeCreateOperation) volAndBricks(db wdb.RODB) (
+	vol *VolumeEntry, brick_entries []*BrickEntry, err error) {
+
+	// NOTE: It is perfectly fine and normal for there to be no bricks or volumes
+	// on the op. However if there are bricks there must be volumes (and vice versa).
+	vol = nil
+	volume_entries, err := volumesFromOp(db, bvc.op)
+	if err != nil {
+		logger.LogError("Failed to get volumes from op: %v", err)
+		return
+	}
+	// try to get gid now even though we haven't done any sanity checks
+	// yet. Otherwise we have to go to the db for bricks twice
+	brickGid := int64(0)
+	if len(volume_entries) == 1 {
+		brickGid = volume_entries[0].Info.Gid
+	}
+	brick_entries, err = bricksFromOp(db, bvc.op, brickGid)
+	if err != nil {
+		logger.LogError("Failed to get bricks from op: %v", err)
+		return
+	}
+
+	if len(volume_entries) > 1 {
+		err = logger.LogError("Unexpected number of new volume entries (%v)",
+			len(volume_entries))
+		return
+	}
+	if len(volume_entries) > 0 && len(brick_entries) == 0 {
+		err = logger.LogError("Cannot create a new block hosting volume without bricks")
+		return
+	}
+	if len(volume_entries) == 0 && len(brick_entries) > 0 {
+		err = logger.LogError("Cannot create bricks without a hosting volume")
+		return
+	}
+
+	if len(volume_entries) == 1 {
+		vol = volume_entries[0]
+	}
+	return
+}
+
+// Exec creates new bricks and volume on the underlying glusterfs storage system.
+func (bvc *BlockVolumeCreateOperation) Exec(executor executors.Executor) error {
+	vol, brick_entries, err := bvc.volAndBricks(bvc.db)
+	if err != nil {
+		return err
+	}
+
+	if vol != nil {
+		err = vol.createVolumeExec(bvc.db, executor, brick_entries)
+		if err != nil {
+			logger.LogError("Error executing create volume: %v", err)
+			return err
+		}
+	}
+	// NOTE: unlike regular volume create this function does update attributes
+	// of the block volume entry with values that come back from the exec commands.
+	// this doesn't break the Operation model but does mean this is non trivially
+	// resumeable if we ever add resume support to normal volume create.
+	err = bvc.bvol.createBlockVolume(bvc.db, executor, bvc.bvol.Info.BlockHostingVolume)
+	if err != nil {
+		logger.LogError("Error executing create block volume: %v", err)
+	}
+	return err
+}
+
+// Finalize marks our new volume and brick db entries as no longer pending.
+func (bvc *BlockVolumeCreateOperation) Finalize() error {
+	return bvc.db.Update(func(tx *bolt.Tx) error {
+		txdb := wdb.WrapTx(tx)
+		vol, brick_entries, err := bvc.volAndBricks(txdb)
+		if err != nil {
+			return err
+		}
+		if vol != nil {
+			for _, brick := range brick_entries {
+				bvc.op.FinalizeBrick(brick)
+				if e := brick.Save(tx); e != nil {
+					return e
+				}
+			}
+			bvc.op.FinalizeVolume(vol)
+			if e := vol.Save(tx); e != nil {
+				return e
+			}
+		}
+
+		// traditionally (that is before operations existed) the block volumes
+		// were updating most of their metadata after exec. This is only
+		// noteworthy because it is different from regular volumes which
+		// do most of those updates upfront.
+		if e := bvc.bvol.saveCreateBlockVolume(txdb); e != nil {
+			return e
+		}
+
+		bvc.op.FinalizeBlockVolume(bvc.bvol)
+		if e := bvc.bvol.Save(tx); e != nil {
+			return e
+		}
+
+		bvc.op.Delete(tx)
+		return nil
+	})
+}
+
+// Rollback removes any dangling volume and bricks from the underlying storage
+// systems and removes the corresponding pending volume and brick entries from
+// the db.
+func (bvc *BlockVolumeCreateOperation) Rollback(executor executors.Executor) error {
+	// TODO make this into one transaction too
+	vol, brick_entries, err := bvc.volAndBricks(bvc.db)
+	if err != nil {
+		return err
+	}
+	if e := bvc.bvol.cleanupBlockVolumeCreate(bvc.db, executor); e != nil {
+		return e
+	}
+	if vol != nil {
+		err = vol.cleanupCreateVolume(bvc.db, executor, brick_entries)
+		if err != nil {
+			logger.LogError("Error on create volume rollback: %v", err)
+			return err
+		}
+	}
+	err = bvc.db.Update(func(tx *bolt.Tx) error {
+		return bvc.op.Delete(tx)
+	})
+	return err
+}
+
 // bricksFromOp returns pending brick entry objects from the db corresponding
 // to the given pending operation entry. The gid of the volume must also be
 // provided as the db does not store this metadata on the brick entries.

--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -1,7 +1,12 @@
 package glusterfs
 
 import (
+	"fmt"
+
+	"github.com/heketi/heketi/executors"
 	wdb "github.com/heketi/heketi/pkg/db"
+
+	"github.com/boltdb/bolt"
 )
 
 type Operation interface {
@@ -39,21 +44,111 @@ func NewVolumeCreateOperation(
 	}
 }
 
+func (vc *VolumeCreateOperation) Label() string {
+	return "Create Volume"
+}
+
+func (vc *VolumeCreateOperation) ResourceUrl() string {
+	return fmt.Sprintf("/volumes/%v", vc.vol.Info.Id)
+}
+
 func (vc *VolumeCreateOperation) Build(allocator Allocator) error {
-	// vc.vol.createVolumeComponents(vc.db, allocator)
-	return nil
+	return vc.db.Update(func(tx *bolt.Tx) error {
+		txdb := wdb.WrapTx(tx)
+		brick_entries, err := vc.vol.createVolumeComponents(txdb, allocator)
+		if err != nil {
+			return err
+		}
+		for _, brick := range brick_entries {
+			vc.op.RecordAddBrick(brick)
+			if e := brick.Save(tx); e != nil {
+				return e
+			}
+		}
+		vc.op.RecordAddVolume(vc.vol)
+		if e := vc.vol.Save(tx); e != nil {
+			return e
+		}
+		if e := vc.op.Save(tx); e != nil {
+			return e
+		}
+		return nil
+	})
 }
 
 func (vc *VolumeCreateOperation) Exec(executor executors.Executor) error {
-	// vc.vol.createVolumeExec(vc.db, executor)
-	return nil
+	brick_entries, err := bricksFromOp(vc.db, vc.op, vc.vol.Info.Gid)
+	if err != nil {
+		logger.LogError("Failed to get bricks from op: %v", err)
+		return err
+	}
+	err = vc.vol.createVolumeExec(vc.db, executor, brick_entries)
+	if err != nil {
+		logger.LogError("Error executing create volume: %v", err)
+	}
+	return err
 }
 
 func (vc *VolumeCreateOperation) Finalize() error {
-	return nil
+	return vc.db.Update(func(tx *bolt.Tx) error {
+		brick_entries, err := bricksFromOp(wdb.WrapTx(tx), vc.op, vc.vol.Info.Gid)
+		if err != nil {
+			logger.LogError("Failed to get bricks from op: %v", err)
+			return err
+		}
+		for _, brick := range brick_entries {
+			vc.op.FinalizeBrick(brick)
+			if e := brick.Save(tx); e != nil {
+				return e
+			}
+		}
+		vc.op.FinalizeVolume(vc.vol)
+		if e := vc.vol.Save(tx); e != nil {
+			return e
+		}
+
+		vc.op.Delete(tx)
+		return nil
+	})
 }
 
 func (vc *VolumeCreateOperation) Rollback(executor executors.Executor) error {
-	// vc.vol.cleanupCreateVolume(vc.db, executors, brick_entries)
-	return nil
+	// TODO make this into one transaction too
+	brick_entries, err := bricksFromOp(vc.db, vc.op, vc.vol.Info.Gid)
+	if err != nil {
+		logger.LogError("Failed to get bricks from op: %v", err)
+		return err
+	}
+	err = vc.vol.cleanupCreateVolume(vc.db, executor, brick_entries)
+	if err != nil {
+		logger.LogError("Error on create volume rollback: %v", err)
+		return err
+	}
+	err = vc.db.Update(func(tx *bolt.Tx) error {
+		return vc.op.Delete(tx)
+	})
+	return err
+}
+
+func bricksFromOp(db wdb.RODB,
+	op *PendingOperationEntry, gid int64) ([]*BrickEntry, error) {
+
+	brick_entries := []*BrickEntry{}
+	err := db.View(func(tx *bolt.Tx) error {
+		for _, a := range op.Actions {
+			if a.Change == OpAddBrick {
+				brick, err := NewBrickEntryFromId(tx, a.Id)
+				if err != nil {
+					return err
+				}
+				// this next line is a bit of an unfortunate hack because
+				// the db does not preserver the requested gid that is
+				// needed for the request
+				brick.gidRequested = gid
+				brick_entries = append(brick_entries, brick)
+			}
+		}
+		return nil
+	})
+	return brick_entries, err
 }

--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -1,0 +1,59 @@
+package glusterfs
+
+import (
+	wdb "github.com/heketi/heketi/pkg/db"
+)
+
+type Operation interface {
+	Label() string
+	ResourceUrl() string
+	Build(allocator Allocator) error
+	Exec(executor executors.Executor) error
+	Rollback(executor executors.Executor) error
+	Finalize() error
+}
+
+type OperationManager struct {
+	db wdb.DB
+	op *PendingOperationEntry
+}
+
+func (om *OperationManager) Id() string {
+	return om.op.Id
+}
+
+type VolumeCreateOperation struct {
+	OperationManager
+	vol *VolumeEntry
+}
+
+func NewVolumeCreateOperation(
+	vol *VolumeEntry, db wdb.DB) *VolumeCreateOperation {
+
+	return &VolumeCreateOperation{
+		OperationManager: OperationManager{
+			db: db,
+			op: NewPendingOperationEntry(NEW_ID),
+		},
+		vol: vol,
+	}
+}
+
+func (vc *VolumeCreateOperation) Build(allocator Allocator) error {
+	// vc.vol.createVolumeComponents(vc.db, allocator)
+	return nil
+}
+
+func (vc *VolumeCreateOperation) Exec(executor executors.Executor) error {
+	// vc.vol.createVolumeExec(vc.db, executor)
+	return nil
+}
+
+func (vc *VolumeCreateOperation) Finalize() error {
+	return nil
+}
+
+func (vc *VolumeCreateOperation) Rollback(executor executors.Executor) error {
+	// vc.vol.cleanupCreateVolume(vc.db, executors, brick_entries)
+	return nil
+}

--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -250,7 +250,7 @@ func bricksFromOp(db wdb.RODB,
 	brick_entries := []*BrickEntry{}
 	err := db.View(func(tx *bolt.Tx) error {
 		for _, a := range op.Actions {
-			if a.Change == OpAddBrick {
+			if a.Change == OpAddBrick || a.Change == OpDeleteBrick {
 				brick, err := NewBrickEntryFromId(tx, a.Id)
 				if err != nil {
 					return err

--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -154,6 +154,25 @@ func bricksFromOp(db wdb.RODB,
 	return brick_entries, err
 }
 
+func expandSizeFromOp(db wdb.RODB,
+	op *PendingOperationEntry) (sizeGB int, e error) {
+	err := db.View(func(tx *bolt.Tx) error {
+		for _, a := range op.Actions {
+			if a.Change == OpExpandVolume {
+				sizeGB, e = a.ExpandSize()
+				return nil
+			}
+		}
+		e = fmt.Errorf("no OpExpandVolume action in pending op: %v",
+			op.Id)
+		return nil
+	})
+	if err != nil && e == nil {
+		e = err
+	}
+	return
+}
+
 func AsyncHttpOperation(app *App,
 	w http.ResponseWriter,
 	r *http.Request,

--- a/apps/glusterfs/operations_test.go
+++ b/apps/glusterfs/operations_test.go
@@ -257,3 +257,128 @@ func TestVolumeCreatePendingNoSpace(t *testing.T) {
 		return nil
 	})
 }
+
+func TestVolumeCreatePendingBrickMissing(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	req := &api.VolumeCreateRequest{}
+	req.Size = 1024
+	req.Durability.Type = api.DurabilityReplicate
+	req.Durability.Replicate.Replica = 3
+
+	vol := NewVolumeEntryFromRequest(req)
+	vc := NewVolumeCreateOperation(vol, app.db)
+
+	// verify that there are no volumes, bricks or pending operations
+	app.db.View(func(tx *bolt.Tx) error {
+		vl, e := VolumeList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(vl) == 0, "expected len(vl) == 0, got", len(vl))
+		bl, e := BrickList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(bl) == 0, "expected len(bl) == 0, got", len(bl))
+		pol, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(pol) == 0, "expected len(pol) == 0, got", len(pol))
+		return nil
+	})
+
+	e := vc.Build(app.Allocator())
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	// verify volumes, bricks, & pending ops exist
+	app.db.View(func(tx *bolt.Tx) error {
+		vl, e := VolumeList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(vl) == 1, "expected len(vl) == 1, got", len(vl))
+		bl, e := BrickList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(bl) == 3, "expected len(bl) == 3, got", len(bl))
+		pol, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(pol) == 1, "expected len(pol) == 1, got", len(pol))
+
+		for _, vid := range vl {
+			v, e := NewVolumeEntryFromId(tx, vid)
+			tests.Assert(t, e == nil, "expected e == nil, got", e)
+			tests.Assert(t, v.Pending.Id == pol[0],
+				"expected v.Pending.Id == pol[0], got:", v.Pending.Id, pol[0])
+		}
+		for _, bid := range bl {
+			b, e := NewBrickEntryFromId(tx, bid)
+			tests.Assert(t, e == nil, "expected e == nil, got", e)
+			tests.Assert(t, b.Pending.Id == pol[0],
+				"expected b.Pending.Id == pol[0], got:", b.Pending.Id, pol[0])
+		}
+		return nil
+	})
+
+	app.db.Update(func(tx *bolt.Tx) error {
+		bl, e := BrickList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		b, e := NewBrickEntryFromId(tx, bl[0])
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		e = b.Delete(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		return nil
+	})
+
+	// now that the brick list in the db is broken Exec/Finalize/Rollback
+	// will return errors
+
+	e = vc.Exec(app.executor)
+	tests.Assert(t, e != nil, "expected e != nil, got", e)
+
+	e = vc.Finalize()
+	tests.Assert(t, e != nil, "expected e != nil, got", e)
+
+	e = vc.Rollback(app.executor)
+	tests.Assert(t, e != nil, "expected e != nil, got", e)
+}
+
+func TestVolumeCreateOperationBasics(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	req := &api.VolumeCreateRequest{}
+	req.Size = 1024
+	req.Durability.Type = api.DurabilityReplicate
+	req.Durability.Replicate.Replica = 3
+
+	vol := NewVolumeEntryFromRequest(req)
+	vol.Info.Id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	vc := NewVolumeCreateOperation(vol, app.db)
+
+	tests.Assert(t, vc.Id() == vc.op.Id,
+		"expected vc.Id() == vc.op.Id, got:", vc.Id(), vc.op.Id)
+	tests.Assert(t, vc.Label() == "Create Volume",
+		`expected vc.Label() == "Volume Create", got:`, vc.Label())
+	tests.Assert(t, vc.ResourceUrl() == "/volumes/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		`expected vc.ResourceUrl() == "/volumes/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", got:`,
+		vc.ResourceUrl())
+}

--- a/apps/glusterfs/operations_test.go
+++ b/apps/glusterfs/operations_test.go
@@ -201,3 +201,59 @@ func TestVolumeCreatePendingRollback(t *testing.T) {
 	})
 }
 
+func TestVolumeCreatePendingNoSpace(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		1*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	req := &api.VolumeCreateRequest{}
+	req.Size = 1024 * 5
+	req.Durability.Type = api.DurabilityReplicate
+	req.Durability.Replicate.Replica = 3
+
+	vol := NewVolumeEntryFromRequest(req)
+	vc := NewVolumeCreateOperation(vol, app.db)
+
+	// verify that there are no volumes, bricks or pending operations
+	app.db.View(func(tx *bolt.Tx) error {
+		vl, e := VolumeList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(vl) == 0, "expected len(vl) == 0, got", len(vl))
+		bl, e := BrickList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(bl) == 0, "expected len(bl) == 0, got", len(bl))
+		pol, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(pol) == 0, "expected len(pol) == 0, got", len(pol))
+		return nil
+	})
+
+	e := vc.Build(app.Allocator())
+	// verify that we failed to allocate due to lack of space
+	tests.Assert(t, e == ErrNoSpace, "expected e == ErrNoSpace, got", e)
+
+	// verify no volumes, bricks or pending ops in db
+	app.db.View(func(tx *bolt.Tx) error {
+		vl, e := VolumeList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(vl) == 0, "expected len(vl) == 0, got", len(vl))
+		bl, e := BrickList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(bl) == 0, "expected len(bl) == 0, got", len(bl))
+		pol, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(pol) == 0, "expected len(pol) == 0, got", len(pol))
+		return nil
+	})
+}

--- a/apps/glusterfs/operations_test.go
+++ b/apps/glusterfs/operations_test.go
@@ -1,0 +1,203 @@
+package glusterfs
+
+import (
+	"os"
+	"testing"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+
+	"github.com/boltdb/bolt"
+	"github.com/heketi/tests"
+)
+
+func TestVolumeCreatePendingCreatedCleared(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	req := &api.VolumeCreateRequest{}
+	req.Size = 1024
+	req.Durability.Type = api.DurabilityReplicate
+	req.Durability.Replicate.Replica = 3
+
+	vol := NewVolumeEntryFromRequest(req)
+	vc := NewVolumeCreateOperation(vol, app.db)
+
+	// verify that there are no volumes, bricks or pending operations
+	app.db.View(func(tx *bolt.Tx) error {
+		vl, e := VolumeList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(vl) == 0, "expected len(vl) == 0, got", len(vl))
+		bl, e := BrickList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(bl) == 0, "expected len(bl) == 0, got", len(bl))
+		pol, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(pol) == 0, "expected len(pol) == 0, got", len(pol))
+		return nil
+	})
+
+	e := vc.Build(app.Allocator())
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	// verify volumes, bricks, & pending ops exist
+	app.db.View(func(tx *bolt.Tx) error {
+		vl, e := VolumeList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(vl) == 1, "expected len(vl) == 1, got", len(vl))
+		bl, e := BrickList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(bl) == 3, "expected len(bl) == 3, got", len(bl))
+		pol, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(pol) == 1, "expected len(pol) == 1, got", len(pol))
+
+		for _, vid := range vl {
+			v, e := NewVolumeEntryFromId(tx, vid)
+			tests.Assert(t, e == nil, "expected e == nil, got", e)
+			tests.Assert(t, v.Pending.Id == pol[0],
+				"expected v.Pending.Id == pol[0], got:", v.Pending.Id, pol[0])
+		}
+		for _, bid := range bl {
+			b, e := NewBrickEntryFromId(tx, bid)
+			tests.Assert(t, e == nil, "expected e == nil, got", e)
+			tests.Assert(t, b.Pending.Id == pol[0],
+				"expected b.Pending.Id == pol[0], got:", b.Pending.Id, pol[0])
+		}
+		return nil
+	})
+
+	e = vc.Exec(app.executor)
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	e = vc.Finalize()
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	// verify volumes & bricks exist but pending is gone
+	app.db.View(func(tx *bolt.Tx) error {
+		vl, e := VolumeList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(vl) == 1, "expected len(vl) == 1, got", len(vl))
+		bl, e := BrickList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(bl) == 3, "expected len(bl) == 3, got", len(bl))
+		pol, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(pol) == 0, "expected len(pol) == 0, got", len(pol))
+
+		for _, vid := range vl {
+			v, e := NewVolumeEntryFromId(tx, vid)
+			tests.Assert(t, e == nil, "expected e == nil, got", e)
+			tests.Assert(t, v.Pending.Id == "",
+				`expected v.Pending.Id == "", got:`, v.Pending.Id)
+		}
+		for _, bid := range bl {
+			b, e := NewBrickEntryFromId(tx, bid)
+			tests.Assert(t, e == nil, "expected e == nil, got", e)
+			tests.Assert(t, b.Pending.Id == "",
+				`expected b.Pending.Id == "", got:`, b.Pending.Id)
+		}
+		return nil
+	})
+}
+
+func TestVolumeCreatePendingRollback(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	req := &api.VolumeCreateRequest{}
+	req.Size = 1024
+	req.Durability.Type = api.DurabilityReplicate
+	req.Durability.Replicate.Replica = 3
+
+	vol := NewVolumeEntryFromRequest(req)
+	vc := NewVolumeCreateOperation(vol, app.db)
+
+	// verify that there are no volumes, bricks or pending operations
+	app.db.View(func(tx *bolt.Tx) error {
+		vl, e := VolumeList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(vl) == 0, "expected len(vl) == 0, got", len(vl))
+		bl, e := BrickList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(bl) == 0, "expected len(bl) == 0, got", len(bl))
+		pol, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(pol) == 0, "expected len(pol) == 0, got", len(pol))
+		return nil
+	})
+
+	e := vc.Build(app.Allocator())
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	// verify volumes, bricks, & pending ops exist
+	app.db.View(func(tx *bolt.Tx) error {
+		vl, e := VolumeList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(vl) == 1, "expected len(vl) == 1, got", len(vl))
+		bl, e := BrickList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(bl) == 3, "expected len(bl) == 3, got", len(bl))
+		pol, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(pol) == 1, "expected len(pol) == 1, got", len(pol))
+
+		for _, vid := range vl {
+			v, e := NewVolumeEntryFromId(tx, vid)
+			tests.Assert(t, e == nil, "expected e == nil, got", e)
+			tests.Assert(t, v.Pending.Id == pol[0],
+				"expected v.Pending.Id == pol[0], got:", v.Pending.Id, pol[0])
+		}
+		for _, bid := range bl {
+			b, e := NewBrickEntryFromId(tx, bid)
+			tests.Assert(t, e == nil, "expected e == nil, got", e)
+			tests.Assert(t, b.Pending.Id == pol[0],
+				"expected b.Pending.Id == pol[0], got:", b.Pending.Id, pol[0])
+		}
+		return nil
+	})
+
+	e = vc.Exec(app.executor)
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	e = vc.Rollback(app.executor)
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	// verify that there are no volumes, bricks or pending operations
+	app.db.View(func(tx *bolt.Tx) error {
+		vl, e := VolumeList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(vl) == 0, "expected len(vl) == 0, got", len(vl))
+		bl, e := BrickList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(bl) == 0, "expected len(bl) == 0, got", len(bl))
+		pol, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(pol) == 0, "expected len(pol) == 0, got", len(pol))
+		return nil
+	})
+}
+

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -517,6 +517,7 @@ func (v *VolumeEntry) Expand(db wdb.DB,
 	defer func() {
 		if e != nil {
 			logger.Debug("Error detected, cleaning up")
+			DestroyBricks(db, executor, brick_entries)
 
 			// Remove from db
 			db.Update(func(tx *bolt.Tx) error {
@@ -536,14 +537,6 @@ func (v *VolumeEntry) Expand(db wdb.DB,
 	if err != nil {
 		return err
 	}
-
-	// Setup cleanup function
-	defer func() {
-		if e != nil {
-			logger.Debug("Error detected, cleaning up")
-			DestroyBricks(db, executor, brick_entries)
-		}
-	}()
 
 	// Create a volume request to send to executor
 	// so that it can add the new bricks

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -648,8 +648,7 @@ func (v *VolumeEntry) BlockVolumeDelete(id string) {
 // Visible returns true if this volume is meant to be visible to
 // API calls.
 func (v *VolumeEntry) Visible() bool {
-	// right now volumes are always visible, this won't always be true
-	return true
+	return v.Pending.Id == ""
 }
 
 func volumeNameExistsInCluster(tx *bolt.Tx, cluster *ClusterEntry,

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -505,7 +505,8 @@ func (v *VolumeEntry) Destroy(db wdb.DB, executor executors.Executor) error {
 
 func (v *VolumeEntry) expandVolumeComponents(db wdb.DB,
 	allocator Allocator,
-	sizeGB int) (brick_entries []*BrickEntry, e error) {
+	sizeGB int,
+	setSize bool) (brick_entries []*BrickEntry, e error) {
 
 	e = db.Update(func(tx *bolt.Tx) error {
 		// Allocate new bricks in the cluster
@@ -517,7 +518,9 @@ func (v *VolumeEntry) expandVolumeComponents(db wdb.DB,
 		}
 
 		// Increase the recorded volume size
-		v.Info.Size += sizeGB
+		if setSize {
+			v.Info.Size += sizeGB
+		}
 
 		// Save brick entries
 		for _, brick := range brick_entries {
@@ -593,7 +596,7 @@ func (v *VolumeEntry) Expand(db wdb.DB,
 		}
 	}()
 
-	brick_entries, e = v.expandVolumeComponents(db, allocator, sizeGB)
+	brick_entries, e = v.expandVolumeComponents(db, allocator, sizeGB, true)
 	if e != nil {
 		return
 	}

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -507,12 +507,7 @@ func (v *VolumeEntry) Expand(db wdb.DB,
 	allocator Allocator,
 	sizeGB int) (e error) {
 
-	// Allocate new bricks in the cluster
-	brick_entries, err := v.allocBricksInCluster(db, allocator, v.Info.Cluster, sizeGB)
-	if err != nil {
-		return err
-	}
-
+	var brick_entries []*BrickEntry
 	// Setup cleanup function
 	defer func() {
 		if e != nil {
@@ -531,6 +526,12 @@ func (v *VolumeEntry) Expand(db wdb.DB,
 			})
 		}
 	}()
+
+	// Allocate new bricks in the cluster
+	brick_entries, err := v.allocBricksInCluster(db, allocator, v.Info.Cluster, sizeGB)
+	if err != nil {
+		return err
+	}
 
 	// Create bricks
 	err = CreateBricks(db, executor, brick_entries)

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -616,7 +616,8 @@ func TestVolumeEntryCreateTwoBricks(t *testing.T) {
 			Path: "/mockpath",
 		}
 
-		tests.Assert(t, brick.Gid == gid)
+		tests.Assert(t, brick.Gid == gid,
+			"expected brick.Gid == gid, got:", brick.Gid, gid)
 		return bInfo, nil
 	}
 

--- a/tests/functional/TestDbExportImport/dbexamples_test.go
+++ b/tests/functional/TestDbExportImport/dbexamples_test.go
@@ -1,0 +1,40 @@
+// +build dbexamples
+
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"os"
+	"testing"
+
+	//"github.com/boltdb/bolt"
+	g "github.com/heketi/heketi/apps/glusterfs"
+	//"github.com/heketi/heketi/pkg/glusterfs/api"
+	//"github.com/heketi/tests"
+)
+
+func TestSimpleCluster(t *testing.T) {
+	filename := "heketi.db.TestSimpleCluster"
+	os.Remove(filename)
+
+	g.BuildSimpleCluster(t, filename)
+}
+
+// TestLeakPendingVolumeCreate will start a volume create operation
+// but never complete it "leaking" the pending operation entry
+// so that we can test it can be dumped by other tooling.
+func TestLeakPendingVolumeCreate(t *testing.T) {
+	filename := "heketi.db.TestLeakPendingVolumeCreate"
+	// remove any existing db files with the same name
+	os.Remove(filename)
+
+	g.LeakPendingVolumeCreate(t, filename)
+}


### PR DESCRIPTION
This PR is the most current form of the work that we've been collaborating on for the past few weeks. It is, unfortunately, rather large but there are a fair number of dependencies to untangle within the changes to break it up and we've been at this long enough, I think.

In short, this series of changes prepares the volume, brick, & block volume entries by breaking up some of the monolithic functions for Create/Expand/Delete. It adds the concept of an Operation which is a type used to manage a large change, such as a Volume Create. Each Operation has functions that implement the operation's phases: Build, Exec, Finalize, and Rollback. Each function attempts to depend only on the minimal set of subsystems as possible. For example, only Build requires the allocator.

A second PR, one that implements an Operation based wrapper for device remove as well as a number of tests and some fixes is next on deck.