### PR TITLE
control behavior of refusing to start with stale pending operation db entries

### DIFF
--- a/apps/glusterfs/app_config.go
+++ b/apps/glusterfs/app_config.go
@@ -34,6 +34,9 @@ type GlusterFSConfig struct {
 	//block settings
 	CreateBlockHostingVolumes bool `json:"auto_create_block_hosting_volume"`
 	BlockHostingVolumeSize    int  `json:"block_hosting_volume_size"`
+
+	// server behaviors
+	IgnoreStaleOperations bool `json:"ignore_stale_operations"`
 }
 
 type ConfigFile struct {
@@ -58,6 +61,10 @@ func loadConfiguration(configIo io.Reader) *GlusterFSConfig {
 	env = os.Getenv("HEKETI_GLUSTERAPP_LOGLEVEL")
 	if env != "" {
 		config.GlusterFS.Loglevel = env
+	}
+	env = os.Getenv("HEKETI_IGNORE_STALE_OPERATIONS")
+	if env != "" {
+		config.GlusterFS.IgnoreStaleOperations = true
 	}
 	return &config.GlusterFS
 }


### PR DESCRIPTION
This series aims to improve the behavior of the server w.r.t. starting up and having existing pending operations entries in the db from a previous instance of the server. This means the operation was previously in progress and the db may not be consistent with what's on gluster.

First change makes it so there's no panic externally visible. The server just exits non-zero.

Then we add a way for users to force Heketi to start even when these items are in the db. This isn't clean but exists for the "I don't care, just start it, I'll deal with the problems later". Hopefully, they will try to deal with the problems later.