### PR TITLE
apps: heavily refactor code where the allocator and replace bricks in volume func interact

### DIFF
--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -313,8 +313,7 @@ func (v *VolumeEntry) replaceBrickInVolume(db wdb.DB, executor executors.Executo
 	}
 
 	newBrickEntry.SetId(newBrickId)
-	var brickEntries []*BrickEntry
-	brickEntries = append(brickEntries, newBrickEntry)
+	brickEntries := []*BrickEntry{newBrickEntry}
 	err = CreateBricks(db, executor, brickEntries)
 	if err != nil {
 		return err

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -276,25 +276,11 @@ func (v *VolumeEntry) replaceBrickInVolume(db wdb.DB, executor executors.Executo
 				continue
 			}
 
-			// Do not allow a device from the same node to be
-			// in the set
-			deviceOk := true
-			for _, brickInSet := range bs.Bricks {
-				if brickInSet.Info.NodeId == newDeviceEntry.NodeId {
-					deviceOk = false
-				}
-			}
-
-			if !deviceOk {
-				continue
-			}
-
 			// Try to allocate a brick on this device
 			// NewBrickEntry will deduct storage from device entry
 			// if successful
-			newBrickEntry = newDeviceEntry.NewBrickEntry(oldBrickEntry.Info.Size,
-				float64(v.Info.Snapshot.Factor),
-				v.Info.Gid, v.Info.Id)
+			newBrickEntry = tryAllocateBrickOnDevice(v,
+				newDeviceEntry, bs, oldBrickEntry.Info.Size)
 			err = newDeviceEntry.Save(tx)
 			if err != nil {
 				return err

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -279,7 +279,7 @@ func (v *VolumeEntry) replaceBrickInVolume(db wdb.DB, executor executors.Executo
 			// Try to allocate a brick on this device
 			// NewBrickEntry will deduct storage from device entry
 			// if successful
-			newBrickEntry = tryAllocateBrickOnDevice(v,
+			newBrickEntry = tryAllocateBrickOnDevice(v, nil,
 				newDeviceEntry, bs, oldBrickEntry.Info.Size)
 			err = newDeviceEntry.Save(tx)
 			if err != nil {

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -290,13 +290,8 @@ func (v *VolumeEntry) replaceBrickInVolume(db wdb.DB, executor executors.Executo
 			}
 
 			// Try to allocate a brick on this device
-			// NewBrickEntry would deduct storage from device entry
-			// which we will save to disk, hence reload the latest device
-			// entry to get latest storage state of device
-			newDeviceEntry, err := NewDeviceEntryFromId(tx, deviceId)
-			if err != nil {
-				return err
-			}
+			// NewBrickEntry will deduct storage from device entry
+			// if successful
 			newBrickEntry = newDeviceEntry.NewBrickEntry(oldBrickEntry.Info.Size,
 				float64(v.Info.Snapshot.Factor),
 				v.Info.Gid, v.Info.Id)

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -117,9 +117,10 @@ func (v *VolumeEntry) getBrickSetForBrickId(db wdb.DB,
 	if err != nil {
 		return setlist, err
 	}
-	for slicestartindex = 0; slicestartindex <= len(vinfo.Bricks.BrickList)-v.Durability.BricksInSet(); slicestartindex = slicestartindex + v.Durability.BricksInSet() {
+	ssize := v.Durability.BricksInSet()
+	for slicestartindex = 0; slicestartindex <= len(vinfo.Bricks.BrickList)-ssize; slicestartindex = slicestartindex + ssize {
 		setlist = make([]*BrickEntry, 0)
-		for _, brick = range vinfo.Bricks.BrickList[slicestartindex : slicestartindex+v.Durability.BricksInSet()] {
+		for _, brick = range vinfo.Bricks.BrickList[slicestartindex : slicestartindex+ssize] {
 			brickentry, found := bmap[brick.Name]
 			if !found {
 				logger.LogError("Unable to create brick entry using brick name:%v",

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -118,7 +118,7 @@ func (v *VolumeEntry) getBrickSetForBrickId(db wdb.DB,
 		return setlist, err
 	}
 	ssize := v.Durability.BricksInSet()
-	for slicestartindex = 0; slicestartindex <= len(vinfo.Bricks.BrickList)-ssize; slicestartindex = slicestartindex + ssize {
+	for slicestartindex = 0; slicestartindex <= len(vinfo.Bricks.BrickList)-ssize; slicestartindex += ssize {
 		setlist = make([]*BrickEntry, 0)
 		for _, brick = range vinfo.Bricks.BrickList[slicestartindex : slicestartindex+ssize] {
 			brickentry, found := bmap[brick.Name]


### PR DESCRIPTION
This (long) series breaks up some of the code within the replaceBrickInVolume function in order to better prepare it for upcoming alternate allocation approaches. It also serves somewhat as a light disentangling of some of the db and allocation logic from the system probes and exec activity.