### PR TITLE
makefile: consistently use defined GO variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,11 @@ SHA := $(shell git rev-parse --short HEAD)
 BRANCH := $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
 VER := $(shell git describe --match='v[0-9].[0-9].[0-9]')
 TAG := $(shell git tag --points-at HEAD 'v[0-9].[0-9].[0-9]' | tail -n1)
-GOARCH := $(shell go env GOARCH)
-GOOS := $(shell go env GOOS)
-GOHOSTARCH := $(shell go env GOHOSTARCH)
-GOHOSTOS := $(shell go env GOHOSTOS)
+GO:=go
+GOARCH := $(shell $(GO) env GOARCH)
+GOOS := $(shell $(GO) env GOOS)
+GOHOSTARCH := $(shell $(GO) env GOHOSTARCH)
+GOHOSTOS := $(shell $(GO) env GOHOSTOS)
 GOBUILDFLAGS :=
 ifeq ($(GOOS),$(GOHOSTOS))
 ifeq ($(GOARCH),$(GOHOSTARCH))
@@ -30,9 +31,6 @@ else
 	VERSION = $(VER)-$(BRANCH)
 endif
 endif
-
-# Go setup
-GO=go
 
 # Sources and Targets
 EXECUTABLES :=$(APP_NAME)
@@ -60,7 +58,7 @@ package:
 	@echo $(PACKAGE)
 
 heketi: vendor glide.lock
-	go build $(GOBUILDFLAGS) $(LDFLAGS) -o $(APP_NAME)
+	$(GO) build $(GOBUILDFLAGS) $(LDFLAGS) -o $(APP_NAME)
 
 server: heketi
 

--- a/client/cli/go/Makefile
+++ b/client/cli/go/Makefile
@@ -9,10 +9,11 @@ SHA := $(shell git rev-parse --short HEAD)
 BRANCH := $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
 VER := $(shell git describe)
 TAG := $(shell git tag --points-at HEAD 'v[0-9].[0-9].[0-9]' | tail -n1)
-GOARCH := $(shell go env GOARCH)
-GOOS := $(shell go env GOOS)
-GOHOSTARCH := $(shell go env GOHOSTARCH)
-GOHOSTOS := $(shell go env GOHOSTOS)
+GO:=go
+GOARCH := $(shell $(GO) env GOARCH)
+GOOS := $(shell $(GO) env GOOS)
+GOHOSTARCH := $(shell $(GO) env GOHOSTARCH)
+GOHOSTOS := $(shell $(GO) env GOHOSTOS)
 GOBUILDFLAGS :=
 ifeq ($(GOOS), $(GOHOSTOS))
 ifeq ($(GOARCH), $(GOHOSTARCH))
@@ -30,10 +31,6 @@ else
 	VERSION = $(VER)-$(BRANCH)
 endif
 endif
-
-# Go setup
-GO=go
-TEST="go test"
 
 # Sources and Targets
 EXECUTABLES :=$(APP_NAME)
@@ -59,13 +56,13 @@ package:
 	@echo $(PACKAGE)
 
 build:
-	go build $(GOBUILDFLAGS) $(LDFLAGS) -o $(APP_NAME)
+	$(GO) build $(GOBUILDFLAGS) $(LDFLAGS) -o $(APP_NAME)
 
 run: build
 	./$(APP_NAME)
 
 test:
-	go test ./...
+	$(GO) test ./...
 
 clean:
 	@echo Cleaning Workspace...


### PR DESCRIPTION
A variable for the go binary was already defined in the Makefile.
Make it available to all lines that use the go binary, and use it
consistently throughout the makefile.

Signed-off-by: John Mulligan <jmulligan@redhat.com>