### PR TITLE
Untangle Pt. II - Device remove operation

### DIFF
--- a/apps/glusterfs/device_entry.go
+++ b/apps/glusterfs/device_entry.go
@@ -405,8 +405,6 @@ func (d *DeviceEntry) Remove(db wdb.DB,
 	executor executors.Executor,
 	allocator Allocator) (e error) {
 
-	var errBrickWithEmptyPath error = fmt.Errorf("Brick has no path")
-
 	// If the device has no bricks, just change the state and we are done
 	if err := d.markFailed(db); err == nil {
 		// device was empty and is now marked failed
@@ -425,6 +423,15 @@ func (d *DeviceEntry) Remove(db wdb.DB,
 			d.Info.Id)
 		return ErrConflict
 	}
+
+	return d.removeBricksFromDevice(db, executor, allocator)
+}
+
+func (d *DeviceEntry) removeBricksFromDevice(db wdb.DB,
+	executor executors.Executor,
+	allocator Allocator) (e error) {
+
+	var errBrickWithEmptyPath error = fmt.Errorf("Brick has no path")
 
 	for _, brickId := range d.Bricks {
 		var brickEntry *BrickEntry

--- a/apps/glusterfs/device_entry.go
+++ b/apps/glusterfs/device_entry.go
@@ -537,12 +537,22 @@ func (d *DeviceEntry) markFailed(db wdb.DB) error {
 // returns nil. If ErrConflict is returned the device was not
 // empty. Any other error is a database failure.
 func markEmptyDeviceFailed(db wdb.DB, id string) error {
+	return markDeviceFailed(db, id, false)
+}
+
+// markDeviceFailed takes a device id and a force flag,
+// and in one transaction, checks the status of the device
+// and if ready or force is set, sets the failed flag.
+// If the change was applied the function
+// returns nil. If ErrConflict is returned the device was not
+// empty. Any other error is a database failure.
+func markDeviceFailed(db wdb.DB, id string, force bool) error {
 	return db.Update(func(tx *bolt.Tx) error {
 		d, err := NewDeviceEntryFromId(tx, id)
 		if err != nil {
 			return err
 		}
-		if !d.IsDeleteOk() {
+		if !force && !d.IsDeleteOk() {
 			return ErrConflict
 		}
 		d.State = api.EntryStateFailed

--- a/apps/glusterfs/listing.go
+++ b/apps/glusterfs/listing.go
@@ -88,6 +88,14 @@ func MapPendingBlockVolumes(tx *bolt.Tx) (map[string]string, error) {
 	})
 }
 
+// MapPendingBricks returns a map of brick-id to pending-op-id or
+// an error if the db cannot be read.
+func MapPendingBricks(tx *bolt.Tx) (map[string]string, error) {
+	return mapPendingItems(tx, func(op *PendingOperationEntry, a PendingOperationAction) bool {
+		return (a.Change == OpAddBrick)
+	})
+}
+
 func mapPendingItems(tx *bolt.Tx,
 	pred func(op *PendingOperationEntry, a PendingOperationAction) bool) (
 	items map[string]string, e error) {

--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -671,6 +671,137 @@ func (vdel *BlockVolumeDeleteOperation) Finalize() error {
 	})
 }
 
+// DeviceRemoveOperation is a phony-ish operation that exists
+// primarily to a) know that set state was being performed
+// and b) to serve as a starting point for a more proper
+// operation in the future.
+type DeviceRemoveOperation struct {
+	OperationManager
+	DeviceId  string
+	allocator Allocator
+}
+
+// Note: passing this allocator here a big hack, but its a temporary
+// workaround for how brick relocation currently works
+func NewDeviceRemoveOperation(
+	deviceId string, allocator Allocator, db wdb.DB) *DeviceRemoveOperation {
+
+	return &DeviceRemoveOperation{
+		OperationManager: OperationManager{
+			db: db,
+			op: NewPendingOperationEntry(NEW_ID),
+		},
+		DeviceId:  deviceId,
+		allocator: allocator,
+	}
+}
+
+func (dro *DeviceRemoveOperation) Label() string {
+	return "Remove Device"
+}
+
+func (dro *DeviceRemoveOperation) ResourceUrl() string {
+	return ""
+}
+
+func (dro *DeviceRemoveOperation) Build(allocator Allocator) error {
+	return dro.db.Update(func(tx *bolt.Tx) error {
+		d, err := NewDeviceEntryFromId(tx, dro.DeviceId)
+		if err != nil {
+			return err
+		}
+		txdb := wdb.WrapTx(tx)
+
+		// If the device has no bricks, just change the state and we are done
+		if err := d.markFailed(txdb); err == nil {
+			// device was empty and is now marked failed
+			return nil
+		} else if err != ErrConflict {
+			// we hit some sort of unexpected error
+			return err
+		}
+		// if we're here markFailed couldn't apply due to conflicts
+		// we don't need to actually record anything in the db
+		// because this is not a long running operation
+
+		if p, err := PendingOperationsOnDevice(txdb, d.Info.Id); err != nil {
+			return err
+		} else if p {
+			logger.LogError("Found operations still pending on device."+
+				" Can not remove device %v at this time.",
+				d.Info.Id)
+			return ErrConflict
+		}
+
+		dro.op.RecordRemoveDevice(d)
+		if e := dro.op.Save(tx); e != nil {
+			return e
+		}
+		return nil
+	})
+}
+
+func (dro *DeviceRemoveOperation) deviceId() (string, error) {
+	if len(dro.op.Actions) == 0 {
+		// we intentionally avoid recording any actions when all needed bits
+		// were taken care of in Build. There's nothing more to do here.
+		return "", nil
+	}
+	if dro.op.Actions[0].Change != OpRemoveDevice {
+		return "", fmt.Errorf("Unexpected action (%v) on DeviceRemoveOperation pending op",
+			dro.op.Actions[0].Change)
+	}
+	return dro.op.Actions[0].Id, nil
+}
+
+func (dro *DeviceRemoveOperation) Exec(executor executors.Executor) error {
+	id, err := dro.deviceId()
+	if err != nil {
+		return err
+	}
+	if id == "" {
+		return nil
+	}
+
+	var d *DeviceEntry
+	if e := dro.db.Update(func(tx *bolt.Tx) error {
+		d, err = NewDeviceEntryFromId(tx, id)
+		return err
+	}); e != nil {
+		return e
+	}
+
+	// pulling the allocator from the operation is a huge hack.
+	// its basically an intentional violation of the Operation model that
+	// we need to do if for now because the remove bricks code is an
+	// extra big tangle
+	return d.removeBricksFromDevice(dro.db, executor, dro.allocator)
+}
+
+func (dro *DeviceRemoveOperation) Rollback(executor executors.Executor) error {
+	return dro.db.Update(func(tx *bolt.Tx) error {
+		dro.op.Delete(tx)
+		return nil
+	})
+}
+
+func (dro *DeviceRemoveOperation) Finalize() error {
+	id, err := dro.deviceId()
+	if err != nil {
+		return err
+	}
+	if id == "" {
+		return nil
+	}
+	return dro.db.Update(func(tx *bolt.Tx) error {
+		txdb := wdb.WrapTx(tx)
+		if e := markDeviceFailed(txdb, id, true); e != nil {
+			return e
+		}
+		return dro.op.Delete(tx)
+	})
+}
+
 // bricksFromOp returns pending brick entry objects from the db corresponding
 // to the given pending operation entry. The gid of the volume must also be
 // provided as the db does not store this metadata on the brick entries.

--- a/apps/glusterfs/operations_test.go
+++ b/apps/glusterfs/operations_test.go
@@ -2,8 +2,10 @@ package glusterfs
 
 import (
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/heketi/heketi/executors"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 
 	"github.com/boltdb/bolt"
@@ -381,4 +383,350 @@ func TestVolumeCreateOperationBasics(t *testing.T) {
 	tests.Assert(t, vc.ResourceUrl() == "/volumes/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		`expected vc.ResourceUrl() == "/volumes/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", got:`,
 		vc.ResourceUrl())
+}
+
+func TestDeviceRemoveOperationEmpty(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		1,    // clusters
+		3,    // nodes_per_cluster
+		3,    // devices_per_node,
+		8*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// grab a device
+	var d *DeviceEntry
+	err = app.db.View(func(tx *bolt.Tx) error {
+		dl, err := DeviceList(tx)
+		if err != nil {
+			return err
+		}
+		for _, id := range dl {
+			d, err = NewDeviceEntryFromId(tx, id)
+			if err != nil {
+				return err
+			}
+			break
+		}
+		return nil
+	})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	dro := NewDeviceRemoveOperation(d.Info.Id, app.Allocator(), app.db)
+	err = dro.Build(app.Allocator())
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// because there are no bricks on this device it can be disabled
+	// instantly and there are no pending ops for it in the db
+	err = app.db.View(func(tx *bolt.Tx) error {
+		l, err := PendingOperationList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(l) == 0, "expected len(l) == 0, got:", len(l))
+		return nil
+	})
+
+	err = dro.Exec(app.executor)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	err = dro.Finalize()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+}
+
+func TestDeviceRemoveOperationWithBricks(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		1,    // clusters
+		3,    // nodes_per_cluster
+		3,    // devices_per_node,
+		8*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	vreq := &api.VolumeCreateRequest{}
+	vreq.Size = 100
+	vreq.Durability.Type = api.DurabilityReplicate
+	vreq.Durability.Replicate.Replica = 3
+	// create two volumes
+	for i := 0; i < 5; i++ {
+		v := NewVolumeEntryFromRequest(vreq)
+		err = v.Create(app.db, app.executor, app.Allocator())
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	}
+
+	// grab a devices that has bricks
+	var d *DeviceEntry
+	err = app.db.View(func(tx *bolt.Tx) error {
+		dl, err := DeviceList(tx)
+		if err != nil {
+			return err
+		}
+		for _, id := range dl {
+			d, err = NewDeviceEntryFromId(tx, id)
+			if err != nil {
+				return err
+			}
+			if len(d.Bricks) > 0 {
+				return nil
+			}
+		}
+		t.Fatalf("should have at least one device with bricks")
+		return nil
+	})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	dro := NewDeviceRemoveOperation(d.Info.Id, app.Allocator(), app.db)
+	err = dro.Build(app.Allocator())
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// because there were bricks on this device it needs to perform
+	// a full "operation cycle"
+	err = app.db.View(func(tx *bolt.Tx) error {
+		l, err := PendingOperationList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(l) == 1, "expected len(l) == 1, got:", len(l))
+		return nil
+	})
+
+	app.xo.MockVolumeInfo = func(host string, volume string) (*executors.Volume, error) {
+		return mockVolumeInfoFromDb(app.db, volume)
+	}
+	app.xo.MockHealInfo = func(host string, volume string) (*executors.HealInfo, error) {
+		return mockHealStatusFromDb(app.db, volume)
+	}
+
+	err = dro.Exec(app.executor)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// operation is not over. we should still have a pending op
+	err = app.db.View(func(tx *bolt.Tx) error {
+		l, err := PendingOperationList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(l) == 1, "expected len(l) == 1, got:", len(l))
+		return nil
+	})
+
+	err = dro.Finalize()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// operation is over. we should _not_ have a pending op now
+	err = app.db.View(func(tx *bolt.Tx) error {
+		l, err := PendingOperationList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(l) == 0, "expected len(l) == 0, got:", len(l))
+		return nil
+	})
+
+	// update d from db
+	err = app.db.View(func(tx *bolt.Tx) error {
+		d, err = NewDeviceEntryFromId(tx, d.Info.Id)
+		return err
+	})
+	// our d should be w/o bricks and be in failed state
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(d.Bricks) == 0,
+		"expected len(d.Bricks) == 0, got:", len(d.Bricks))
+	tests.Assert(t, d.State == api.EntryStateFailed)
+}
+
+func TestDeviceRemoveOperationTooFewDevices(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		1,    // clusters
+		3,    // nodes_per_cluster
+		1,    // devices_per_node,
+		8*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	vreq := &api.VolumeCreateRequest{}
+	vreq.Size = 100
+	vreq.Durability.Type = api.DurabilityReplicate
+	vreq.Durability.Replicate.Replica = 3
+	// create two volumes
+	for i := 0; i < 5; i++ {
+		v := NewVolumeEntryFromRequest(vreq)
+		err = v.Create(app.db, app.executor, app.Allocator())
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	}
+
+	// grab a devices that has bricks
+	var d *DeviceEntry
+	err = app.db.View(func(tx *bolt.Tx) error {
+		dl, err := DeviceList(tx)
+		if err != nil {
+			return err
+		}
+		for _, id := range dl {
+			d, err = NewDeviceEntryFromId(tx, id)
+			if err != nil {
+				return err
+			}
+			if len(d.Bricks) > 0 {
+				return nil
+			}
+		}
+		t.Fatalf("should have at least one device with bricks")
+		return nil
+	})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	dro := NewDeviceRemoveOperation(d.Info.Id, app.Allocator(), app.db)
+	err = dro.Build(app.Allocator())
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// because there were bricks on this device it needs to perform
+	// a full "operation cycle"
+	err = app.db.View(func(tx *bolt.Tx) error {
+		l, err := PendingOperationList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(l) == 1, "expected len(l) == 1, got:", len(l))
+		return nil
+	})
+
+	app.xo.MockVolumeInfo = func(host string, volume string) (*executors.Volume, error) {
+		return mockVolumeInfoFromDb(app.db, volume)
+	}
+	app.xo.MockHealInfo = func(host string, volume string) (*executors.HealInfo, error) {
+		return mockHealStatusFromDb(app.db, volume)
+	}
+
+	err = dro.Exec(app.executor)
+	tests.Assert(t, strings.Contains(err.Error(), ErrNoReplacement.Error()),
+		"expected strings.Contains(err.Error(), ErrNoReplacement.Error()), got:",
+		err.Error())
+
+	// operation is not over. we should still have a pending op
+	err = app.db.View(func(tx *bolt.Tx) error {
+		l, err := PendingOperationList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(l) == 1, "expected len(l) == 1, got:", len(l))
+		return nil
+	})
+
+	err = dro.Rollback(app.executor)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// operation is over. we should _not_ have a pending op now
+	err = app.db.View(func(tx *bolt.Tx) error {
+		l, err := PendingOperationList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(l) == 0, "expected len(l) == 0, got:", len(l))
+		return nil
+	})
+
+	// update d from db
+	err = app.db.View(func(tx *bolt.Tx) error {
+		d, err = NewDeviceEntryFromId(tx, d.Info.Id)
+		return err
+	})
+	// our d should be in the original state because the exec failed
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(d.Bricks) > 0,
+		"expected len(d.Bricks) > 0, got:", len(d.Bricks))
+	tests.Assert(t, d.State == api.EntryStateOffline)
+}
+
+func TestDeviceRemoveOperationOtherPendingOps(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		1,    // clusters
+		3,    // nodes_per_cluster
+		1,    // devices_per_node,
+		8*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	vreq := &api.VolumeCreateRequest{}
+	vreq.Size = 100
+	vreq.Durability.Type = api.DurabilityReplicate
+	vreq.Durability.Replicate.Replica = 3
+	// create two volumes
+	for i := 0; i < 4; i++ {
+		v := NewVolumeEntryFromRequest(vreq)
+		err = v.Create(app.db, app.executor, app.Allocator())
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	}
+
+	// grab a devices that has bricks
+	var d *DeviceEntry
+	err = app.db.View(func(tx *bolt.Tx) error {
+		dl, err := DeviceList(tx)
+		if err != nil {
+			return err
+		}
+		for _, id := range dl {
+			d, err = NewDeviceEntryFromId(tx, id)
+			if err != nil {
+				return err
+			}
+			if len(d.Bricks) > 0 {
+				return nil
+			}
+		}
+		t.Fatalf("should have at least one device with bricks")
+		return nil
+	})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// now start a volume create operation but don't finish it
+	vol := NewVolumeEntryFromRequest(vreq)
+	vc := NewVolumeCreateOperation(vol, app.db)
+	err = vc.Build(app.Allocator())
+	tests.Assert(t, err == nil, "expected e == nil, got", err)
+	// we should have one pending operation
+	err = app.db.View(func(tx *bolt.Tx) error {
+		l, err := PendingOperationList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(l) == 1, "expected len(l) == 1, got:", len(l))
+		return nil
+	})
+
+	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	dro := NewDeviceRemoveOperation(d.Info.Id, app.Allocator(), app.db)
+	err = dro.Build(app.Allocator())
+	tests.Assert(t, err == ErrConflict, "expected err == ErrConflict, got:", err)
+
+	// we should have one pending operation (the volume create)
+	err = app.db.View(func(tx *bolt.Tx) error {
+		l, err := PendingOperationList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(l) == 1, "expected len(l) == 1, got:", len(l))
+		return nil
+	})
 }

