### PR TITLE
allow setting HEKETI_IGNORE_STALE_OPERATIONS to false

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -216,7 +216,10 @@ func (a *App) setFromEnvironmentalVariable() {
 
 	env = os.Getenv("HEKETI_IGNORE_STALE_OPERATIONS")
 	if env != "" {
-		a.conf.IgnoreStaleOperations = true
+		a.conf.IgnoreStaleOperations, err = strconv.ParseBool(env)
+		if err != nil {
+			logger.LogError("Error: While parsing HEKETI_IGNORE_STALE_OPERATIONS as bool: %v", err)
+		}
 	}
 
 	env = os.Getenv("HEKETI_AUTO_CREATE_BLOCK_HOSTING_VOLUME")


### PR DESCRIPTION
Earlier, setting the env var to anything would result in true. We
should rather parse it as bool allowing one to set it to "false".

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>