### PR TITLE
tests: add a check that functional test go code compiles

### DIFF
--- a/tests/100-compile-functest-go.sh
+++ b/tests/100-compile-functest-go.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+TAGS="functional dbexamples"
+find tests/functional -name '*.go' -print0 | \
+	xargs -0 dirname | sort -u | \
+	sed -e 's,^/*,github.com/heketi/heketi/,' | \
+	xargs -L1 go test -c -tags "$TAGS"


### PR DESCRIPTION
Add a test to verify that the Go code used for the functional
tests can be compiled. This should help find some issues with the
functional test code before the functional tests are run.

Signed-off-by: John Mulligan <jmulligan@redhat.com>