### PR TITLE
apps: clean up the Allocator interface a little

### DIFF
--- a/apps/glusterfs/allocator.go
+++ b/apps/glusterfs/allocator.go
@@ -20,5 +20,5 @@ type Allocator interface {
 	// of its replicas. The caller must close() the done channel when it no longer
 	// needs to read from the generator.
 	GetNodes(db wdb.RODB, clusterId, brickId string) (<-chan string,
-		chan<- struct{}, <-chan error)
+		chan<- struct{}, error)
 }

--- a/apps/glusterfs/allocator_simple_test.go
+++ b/apps/glusterfs/allocator_simple_test.go
@@ -47,15 +47,14 @@ func TestSimpleAllocatorGetNodesEmpty(t *testing.T) {
 	a := NewSimpleAllocator()
 	tests.Assert(t, a != nil)
 
-	ch, done, errc := a.GetNodes(app.db, utils.GenUUID(), utils.GenUUID())
+	ch, done, err := a.GetNodes(app.db, utils.GenUUID(), utils.GenUUID())
 	defer func() { close(done) }()
+	tests.Assert(t, err == ErrNotFound)
 
 	for d := range ch {
 		tests.Assert(t, false,
 			"Ring should be empty, but we got a device id:", d)
 	}
-	err = <-errc
-	tests.Assert(t, err == ErrNotFound)
 }
 
 func TestSimpleAllocatorAddDevice(t *testing.T) {
@@ -122,17 +121,16 @@ func TestSimpleAllocatorInitFromDb(t *testing.T) {
 	tests.Assert(t, a != nil)
 
 	// Get the nodes from the ring
-	ch, done, errc := a.GetNodes(app.db, clusterId, utils.GenUUID())
+	ch, done, err := a.GetNodes(app.db, clusterId, utils.GenUUID())
 	defer func() { close(done) }()
+	tests.Assert(t, err == nil)
 
 	var devices int
 	for d := range ch {
 		devices++
 		tests.Assert(t, d != "")
 	}
-	err = <-errc
 	tests.Assert(t, devices == 10*20)
-	tests.Assert(t, err == nil)
 
 }
 
@@ -189,16 +187,15 @@ func TestSimpleAllocatorInitFromDbWithOfflineDevices(t *testing.T) {
 	tests.Assert(t, a != nil)
 
 	// Get the nodes from the ring
-	ch, done, errc := a.GetNodes(app.db, clusterId, utils.GenUUID())
+	ch, done, err := a.GetNodes(app.db, clusterId, utils.GenUUID())
 	defer func() { close(done) }()
+	tests.Assert(t, err == nil)
 
 	var devices int
 	for d := range ch {
 		devices++
 		tests.Assert(t, d != "")
 	}
-	err = <-errc
-	tests.Assert(t, err == nil)
 
 	// Only three online devices should be in the list
 	tests.Assert(t, devices == 3, devices)

--- a/apps/glusterfs/allocator_simple_test.go
+++ b/apps/glusterfs/allocator_simple_test.go
@@ -48,7 +48,7 @@ func TestSimpleAllocatorGetNodesEmpty(t *testing.T) {
 	tests.Assert(t, a != nil)
 
 	ch, done, err := a.GetNodes(app.db, utils.GenUUID(), utils.GenUUID())
-	defer func() { close(done) }()
+	defer close(done)
 	tests.Assert(t, err == ErrNotFound)
 
 	for d := range ch {
@@ -122,7 +122,7 @@ func TestSimpleAllocatorInitFromDb(t *testing.T) {
 
 	// Get the nodes from the ring
 	ch, done, err := a.GetNodes(app.db, clusterId, utils.GenUUID())
-	defer func() { close(done) }()
+	defer close(done)
 	tests.Assert(t, err == nil)
 
 	var devices int
@@ -188,7 +188,7 @@ func TestSimpleAllocatorInitFromDbWithOfflineDevices(t *testing.T) {
 
 	// Get the nodes from the ring
 	ch, done, err := a.GetNodes(app.db, clusterId, utils.GenUUID())
-	defer func() { close(done) }()
+	defer close(done)
 	tests.Assert(t, err == nil)
 
 	var devices int

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -109,9 +109,7 @@ func allocateBricks(
 			// Get allocator generator
 			// The same generator should be used for the brick and its replicas
 			deviceCh, done, err := allocator.GetNodes(txdb, cluster, brickId)
-			defer func() {
-				close(done)
-			}()
+			defer close(done)
 			if err != nil {
 				return err
 			}

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -255,10 +255,13 @@ func (v *VolumeEntry) replaceBrickInVolume(db wdb.DB, executor executors.Executo
 	newBrickId := utils.GenUUID()
 
 	// Check the ring for devices to place the brick
-	deviceCh, done, errc := allocator.GetNodes(db, v.Info.Cluster, newBrickId)
+	deviceCh, done, err := allocator.GetNodes(db, v.Info.Cluster, newBrickId)
 	defer func() {
 		close(done)
 	}()
+	if err != nil {
+		return err
+	}
 
 	for deviceId := range deviceCh {
 
@@ -418,10 +421,6 @@ func (v *VolumeEntry) replaceBrickInVolume(db wdb.DB, executor executors.Executo
 			newBrickEntry.Id(), newBrickEntry.Info.NodeId, newBrickEntry.Info.Path)
 
 		return nil
-	}
-	// Check if allocator returned an error
-	if err := <-errc; err != nil {
-		return err
 	}
 
 	// No device found

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -256,9 +256,7 @@ func (v *VolumeEntry) replaceBrickInVolume(db wdb.DB, executor executors.Executo
 
 	// Check the ring for devices to place the brick
 	deviceCh, done, err := allocator.GetNodes(db, v.Info.Cluster, newBrickId)
-	defer func() {
-		close(done)
-	}()
+	defer close(done)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change drops the use of an error channel for a regular error, as well as simplifying the defers for the device channel. See commits for details.