### PR TITLE
apps:glusterfs: use View instead of Update in DeviceRemoveOperation.Exec

### DIFF
--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -764,7 +764,7 @@ func (dro *DeviceRemoveOperation) Exec(executor executors.Executor) error {
 	}
 
 	var d *DeviceEntry
-	if e := dro.db.Update(func(tx *bolt.Tx) error {
+	if e := dro.db.View(func(tx *bolt.Tx) error {
 		d, err = NewDeviceEntryFromId(tx, id)
 		return err
 	}); e != nil {


### PR DESCRIPTION
No writing done here.

Signed-off-by: Michael Adam <obnox@redhat.com>