### PR TITLE
Cleanup allocator more

### DIFF
--- a/apps/glusterfs/allocator_simple.go
+++ b/apps/glusterfs/allocator_simple.go
@@ -78,7 +78,6 @@ func getDeviceListFromDB(db wdb.RODB, clusterId,
 		return nil, err
 	}
 
-	ring.Rebalance()
 	devicelist := ring.GetDeviceList(brickId)
 
 	return devicelist, nil

--- a/apps/glusterfs/allocator_simple.go
+++ b/apps/glusterfs/allocator_simple.go
@@ -81,18 +81,14 @@ func getDeviceListFromDB(db wdb.RODB, clusterId,
 	devicelist := ring.GetDeviceList(brickId)
 
 	return devicelist, nil
-
 }
 
 func (s *SimpleAllocator) GetNodes(db wdb.RODB, clusterId,
 	brickId string) (<-chan string, chan<- struct{}, error) {
 
-	// Initialize channels
 	device, done := make(chan string), make(chan struct{})
 
-	// Get the list of devices for this brick id
 	devicelist, err := getDeviceListFromDB(db, clusterId, brickId)
-
 	if err != nil {
 		close(device)
 		return device, done, err

--- a/apps/glusterfs/allocator_simple_test.go
+++ b/apps/glusterfs/allocator_simple_test.go
@@ -23,7 +23,6 @@ func TestNewSimpleAllocator(t *testing.T) {
 
 	a := NewSimpleAllocator()
 	tests.Assert(t, a != nil)
-	tests.Assert(t, a.rings != nil)
 
 }
 
@@ -57,24 +56,21 @@ func TestSimpleAllocatorGetNodesEmpty(t *testing.T) {
 	}
 }
 
-func TestSimpleAllocatorAddDevice(t *testing.T) {
-	a := NewSimpleAllocator()
-	tests.Assert(t, a != nil)
+func TestSingleClusterRingAddDevice(t *testing.T) {
 
 	cluster := createSampleClusterEntry()
 	node := createSampleNodeEntry()
 	node.Info.ClusterId = cluster.Info.Id
 	device := createSampleDeviceEntry(node.Info.Id, 10000)
 
-	tests.Assert(t, len(a.rings) == 0)
-	tests.Assert(t, a.addCluster(cluster.Info.Id) == nil)
-	err := a.addDevice(cluster, node, device)
+	s := &singleClusterRing{clusterId: cluster.Info.Id}
+	tests.Assert(t, s.addCluster(cluster.Info.Id) == nil)
+	err := s.addDevice(cluster, node, device)
 	tests.Assert(t, err == nil)
-	tests.Assert(t, len(a.rings) == 1)
-	tests.Assert(t, a.rings[cluster.Info.Id] != nil)
+	tests.Assert(t, len(s.ring.ring) == 1)
 
 	// Get the nodes from the ring
-	devicelist, err := a.getDeviceList(cluster.Info.Id, utils.GenUUID())
+	devicelist, err := s.getDeviceList(utils.GenUUID())
 	tests.Assert(t, err == nil)
 
 	var devices int

--- a/apps/glusterfs/allocator_simple_test.go
+++ b/apps/glusterfs/allocator_simple_test.go
@@ -56,31 +56,6 @@ func TestSimpleAllocatorGetNodesEmpty(t *testing.T) {
 	}
 }
 
-func TestSingleClusterRingAddDevice(t *testing.T) {
-
-	cluster := createSampleClusterEntry()
-	node := createSampleNodeEntry()
-	node.Info.ClusterId = cluster.Info.Id
-	device := createSampleDeviceEntry(node.Info.Id, 10000)
-
-	s := &singleClusterRing{clusterId: cluster.Info.Id}
-	tests.Assert(t, s.addCluster(cluster.Info.Id) == nil)
-	err := s.addDevice(cluster, node, device)
-	tests.Assert(t, err == nil)
-	tests.Assert(t, len(s.ring.ring) == 1)
-
-	// Get the nodes from the ring
-	devicelist, err := s.getDeviceList(utils.GenUUID())
-	tests.Assert(t, err == nil)
-
-	var devices int
-	for _, d := range devicelist {
-		devices++
-		tests.Assert(t, d.deviceId == device.Info.Id)
-	}
-	tests.Assert(t, devices == 1)
-}
-
 func TestSimpleAllocatorInitFromDb(t *testing.T) {
 	tmpfile := tests.Tempfile()
 	defer os.Remove(tmpfile)


### PR DESCRIPTION
This is a continuation of the work begun in PR #1078.
It takes the patch from that PR and further simplifies and cleans up the code in simple_allocator.go.
Now the ring really only exists as stack variables below GetNodes.