--- a/apps/glusterfs/pendingop.go
+++ b/apps/glusterfs/pendingop.go
@@ -34,6 +34,7 @@ const (
 	OperationExpandVolume
 	OperationCreateBlockVolume
 	OperationDeleteBlockVolume
+	OperationRemoveDevice
 )
 
 // PendingChangeType identifies what kind of lower-level new item or change
@@ -49,6 +50,7 @@ const (
 	OpExpandVolume
 	OpAddBlockVolume
 	OpDeleteBlockVolume
+	OpRemoveDevice
 )
 
 // PendingOperationAction tracks individual changes to entries within the

--- a/apps/glusterfs/pendingop_entry.go
+++ b/apps/glusterfs/pendingop_entry.go
@@ -243,6 +243,13 @@ func (p *PendingOperationEntry) RecordDeleteBlockVolume(bv *BlockVolumeEntry) {
 	bv.Pending.Id = p.Id
 }
 
+// RecordRemoveDevice adds tracking metadata for a long-running device
+// removal operation.
+func (p *PendingOperationEntry) RecordRemoveDevice(d *DeviceEntry) {
+	p.recordChange(OpRemoveDevice, d.Info.Id)
+	p.Type = OperationRemoveDevice
+}
+
 // PendingOperationUpgrade updates the heketi db with metadata needed to
 // support pending operation entries.
 func PendingOperationUpgrade(tx *bolt.Tx) error {


### PR DESCRIPTION
This series wraps the action of removing a device (aka marking it failed) in an Operation. There are a couple of points worth mentioning for when this is being reviewed:

- The Operation abstraction did not fit great around the brick replace part of device remove. Thus, for now, the operation actually needs to use the allocator in more than just the Build function and takes it in the New... function.
- If the device has no bricks and can be updated immediately, it will set everything in the Build transaction, skip creating the pending operation and Exec and Finalize act as no-ops.
- Working on nodes was deferred for now. As each device w/in a node is removed an operation will be created but there is no overall operation for nodes. Similarly, the operation is left as an implementation detail of the Remove function rather than used directly in the rest endpoints.