### PR TITLE
Support exporting pre-6x heketi db

### DIFF
--- a/apps/glusterfs/app_db.go
+++ b/apps/glusterfs/app_db.go
@@ -143,35 +143,43 @@ func dbDumpInternal(db *bolt.DB) (Db, error) {
 			}
 		}
 
-		// BlockVolume Bucket
-		logger.Debug("blockvolume bucket")
-		blockvolumes, err := BlockVolumeList(tx)
-		if err != nil {
-			return err
-		}
-
-		for _, blockvolume := range blockvolumes {
-			logger.Debug("adding blockvolume entry %v", blockvolume)
-			blockvolEntry, err := NewBlockVolumeEntryFromId(tx, blockvolume)
+		if b := tx.Bucket([]byte(BOLTDB_BUCKET_BLOCKVOLUME)); b == nil {
+			logger.Warning("unable to find block volume bucket... skipping")
+		} else {
+			// BlockVolume Bucket
+			logger.Debug("blockvolume bucket")
+			blockvolumes, err := BlockVolumeList(tx)
 			if err != nil {
 				return err
 			}
-			blockvolEntryList[blockvolEntry.Info.Id] = *blockvolEntry
+
+			for _, blockvolume := range blockvolumes {
+				logger.Debug("adding blockvolume entry %v", blockvolume)
+				blockvolEntry, err := NewBlockVolumeEntryFromId(tx, blockvolume)
+				if err != nil {
+					return err
+				}
+				blockvolEntryList[blockvolEntry.Info.Id] = *blockvolEntry
+			}
 		}
 
-		// DbAttributes Bucket
-		dbattributes, err := DbAttributeList(tx)
-		if err != nil {
-			return err
-		}
-
-		for _, dbattribute := range dbattributes {
-			logger.Debug("adding dbattribute entry %v", dbattribute)
-			dbattributeEntry, err := NewDbAttributeEntryFromKey(tx, dbattribute)
+		if b := tx.Bucket([]byte(BOLTDB_BUCKET_DBATTRIBUTE)); b == nil {
+			logger.Warning("unable to find dbattribute bucket... skipping")
+		} else {
+			// DbAttributes Bucket
+			dbattributes, err := DbAttributeList(tx)
 			if err != nil {
 				return err
 			}
-			dbattributeEntryList[dbattributeEntry.Key] = *dbattributeEntry
+
+			for _, dbattribute := range dbattributes {
+				logger.Debug("adding dbattribute entry %v", dbattribute)
+				dbattributeEntry, err := NewDbAttributeEntryFromKey(tx, dbattribute)
+				if err != nil {
+					return err
+				}
+				dbattributeEntryList[dbattributeEntry.Key] = *dbattributeEntry
+			}
 		}
 
 		pendingops, err := PendingOperationList(tx)

--- a/apps/glusterfs/pendingop_entry.go
+++ b/apps/glusterfs/pendingop_entry.go
@@ -267,6 +267,5 @@ func PendingOperationUpgrade(tx *bolt.Tx) error {
 
 	// there are no data changes related to enabling Pending Ops in the db
 	// so simply save the entry to record that this db now has them
-	//return entry.Save(tx)
-	return nil // disable it for now
+	return entry.Save(tx)
 }

--- a/tests/300-db-import-export.sh
+++ b/tests/300-db-import-export.sh
@@ -120,6 +120,7 @@ assert "nonsense" not in j
 # check expected numbers of items
 assert len(j["pendingoperations"]) == 1
 assert len(j["volumeentries"]) == 1
+assert "DB_HAS_PENDING_OPS_BUCKET" in j["dbattributeentries"]
 
 # check that pending operations match pending ids
 vol = list(j["volumeentries"].values())[0]


### PR DESCRIPTION
This series enables the db feature flag for pending operations and uses that to enable or disable exporting pending operations. Checks for other buckets not present in Heketi 4.x are performed to enable or disable exporting the dbattributes and block volume buckets.