### PR TITLE
Rework allocator initialization

### DIFF
--- a/apps/glusterfs/allocator.go
+++ b/apps/glusterfs/allocator.go
@@ -9,12 +9,16 @@
 
 package glusterfs
 
+import (
+	wdb "github.com/heketi/heketi/pkg/db"
+)
+
 type Allocator interface {
 
 	// Returns a generator, done, and error channel.
 	// The generator returns the location for the brick, then the possible locations
 	// of its replicas. The caller must close() the done channel when it no longer
 	// needs to read from the generator.
-	GetNodes(clusterId, brickId string) (<-chan string,
+	GetNodes(db wdb.RODB, clusterId, brickId string) (<-chan string,
 		chan<- struct{}, <-chan error)
 }

--- a/apps/glusterfs/allocator_simple.go
+++ b/apps/glusterfs/allocator_simple.go
@@ -30,6 +30,8 @@ func NewSimpleAllocator() *SimpleAllocator {
 }
 
 func (s *SimpleAllocator) loadRingFromDB(tx *bolt.Tx) error {
+	s.rings = map[string]*SimpleAllocatorRing{}
+
 	clusters, err := ClusterList(tx)
 	if err != nil {
 		return err

--- a/apps/glusterfs/allocator_simple.go
+++ b/apps/glusterfs/allocator_simple.go
@@ -154,8 +154,8 @@ func (s *SimpleAllocator) getDeviceList(clusterId, brickId string) (SimpleDevice
 
 }
 
-func (s *SimpleAllocator) GetNodes(clusterId, brickId string) (<-chan string,
-	chan<- struct{}, <-chan error) {
+func (s *SimpleAllocator) GetNodes(db wdb.RODB, clusterId,
+	brickId string) (<-chan string, chan<- struct{}, <-chan error) {
 
 	// Initialize channels
 	device, done := make(chan string), make(chan struct{})
@@ -163,6 +163,12 @@ func (s *SimpleAllocator) GetNodes(clusterId, brickId string) (<-chan string,
 	// Make sure to make a buffered channel for the error, so we can
 	// set it and return
 	errc := make(chan error, 1)
+
+	if err := db.View(s.loadRingFromDB); err != nil {
+		errc <- err
+		close(device)
+		return device, done, errc
+	}
 
 	// Get the list of devices for this brick id
 	devicelist, err := s.getDeviceList(clusterId, brickId)

--- a/apps/glusterfs/allocator_simple.go
+++ b/apps/glusterfs/allocator_simple.go
@@ -82,19 +82,6 @@ func (s *SimpleAllocator) loadRingFromDB(tx *bolt.Tx) error {
 	return nil
 }
 
-// Create a new simple allocator and initialize it with data from the db
-func NewSimpleAllocatorFromDb(db wdb.RODB) *SimpleAllocator {
-
-	s := NewSimpleAllocator()
-
-	if err := db.View(s.loadRingFromDB); err != nil {
-		return nil
-	}
-
-	return s
-
-}
-
 func (s *SimpleAllocator) addDevice(cluster *ClusterEntry,
 	node *NodeEntry,
 	device *DeviceEntry) error {

--- a/apps/glusterfs/allocator_simple_test.go
+++ b/apps/glusterfs/allocator_simple_test.go
@@ -28,15 +28,33 @@ func TestNewSimpleAllocator(t *testing.T) {
 }
 
 func TestSimpleAllocatorGetNodesEmpty(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Setup database
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	// Create large cluster
+	err := setupSampleDbWithTopology(app,
+		0, // clusters
+		0, // nodes_per_cluster
+		0, // devices_per_node,
+		0, // disksize)
+	)
+	tests.Assert(t, err == nil)
+
 	a := NewSimpleAllocator()
 	tests.Assert(t, a != nil)
 
-	ch, _, errc := a.GetNodes(utils.GenUUID(), utils.GenUUID())
+	ch, done, errc := a.GetNodes(app.db, utils.GenUUID(), utils.GenUUID())
+	defer func() { close(done) }()
+
 	for d := range ch {
 		tests.Assert(t, false,
 			"Ring should be empty, but we got a device id:", d)
 	}
-	err := <-errc
+	err = <-errc
 	tests.Assert(t, err == ErrNotFound)
 }
 
@@ -100,11 +118,12 @@ func TestSimpleAllocatorInitFromDb(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Create an allocator and initialize it from the DB
-	a := NewSimpleAllocatorFromDb(app.db)
+	a := NewSimpleAllocator()
 	tests.Assert(t, a != nil)
 
 	// Get the nodes from the ring
-	ch, _, errc := a.GetNodes(clusterId, utils.GenUUID())
+	ch, done, errc := a.GetNodes(app.db, clusterId, utils.GenUUID())
+	defer func() { close(done) }()
 
 	var devices int
 	for d := range ch {
@@ -166,11 +185,12 @@ func TestSimpleAllocatorInitFromDbWithOfflineDevices(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Create an allocator and initialize it from the DB
-	a := NewSimpleAllocatorFromDb(app.db)
+	a := NewSimpleAllocator()
 	tests.Assert(t, a != nil)
 
 	// Get the nodes from the ring
-	ch, _, errc := a.GetNodes(clusterId, utils.GenUUID())
+	ch, done, errc := a.GetNodes(app.db, clusterId, utils.GenUUID())
+	defer func() { close(done) }()
 
 	var devices int
 	for d := range ch {

--- a/apps/glusterfs/allocator_simple_test.go
+++ b/apps/glusterfs/allocator_simple_test.go
@@ -56,16 +56,15 @@ func TestSimpleAllocatorAddDevice(t *testing.T) {
 	tests.Assert(t, a.rings[cluster.Info.Id] != nil)
 
 	// Get the nodes from the ring
-	ch, _, errc := a.GetNodes(cluster.Info.Id, utils.GenUUID())
+	devicelist, err := a.getDeviceList(cluster.Info.Id, utils.GenUUID())
+	tests.Assert(t, err == nil)
 
 	var devices int
-	for d := range ch {
+	for _, d := range devicelist {
 		devices++
-		tests.Assert(t, d == device.Info.Id)
+		tests.Assert(t, d.deviceId == device.Info.Id)
 	}
-	err = <-errc
 	tests.Assert(t, devices == 1)
-	tests.Assert(t, err == nil)
 }
 
 func TestSimpleAllocatorInitFromDb(t *testing.T) {

--- a/apps/glusterfs/allocator_simple_test.go
+++ b/apps/glusterfs/allocator_simple_test.go
@@ -33,7 +33,8 @@ func TestSimpleAllocatorGetNodesEmpty(t *testing.T) {
 
 	ch, _, errc := a.GetNodes(utils.GenUUID(), utils.GenUUID())
 	for d := range ch {
-		tests.Assert(t, false, d)
+		tests.Assert(t, false,
+			"Ring should be empty, but we got a device id:", d)
 	}
 	err := <-errc
 	tests.Assert(t, err == ErrNotFound)

--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -476,7 +476,7 @@ func (a *App) newAllocator() Allocator {
 	switch {
 	case a.conf.Allocator == "simple" || a.conf.Allocator == "":
 		a.conf.Allocator = "simple"
-		if r := NewSimpleAllocatorFromDb(a.db); r != nil {
+		if r := NewSimpleAllocator(); r != nil {
 			alloc = r
 		} else {
 			panic(errors.New("failed to set up simple allocator"))

--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -449,7 +449,7 @@ func (a *App) Allocator() Allocator {
 	return a._allocator
 }
 
-// SetAllocator manually sets the allocator for thie app.
+// SetAllocator manually sets the allocator for this app.
 // The specified allocator will be cached on the app and
 // subsequent calls to Allocator will return the same object.
 // Generally this should only be used in test code.

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -102,6 +102,7 @@ func allocateBricks(
 	devcache := map[string](*DeviceEntry){}
 
 	err := db.View(func(tx *bolt.Tx) error {
+		txdb := wdb.WrapTx(tx)
 
 		// Determine allocation for each brick required for this volume
 		for brick_num := 0; brick_num < bricksets; brick_num++ {
@@ -116,7 +117,7 @@ func allocateBricks(
 
 			// Get allocator generator
 			// The same generator should be used for the brick and its replicas
-			deviceCh, done, errc := allocator.GetNodes(cluster, brickId)
+			deviceCh, done, errc := allocator.GetNodes(txdb, cluster, brickId)
 			defer func() {
 				close(done)
 			}()
@@ -398,7 +399,7 @@ func (v *VolumeEntry) replaceBrickInVolume(db wdb.DB, executor executors.Executo
 	newBrickId := utils.GenUUID()
 
 	// Check the ring for devices to place the brick
-	deviceCh, done, errc := allocator.GetNodes(v.Info.Cluster, newBrickId)
+	deviceCh, done, errc := allocator.GetNodes(db, v.Info.Cluster, newBrickId)
 	defer func() {
 		close(done)
 	}()


### PR DESCRIPTION
Let the allocator only load the ring from the DB in GetNodes().
This makes sure the allocator is always up to date when using it.