### PR TITLE
Refactor allocate bricks

### DIFF
--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -117,10 +117,8 @@ func allocateBricks(
 					r.Bricks = append(r.Bricks, brick)
 					r.Devices = append(r.Devices, device)
 
-					// Add to set list
 					setlist = append(setlist, brick)
 
-					// Add brick to device
 					device.BrickAdd(brick.Id())
 
 					return nil

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -108,7 +108,7 @@ func allocateBricks(
 						continue
 					}
 
-					// If the first in the set, the reset the id
+					// If the first in the set, then reset the id
 					if i == 0 {
 						brick.SetId(brickId)
 					}

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -84,8 +84,6 @@ func allocateBricks(
 		for i := 0; i < v.Durability.BricksInSet(); i++ {
 			logger.Debug("%v / %v", i, v.Durability.BricksInSet())
 
-			// Do the work in the database context so that the cluster
-			// data does not change while determining brick location
 			err := db.View(func(tx *bolt.Tx) error {
 
 				// Check the ring for devices to place the brick

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -98,26 +98,26 @@ func allocateBricks(
 						float64(v.Info.Snapshot.Factor),
 						v.Info.Gid, v.Info.Id)
 
-					// Determine if it was successful
-					if brick != nil {
-
-						// If the first in the set, the reset the id
-						if i == 0 {
-							brick.SetId(brickId)
-						}
-
-						// Save the brick entry to create later
-						r.Bricks = append(r.Bricks, brick)
-						r.Devices = append(r.Devices, device)
-
-						// Add to set list
-						setlist = append(setlist, brick)
-
-						// Add brick to device
-						device.BrickAdd(brick.Id())
-
-						return nil
+					if brick == nil {
+						continue
 					}
+
+					// If the first in the set, the reset the id
+					if i == 0 {
+						brick.SetId(brickId)
+					}
+
+					// Save the brick entry to create later
+					r.Bricks = append(r.Bricks, brick)
+					r.Devices = append(r.Devices, device)
+
+					// Add to set list
+					setlist = append(setlist, brick)
+
+					// Add brick to device
+					device.BrickAdd(brick.Id())
+
+					return nil
 				}
 
 				// Check if allocator returned an error


### PR DESCRIPTION
This is a prep work for upcoming change to the allocator.
It makes allocateBricks() a little easier to digest.
And mainly it changes the code to use a single transaction around all loops.
This will later allow us to change GetNodes to dynamically load the ring from the db via the transaction.