### PR TITLE
apps/glusterfs: read all env var in the same place

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -69,6 +69,9 @@ func NewApp(configIo io.Reader) *App {
 		return nil
 	}
 
+	// Set values mentioned in environmental variable
+	app.setFromEnvironmentalVariable()
+
 	// Setup loglevel
 	err = app.setLogLevel(app.conf.Loglevel)
 	if err != nil {
@@ -165,9 +168,6 @@ func NewApp(configIo io.Reader) *App {
 			"Server will be running with incomplete/inconsistent state in DB.")
 	}
 
-	// Set values mentioned in environmental variable
-	app.setFromEnvironmentalVariable()
-
 	// Set advanced settings
 	app.setAdvSettings()
 
@@ -202,7 +202,24 @@ func (a *App) setLogLevel(level string) error {
 
 func (a *App) setFromEnvironmentalVariable() {
 	var err error
-	env := os.Getenv("HEKETI_AUTO_CREATE_BLOCK_HOSTING_VOLUME")
+
+	// environment variable overrides file config
+	env := os.Getenv("HEKETI_EXECUTOR")
+	if env != "" {
+		a.conf.Executor = env
+	}
+
+	env = os.Getenv("HEKETI_GLUSTERAPP_LOGLEVEL")
+	if env != "" {
+		a.conf.Loglevel = env
+	}
+
+	env = os.Getenv("HEKETI_IGNORE_STALE_OPERATIONS")
+	if env != "" {
+		a.conf.IgnoreStaleOperations = true
+	}
+
+	env = os.Getenv("HEKETI_AUTO_CREATE_BLOCK_HOSTING_VOLUME")
 	if "" != env {
 		a.conf.CreateBlockHostingVolumes, err = strconv.ParseBool(env)
 		if err != nil {

--- a/apps/glusterfs/app_config.go
+++ b/apps/glusterfs/app_config.go
@@ -12,7 +12,6 @@ package glusterfs
 import (
 	"encoding/json"
 	"io"
-	"os"
 
 	"github.com/heketi/heketi/executors/kubeexec"
 	"github.com/heketi/heketi/executors/sshexec"
@@ -51,20 +50,6 @@ func loadConfiguration(configIo io.Reader) *GlusterFSConfig {
 		logger.LogError("Unable to parse config file: %v\n",
 			err.Error())
 		return nil
-	}
-
-	// Set environment variable to override configuration file
-	env := os.Getenv("HEKETI_EXECUTOR")
-	if env != "" {
-		config.GlusterFS.Executor = env
-	}
-	env = os.Getenv("HEKETI_GLUSTERAPP_LOGLEVEL")
-	if env != "" {
-		config.GlusterFS.Loglevel = env
-	}
-	env = os.Getenv("HEKETI_IGNORE_STALE_OPERATIONS")
-	if env != "" {
-		config.GlusterFS.IgnoreStaleOperations = true
 	}
 	return &config.GlusterFS
 }


### PR DESCRIPTION
Some of the env vars were being read inside function that loads config
from file. Moved everything to one function. Also moved the function
call earlier in the stack to ensure all operations refer to updated
config from environment vars.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>