### PR TITLE
Add DB generation IDs

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -120,7 +120,7 @@ func NewApp(configIo io.Reader) *App {
 			}
 
 			// Handle Upgrade Changes
-			err = app.Upgrade(tx)
+			err = UpgradeDB(tx)
 			if err != nil {
 				logger.LogError("Unable to Upgrade Changes")
 				return err
@@ -184,48 +184,6 @@ func (a *App) setLogLevel(level string) {
 	case "debug":
 		logger.SetLevel(utils.LEVEL_DEBUG)
 	}
-}
-
-// Upgrade Path to update all the values for new API entries
-func (a *App) Upgrade(tx *bolt.Tx) error {
-
-	err := ClusterEntryUpgrade(tx)
-	if err != nil {
-		logger.LogError("Failed to upgrade db for cluster entries")
-		return err
-	}
-
-	err = NodeEntryUpgrade(tx)
-	if err != nil {
-		logger.LogError("Failed to upgrade db for node entries")
-		return err
-	}
-
-	err = VolumeEntryUpgrade(tx)
-	if err != nil {
-		logger.LogError("Failed to upgrade db for volume entries")
-		return err
-	}
-
-	err = DeviceEntryUpgrade(tx)
-	if err != nil {
-		logger.LogError("Failed to upgrade db for device entries")
-		return err
-	}
-
-	err = BrickEntryUpgrade(tx)
-	if err != nil {
-		logger.LogError("Failed to upgrade db for brick entries: %v", err)
-		return err
-	}
-
-	err = PendingOperationUpgrade(tx)
-	if err != nil {
-		logger.LogError("Failed to upgrade db for pending operations: %v", err)
-		return err
-	}
-
-	return nil
 }
 
 func (a *App) setFromEnvironmentalVariable() {

--- a/apps/glusterfs/app_db.go
+++ b/apps/glusterfs/app_db.go
@@ -382,6 +382,12 @@ func DbCreate(jsonfile string, dbfile string, debug bool) error {
 				return fmt.Errorf("Could not save pending operation bucket: %v", err.Error())
 			}
 		}
+		// always record a new generation id on db import as the db contents
+		// were no longer fully under heketi's control
+		logger.Debug("recording new DB generation ID")
+		if err := recordNewDBGenerationID(tx); err != nil {
+			return fmt.Errorf("Could not record DB generation ID: %v", err.Error())
+		}
 		return nil
 	})
 	if err != nil {

--- a/apps/glusterfs/dbcommon.go
+++ b/apps/glusterfs/dbcommon.go
@@ -69,3 +69,46 @@ func initializeBuckets(tx *bolt.Tx) error {
 
 	return nil
 }
+
+// UpgradeDB runs all upgrade routines in order to to update the DB
+// to the latest "schemas" and data.
+func UpgradeDB(tx *bolt.Tx) error {
+
+	err := ClusterEntryUpgrade(tx)
+	if err != nil {
+		logger.LogError("Failed to upgrade db for cluster entries")
+		return err
+	}
+
+	err = NodeEntryUpgrade(tx)
+	if err != nil {
+		logger.LogError("Failed to upgrade db for node entries")
+		return err
+	}
+
+	err = VolumeEntryUpgrade(tx)
+	if err != nil {
+		logger.LogError("Failed to upgrade db for volume entries")
+		return err
+	}
+
+	err = DeviceEntryUpgrade(tx)
+	if err != nil {
+		logger.LogError("Failed to upgrade db for device entries")
+		return err
+	}
+
+	err = BrickEntryUpgrade(tx)
+	if err != nil {
+		logger.LogError("Failed to upgrade db for brick entries: %v", err)
+		return err
+	}
+
+	err = PendingOperationUpgrade(tx)
+	if err != nil {
+		logger.LogError("Failed to upgrade db for pending operations: %v", err)
+		return err
+	}
+
+	return nil
+}

--- a/tests/300-db-import-export.sh
+++ b/tests/300-db-import-export.sh
@@ -40,7 +40,7 @@ kill_server() {
 show_err() {
         if [[ $? -ne 0 ]]
         then
-                echo "failure/error on line $1"
+                echo -e "\nFAIL: error on line $1"
         fi
 }
 

--- a/tests/300-db-import-export.sh
+++ b/tests/300-db-import-export.sh
@@ -54,6 +54,22 @@ cleanup() {
 	rm -f topologyinfo.* &> /dev/null
 }
 
+reset_gen_id() {
+python <<EOF
+path="$1"
+
+import json
+
+with open(path) as fh:
+    j = json.load(fh)
+
+if j['dbattributeentries'].get('DB_GENERATION_ID'):
+    j['dbattributeentries']['DB_GENERATION_ID']['Value'] = 'x-fake-id'
+
+with open(path, 'w') as fh:
+    json.dump(j, fh)
+EOF
+}
 
 require_heketi_binaries
 start_server
@@ -81,8 +97,30 @@ kill_server
 
 # test one cycle of export and import
 ./heketi-server db export --jsonfile db.json.original --dbfile heketi.db &> /dev/null
+
+# verify that the dump contains a db gen id
+python <<EOF
+path="db.json.original"
+
+import json
+
+with open(path) as fh:
+    j = json.load(fh)
+
+assert 'dbattributeentries' in j
+assert 'DB_GENERATION_ID' in j['dbattributeentries']
+assert 'Key' in j['dbattributeentries']['DB_GENERATION_ID']
+assert j['dbattributeentries']['DB_GENERATION_ID']['Key'] == 'DB_GENERATION_ID'
+assert 'Value' in j['dbattributeentries']['DB_GENERATION_ID']
+assert len(j['dbattributeentries']['DB_GENERATION_ID']['Value']) == 32
+EOF
+
 ./heketi-server db import --jsonfile db.json.original --dbfile heketi.db.new &> /dev/null
 ./heketi-server db export --jsonfile db.json.new --dbfile heketi.db.new
+
+# reset the db generation id to a dummy value, otherwise all dumps are unique
+reset_gen_id db.json.original
+reset_gen_id db.json.new
 diff db.json.original db.json.new &> /dev/null
 
 # existing json file should not be overwritten
@@ -133,4 +171,7 @@ EOF
     --dbfile heketi.db.TestLeakPendingVolumeCreate_2 &> /dev/null
 ./heketi-server db export --jsonfile db.json.TestLeakPendingVolumeCreate_2 \
      --dbfile heketi.db.TestLeakPendingVolumeCreate_2 &> /dev/null
+
+reset_gen_id db.json.TestLeakPendingVolumeCreate
+reset_gen_id db.json.TestLeakPendingVolumeCreate_2
 diff db.json.TestLeakPendingVolumeCreate db.json.TestLeakPendingVolumeCreate_2 &> /dev/null


### PR DESCRIPTION
Add a "UUID" to track the db generation. A db generation starts when the db is first populated or upgraded. It should be reset when the db is manually modified (yet to come).

This series add the DB generation attribute to the db on create or upgrade, as well as generating a new ID on db import.