### PR TITLE
apps: add brick and device sets to brick allocation functions

### DIFF
--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -153,7 +153,7 @@ func allocateBricks(
 	allocator Allocator,
 	cluster string,
 	v *VolumeEntry,
-	bricksets int,
+	numBrickSets int,
 	brick_size uint64) (*BrickAllocation, error) {
 
 	r := &BrickAllocation{
@@ -167,7 +167,7 @@ func allocateBricks(
 		txdb := wdb.WrapTx(tx)
 
 		// Determine allocation for each brick required for this volume
-		for brick_num := 0; brick_num < bricksets; brick_num++ {
+		for brick_num := 0; brick_num < numBrickSets; brick_num++ {
 			logger.Info("brick_num: %v", brick_num)
 
 			// Generate an id for the brick

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -195,17 +195,5 @@ func allocateBricks(
 
 		return nil
 	})
-	if err != nil {
-		return r, err
-	}
-
-	// Only assign bricks to the volume object on success
-	for _, bs := range r.BrickSets {
-		for _, brick := range bs.Bricks {
-			logger.Debug("Adding brick %v to volume %v", brick.Id(), v.Info.Id)
-			v.BrickAdd(brick.Id())
-		}
-	}
-
-	return r, nil
+	return r, err
 }

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -167,8 +167,8 @@ func allocateBricks(
 		txdb := wdb.WrapTx(tx)
 
 		// Determine allocation for each brick required for this volume
-		for brick_num := 0; brick_num < numBrickSets; brick_num++ {
-			logger.Info("brick_num: %v", brick_num)
+		for sn := 0; sn < numBrickSets; sn++ {
+			logger.Info("Allocating brick set #%v", sn)
 
 			// Generate an id for the brick
 			brickId := utils.GenUUID()

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -16,6 +16,40 @@ import (
 	"github.com/heketi/heketi/pkg/utils"
 )
 
+type BrickSet struct {
+	SetSize int
+	Bricks  []*BrickEntry
+}
+
+func NewBrickSet(s int) *BrickSet {
+	return &BrickSet{SetSize: s, Bricks: []*BrickEntry{}}
+}
+
+func (bs *BrickSet) Add(b *BrickEntry) {
+	bs.Bricks = append(bs.Bricks, b)
+}
+
+func (bs *BrickSet) Full() bool {
+	return len(bs.Bricks) == bs.SetSize
+}
+
+type DeviceSet struct {
+	SetSize int
+	Devices []*DeviceEntry
+}
+
+func NewDeviceSet(s int) *DeviceSet {
+	return &DeviceSet{SetSize: s, Devices: []*DeviceEntry{}}
+}
+
+func (ds *DeviceSet) Add(d *DeviceEntry) {
+	ds.Devices = append(ds.Devices, d)
+}
+
+func (ds *DeviceSet) Full() bool {
+	return len(ds.Devices) == ds.SetSize
+}
+
 type BrickAllocation struct {
 	Bricks  []*BrickEntry
 	Devices []*DeviceEntry

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -11,6 +11,7 @@ package glusterfs
 
 import (
 	"github.com/boltdb/bolt"
+	"github.com/lpabon/godbc"
 
 	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/utils"
@@ -26,6 +27,7 @@ func NewBrickSet(s int) *BrickSet {
 }
 
 func (bs *BrickSet) Add(b *BrickEntry) {
+	godbc.Require(!bs.Full())
 	bs.Bricks = append(bs.Bricks, b)
 }
 
@@ -43,6 +45,7 @@ func NewDeviceSet(s int) *DeviceSet {
 }
 
 func (ds *DeviceSet) Add(d *DeviceEntry) {
+	godbc.Require(!ds.Full())
 	ds.Devices = append(ds.Devices, d)
 }
 

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -462,6 +462,8 @@ func (v *VolumeEntry) allocBricks(
 				if err != nil {
 					return err
 				}
+				logger.Debug("Adding brick %v to volume %v", x.Id(), v.Info.Id)
+				v.BrickAdd(x.Id())
 			}
 		}
 		for _, ds := range r.DeviceSets {

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -454,19 +454,24 @@ func (v *VolumeEntry) allocBricks(
 		if e != nil {
 			return e
 		}
-		for _, x := range r.Bricks {
-			err := x.Save(tx)
-			if err != nil {
-				return err
+		brick_entries = []*BrickEntry{}
+		for _, bs := range r.BrickSets {
+			for _, x := range bs.Bricks {
+				brick_entries = append(brick_entries, x)
+				err := x.Save(tx)
+				if err != nil {
+					return err
+				}
 			}
 		}
-		for _, x := range r.Devices {
-			err := x.Save(tx)
-			if err != nil {
-				return err
+		for _, ds := range r.DeviceSets {
+			for _, x := range ds.Devices {
+				err := x.Save(tx)
+				if err != nil {
+					return err
+				}
 			}
 		}
-		brick_entries = r.Bricks
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
These changes add new brick and device types to brick_allocate.go, and tries to use them to better organize some of the code within. If it seems like a lot of change for little benefit, the expectation is this approach will become more fundamental and useful in future series.