### PR TITLE
instantiate simple allocator directly where needed

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -483,22 +483,3 @@ func (a *App) NotFoundHandler(w http.ResponseWriter, r *http.Request) {
 	logger.Warning("Invalid path or request %v", r.URL.Path)
 	http.Error(w, "Invalid path or request", http.StatusNotFound)
 }
-
-// Allocator returns an allocator appropriate for the configuration
-// of this app.
-func (a *App) Allocator() Allocator {
-	var alloc Allocator
-	switch {
-	case a.conf.Allocator == "simple" || a.conf.Allocator == "":
-		a.conf.Allocator = "simple"
-		if r := NewSimpleAllocator(); r != nil {
-			alloc = r
-		} else {
-			panic(errors.New("failed to set up simple allocator"))
-		}
-	default:
-		panic(errors.New("cannot load invalid allocator: " + a.conf.Allocator))
-	}
-	logger.Info("Loaded %v allocator", a.conf.Allocator)
-	return alloc
-}

--- a/apps/glusterfs/app_block_volume_test.go
+++ b/apps/glusterfs/app_block_volume_test.go
@@ -328,7 +328,7 @@ func TestBlockVolumeInfo(t *testing.T) {
 	v := NewBlockVolumeEntryFromRequest(req)
 	tests.Assert(t, v != nil)
 	tests.Assert(t, v.Info.Auth == true)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Now that we have some data in the database, we can
@@ -559,7 +559,7 @@ func TestBlockVolumeDelete(t *testing.T) {
 	// Create a volume
 	v := createSampleBlockVolumeEntry(100)
 	tests.Assert(t, v != nil)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Delete the volume

--- a/apps/glusterfs/app_device.go
+++ b/apps/glusterfs/app_device.go
@@ -332,7 +332,7 @@ func (a *App) DeviceSetState(w http.ResponseWriter, r *http.Request) {
 
 	// Set state
 	a.asyncManager.AsyncHttpRedirectFunc(w, r, func() (string, error) {
-		err = device.SetState(a.db, a.executor, a.Allocator(), msg.State)
+		err = device.SetState(a.db, a.executor, msg.State)
 		if err != nil {
 			return "", err
 		}

--- a/apps/glusterfs/app_node.go
+++ b/apps/glusterfs/app_node.go
@@ -373,7 +373,7 @@ func (a *App) NodeSetState(w http.ResponseWriter, r *http.Request) {
 
 	// Set state
 	a.asyncManager.AsyncHttpRedirectFunc(w, r, func() (string, error) {
-		err = node.SetState(a.db, a.executor, a.Allocator(), msg.State)
+		err = node.SetState(a.db, a.executor, msg.State)
 		if err != nil {
 			return "", err
 		}

--- a/apps/glusterfs/app_volume_test.go
+++ b/apps/glusterfs/app_volume_test.go
@@ -643,7 +643,7 @@ func TestVolumeInfo(t *testing.T) {
 	req.Durability.Type = api.DurabilityEC
 	v := NewVolumeEntryFromRequest(req)
 	tests.Assert(t, v != nil)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Now that we have some data in the database, we can
@@ -872,7 +872,7 @@ func TestVolumeDelete(t *testing.T) {
 	// Create a volume
 	v := createSampleReplicaVolumeEntry(100, 2)
 	tests.Assert(t, v != nil)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Delete the volume
@@ -1017,7 +1017,7 @@ func TestVolumeExpand(t *testing.T) {
 	// Create a volume
 	v := createSampleReplicaVolumeEntry(100, 2)
 	tests.Assert(t, v != nil)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Keep a copy
@@ -1084,13 +1084,13 @@ func TestVolumeClusterResizeByAddingDevices(t *testing.T) {
 	// Create a volume which uses the entire storage
 	v := createSampleReplicaVolumeEntry(495, 2)
 	tests.Assert(t, v != nil)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Try to create another volume, but this should fail
 	v = createSampleReplicaVolumeEntry(495, 2)
 	tests.Assert(t, v != nil)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == ErrNoSpace)
 
 	// Create a client
@@ -1118,13 +1118,13 @@ func TestVolumeClusterResizeByAddingDevices(t *testing.T) {
 	// Now add a volume, and it should work
 	v = createSampleReplicaVolumeEntry(495, 2)
 	tests.Assert(t, v != nil)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Try to create another volume, but this should fail
 	v = createSampleReplicaVolumeEntry(495, 2)
 	tests.Assert(t, v != nil)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == ErrNoSpace)
 }
 

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -235,12 +235,10 @@ func (v *BlockVolumeEntry) cleanupBlockVolumeCreate(db wdb.DB,
 }
 
 func (v *BlockVolumeEntry) Create(db wdb.DB,
-	executor executors.Executor,
-	allocator Allocator) (e error) {
+	executor executors.Executor) (e error) {
 
 	return RunOperation(
 		NewBlockVolumeCreateOperation(v, db),
-		allocator,
 		executor)
 }
 
@@ -358,7 +356,6 @@ func (v *BlockVolumeEntry) Destroy(db wdb.DB, executor executors.Executor) error
 
 	return RunOperation(
 		NewBlockVolumeDeleteOperation(v, db),
-		nil,
 		executor)
 }
 

--- a/apps/glusterfs/block_volume_entry_test.go
+++ b/apps/glusterfs/block_volume_entry_test.go
@@ -280,7 +280,7 @@ func TestBlockVolumeEntryCreateMissingCluster(t *testing.T) {
 	})
 	tests.Assert(t, err == nil)
 
-	err = bv.Create(app.db, app.executor, app.Allocator())
+	err = bv.Create(app.db, app.executor)
 	tests.Assert(t, err == ErrNoSpace)
 
 }
@@ -305,7 +305,7 @@ func TestBlockVolumeEntryDestroy(t *testing.T) {
 	// Create a blockvolume
 	bv := createSampleBlockVolumeEntry(200)
 
-	err = bv.Create(app.db, app.executor, app.Allocator())
+	err = bv.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Destroy the blockvolume
@@ -407,13 +407,13 @@ func TestBlockVolumeEntryNameConflictSingleVolume(t *testing.T) {
 	// Create blockvolume
 	bv := createSampleBlockVolumeEntry(500)
 	bv.Info.Name = "myvol"
-	err = bv.Create(app.db, app.executor, app.Allocator())
+	err = bv.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Create another blockvolume same name
 	bv = createSampleBlockVolumeEntry(400)
 	bv.Info.Name = "myvol"
-	err = bv.Create(app.db, app.executor, app.Allocator())
+	err = bv.Create(app.db, app.executor)
 	tests.Assert(t, err != nil, err)
 }
 
@@ -438,13 +438,13 @@ func TestBlockVolumeEntryNameConflictMultiVolume(t *testing.T) {
 	for i := 0; i < 8; i++ {
 		bv := createSampleBlockVolumeEntry(500)
 		bv.Info.Name = "myvol"
-		err = bv.Create(app.db, app.executor, app.Allocator())
+		err = bv.Create(app.db, app.executor)
 		tests.Assert(t, err == nil)
 	}
 	// Create another blockvolume same name
 	bv := createSampleBlockVolumeEntry(400)
 	bv.Info.Name = "myvol"
-	err = bv.Create(app.db, app.executor, app.Allocator())
+	err = bv.Create(app.db, app.executor)
 	tests.Assert(t, err != nil, err)
 }
 
@@ -469,12 +469,12 @@ func TestBlockVolumeEntryNameConflictMultiCluster(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		bv := createSampleBlockVolumeEntry(500)
 		bv.Info.Name = "myvol"
-		err = bv.Create(app.db, app.executor, app.Allocator())
+		err = bv.Create(app.db, app.executor)
 		tests.Assert(t, err == nil)
 	}
 	// Create another blockvolume same name
 	bv := createSampleBlockVolumeEntry(400)
 	bv.Info.Name = "myvol"
-	err = bv.Create(app.db, app.executor, app.Allocator())
+	err = bv.Create(app.db, app.executor)
 	tests.Assert(t, err != nil, err)
 }

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -197,9 +197,9 @@ func allocateBricks(
 			// Generate an id for the brick
 			brickId := utils.GenUUID()
 
-			// Get allocator generator
-			// The same generator should be used for the brick and its replicas
-			deviceCh, done, err := allocator.GetNodes(txdb, cluster, brickId)
+			a := NewSimpleAllocator()
+
+			deviceCh, done, err := a.GetNodes(txdb, cluster, brickId)
 			defer close(done)
 			if err != nil {
 				return err

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -171,7 +171,6 @@ func populateBrickSet(v *VolumeEntry,
 
 func allocateBricks(
 	db wdb.RODB,
-	allocator Allocator,
 	cluster string,
 	v *VolumeEntry,
 	numBrickSets int,

--- a/apps/glusterfs/dbcommon_test.go
+++ b/apps/glusterfs/dbcommon_test.go
@@ -42,7 +42,7 @@ func TestDeleteBricksWithEmptyPath(t *testing.T) {
 	// create a few volumes
 	for i := 0; i < 15; i++ {
 		v := NewVolumeEntryFromRequest(vreq)
-		err = v.Create(app.db, app.executor, app.Allocator())
+		err = v.Create(app.db, app.executor)
 		tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	}
 

--- a/apps/glusterfs/dbexamples.go
+++ b/apps/glusterfs/dbexamples.go
@@ -104,7 +104,7 @@ func LeakPendingVolumeCreate(t *testing.T, filename string) {
 		return nil
 	})
 
-	e := vc.Build(app.Allocator())
+	e := vc.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got", e)
 
 	// verify volumes, bricks, & pending ops exist

--- a/apps/glusterfs/device_entry_test.go
+++ b/apps/glusterfs/device_entry_test.go
@@ -228,12 +228,12 @@ func TestDeviceEntryRegister(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Set offline
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	err = d.SetState(app.db, app.executor, api.EntryStateOffline)
 	tests.Assert(t, d.State == api.EntryStateOffline)
 	tests.Assert(t, err == nil, err)
 
 	// Set failed
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateFailed)
+	err = d.SetState(app.db, app.executor, api.EntryStateFailed)
 	tests.Assert(t, d.State == api.EntryStateFailed)
 	tests.Assert(t, err == nil, err)
 
@@ -294,12 +294,12 @@ func TestDeviceEntryRegisterStaleRegistration(t *testing.T) {
 	tests.Assert(t, err != nil)
 
 	// Set offline
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	err = d.SetState(app.db, app.executor, api.EntryStateOffline)
 	tests.Assert(t, d.State == api.EntryStateOffline)
 	tests.Assert(t, err == nil, err)
 
 	// Set failed
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateFailed)
+	err = d.SetState(app.db, app.executor, api.EntryStateFailed)
 	tests.Assert(t, d.State == api.EntryStateFailed)
 	tests.Assert(t, err == nil, err)
 
@@ -430,12 +430,12 @@ func TestNewDeviceEntrySaveDelete(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Set offline
-	err = device.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	err = device.SetState(app.db, app.executor, api.EntryStateOffline)
 	tests.Assert(t, device.State == api.EntryStateOffline)
 	tests.Assert(t, err == nil, err)
 
 	// Set failed
-	err = device.SetState(app.db, app.executor, app.Allocator(), api.EntryStateFailed)
+	err = device.SetState(app.db, app.executor, api.EntryStateFailed)
 	tests.Assert(t, device.State == api.EntryStateFailed, device.State)
 	tests.Assert(t, err == nil, err)
 
@@ -666,32 +666,32 @@ func TestDeviceSetStateFailed(t *testing.T) {
 	})
 
 	// Set offline
-	err := d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	err := d.SetState(app.db, app.executor, api.EntryStateOffline)
 	tests.Assert(t, d.State == api.EntryStateOffline)
 	tests.Assert(t, err == nil, err)
 
 	// Set failed, Note: this requires the current state to be offline
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateFailed)
+	err = d.SetState(app.db, app.executor, api.EntryStateFailed)
 	tests.Assert(t, d.State == api.EntryStateFailed)
 	tests.Assert(t, err == nil)
 
 	// Set failed again
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateFailed)
+	err = d.SetState(app.db, app.executor, api.EntryStateFailed)
 	tests.Assert(t, d.State == api.EntryStateFailed)
 	tests.Assert(t, err == nil)
 
 	// Set online from failed, this should fail
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOnline)
+	err = d.SetState(app.db, app.executor, api.EntryStateOnline)
 	tests.Assert(t, d.State == api.EntryStateFailed)
 	tests.Assert(t, err != nil)
 
 	// Set offline
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	err = d.SetState(app.db, app.executor, api.EntryStateOffline)
 	tests.Assert(t, d.State == api.EntryStateOffline)
 	tests.Assert(t, err == nil)
 
 	// Set online from offline, this should pass
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOnline)
+	err = d.SetState(app.db, app.executor, api.EntryStateOnline)
 	tests.Assert(t, d.State == api.EntryStateOnline)
 	tests.Assert(t, err == nil)
 }
@@ -742,17 +742,17 @@ func TestDeviceSetStateOfflineOnline(t *testing.T) {
 	})
 
 	// Set offline
-	err := d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	err := d.SetState(app.db, app.executor, api.EntryStateOffline)
 	tests.Assert(t, d.State == api.EntryStateOffline)
 	tests.Assert(t, err == nil)
 
 	// Set offline again
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	err = d.SetState(app.db, app.executor, api.EntryStateOffline)
 	tests.Assert(t, d.State == api.EntryStateOffline)
 	tests.Assert(t, err == nil)
 
 	// Set online
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOnline)
+	err = d.SetState(app.db, app.executor, api.EntryStateOnline)
 	tests.Assert(t, d.State == api.EntryStateOnline)
 	tests.Assert(t, err == nil)
 }
@@ -779,7 +779,7 @@ func TestDeviceSetStateFailedWithBricks(t *testing.T) {
 	// create a few volumes
 	for i := 0; i < 5; i++ {
 		v := NewVolumeEntryFromRequest(vreq)
-		err = v.Create(app.db, app.executor, app.Allocator())
+		err = v.Create(app.db, app.executor)
 		tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	}
 
@@ -804,7 +804,7 @@ func TestDeviceSetStateFailedWithBricks(t *testing.T) {
 	})
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	err = d.SetState(app.db, app.executor, api.EntryStateOffline)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, d.State == api.EntryStateOffline)
 
@@ -825,7 +825,7 @@ func TestDeviceSetStateFailedWithBricks(t *testing.T) {
 		return mockHealStatusFromDb(app.db, volume)
 	}
 
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateFailed)
+	err = d.SetState(app.db, app.executor, api.EntryStateFailed)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	// update d from db
@@ -861,7 +861,7 @@ func TestDeviceSetStateFailedTooFewDevices(t *testing.T) {
 	// create a few volumes
 	for i := 0; i < 5; i++ {
 		v := NewVolumeEntryFromRequest(vreq)
-		err = v.Create(app.db, app.executor, app.Allocator())
+		err = v.Create(app.db, app.executor)
 		tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	}
 
@@ -886,7 +886,7 @@ func TestDeviceSetStateFailedTooFewDevices(t *testing.T) {
 	})
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	err = d.SetState(app.db, app.executor, api.EntryStateOffline)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, d.State == api.EntryStateOffline)
 
@@ -907,7 +907,7 @@ func TestDeviceSetStateFailedTooFewDevices(t *testing.T) {
 		return mockHealStatusFromDb(app.db, volume)
 	}
 
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateFailed)
+	err = d.SetState(app.db, app.executor, api.EntryStateFailed)
 	tests.Assert(t, strings.Contains(err.Error(), ErrNoReplacement.Error()),
 		"expected strings.Contains(err.Error(), ErrNoReplacement.Error()), got:",
 		err.Error())
@@ -988,7 +988,7 @@ func TestDeviceSetStateFailedWithEmptyPathBricks(t *testing.T) {
 	// create a few volumes
 	for i := 0; i < 5; i++ {
 		v := NewVolumeEntryFromRequest(vreq)
-		err = v.Create(app.db, app.executor, app.Allocator())
+		err = v.Create(app.db, app.executor)
 		tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	}
 
@@ -1027,7 +1027,7 @@ func TestDeviceSetStateFailedWithEmptyPathBricks(t *testing.T) {
 	})
 	tests.Assert(t, err == nil)
 
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	err = d.SetState(app.db, app.executor, api.EntryStateOffline)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, d.State == api.EntryStateOffline)
 
@@ -1050,7 +1050,7 @@ func TestDeviceSetStateFailedWithEmptyPathBricks(t *testing.T) {
 
 	// Fail the device, it should go through
 	// however, we would skipped on brick and that should remain in the device
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateFailed)
+	err = d.SetState(app.db, app.executor, api.EntryStateFailed)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	// update d from db

--- a/apps/glusterfs/listing_test.go
+++ b/apps/glusterfs/listing_test.go
@@ -41,7 +41,7 @@ func TestListCompleteVolumes(t *testing.T) {
 	req.Durability.Replicate.Replica = 3
 
 	vol := NewVolumeEntryFromRequest(req)
-	err = vol.Create(app.db, app.executor, app.Allocator())
+	err = vol.Create(app.db, app.executor)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	app.db.View(func(tx *bolt.Tx) error {
@@ -85,7 +85,7 @@ func TestListCompleteBlockVolumes(t *testing.T) {
 	req.Size = 1024
 
 	vol := NewBlockVolumeEntryFromRequest(req)
-	err = vol.Create(app.db, app.executor, app.Allocator())
+	err = vol.Create(app.db, app.executor)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	app.db.View(func(tx *bolt.Tx) error {
@@ -151,7 +151,7 @@ func TestListCompleteVolumesFakedPending(t *testing.T) {
 	req.Durability.Replicate.Replica = 3
 
 	vol := NewVolumeEntryFromRequest(req)
-	err = vol.Create(app.db, app.executor, app.Allocator())
+	err = vol.Create(app.db, app.executor)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	app.db.View(func(tx *bolt.Tx) error {
@@ -204,7 +204,7 @@ func TestListCompleteBlockVolumesFakedPending(t *testing.T) {
 	req.Size = 1024
 
 	vol := NewBlockVolumeEntryFromRequest(req)
-	err = vol.Create(app.db, app.executor, app.Allocator())
+	err = vol.Create(app.db, app.executor)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	app.db.View(func(tx *bolt.Tx) error {
@@ -259,14 +259,14 @@ func TestUpdateClusterInfoCompleteFakedPending(t *testing.T) {
 	vreq.Durability.Replicate.Replica = 3
 
 	vol := NewVolumeEntryFromRequest(vreq)
-	err = vol.Create(app.db, app.executor, app.Allocator())
+	err = vol.Create(app.db, app.executor)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	breq := &api.BlockVolumeCreateRequest{}
 	breq.Size = 1024
 
 	bvol := NewBlockVolumeEntryFromRequest(breq)
-	err = bvol.Create(app.db, app.executor, app.Allocator())
+	err = bvol.Create(app.db, app.executor)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	app.db.View(func(tx *bolt.Tx) error {

--- a/apps/glusterfs/node_entry.go
+++ b/apps/glusterfs/node_entry.go
@@ -280,7 +280,6 @@ func (n *NodeEntry) Delete(tx *bolt.Tx) error {
 }
 
 func (n *NodeEntry) SetState(db wdb.DB, e executors.Executor,
-	a Allocator,
 	s api.EntryState) error {
 
 	// Check current state
@@ -352,7 +351,7 @@ func (n *NodeEntry) SetState(db wdb.DB, e executors.Executor,
 					}
 					return nil
 				})
-				err = d.Remove(db, e, a)
+				err = d.Remove(db, e)
 				if err != nil {
 					if err == ErrNoReplacement {
 						return logger.LogError("Unable to remove node [%v] as no device was found to replace device [%v]", n.Info.Id, d.Id())

--- a/apps/glusterfs/node_entry_test.go
+++ b/apps/glusterfs/node_entry_test.go
@@ -526,27 +526,27 @@ func TestNodeSetStateFailed(t *testing.T) {
 	})
 
 	// Set failed
-	err := n.SetState(app.db, app.executor, app.Allocator(), api.EntryStateFailed)
+	err := n.SetState(app.db, app.executor, api.EntryStateFailed)
 	tests.Assert(t, n.State == api.EntryStateOnline)
 	tests.Assert(t, err != nil)
 
 	// Set offline
-	err = n.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	err = n.SetState(app.db, app.executor, api.EntryStateOffline)
 	tests.Assert(t, n.State == api.EntryStateOffline)
 	tests.Assert(t, err == nil)
 
 	// Set failed
-	err = n.SetState(app.db, app.executor, app.Allocator(), api.EntryStateFailed)
+	err = n.SetState(app.db, app.executor, api.EntryStateFailed)
 	tests.Assert(t, n.State == api.EntryStateFailed)
 	tests.Assert(t, err == nil)
 
 	// Set offline
-	err = n.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	err = n.SetState(app.db, app.executor, api.EntryStateOffline)
 	tests.Assert(t, n.State == api.EntryStateFailed)
 	tests.Assert(t, err != nil)
 
 	// Set online
-	err = n.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOnline)
+	err = n.SetState(app.db, app.executor, api.EntryStateOnline)
 	tests.Assert(t, n.State == api.EntryStateFailed)
 	tests.Assert(t, err != nil)
 }
@@ -596,17 +596,17 @@ func TestNodeSetStateOfflineOnline(t *testing.T) {
 	})
 
 	// Set offline
-	err := n.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	err := n.SetState(app.db, app.executor, api.EntryStateOffline)
 	tests.Assert(t, n.State == api.EntryStateOffline)
 	tests.Assert(t, err == nil)
 
 	// Set offline again
-	err = n.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	err = n.SetState(app.db, app.executor, api.EntryStateOffline)
 	tests.Assert(t, n.State == api.EntryStateOffline)
 	tests.Assert(t, err == nil)
 
 	// Set online
-	err = n.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOnline)
+	err = n.SetState(app.db, app.executor, api.EntryStateOnline)
 	tests.Assert(t, n.State == api.EntryStateOnline)
 	tests.Assert(t, err == nil)
 }

--- a/apps/glusterfs/operations_test.go
+++ b/apps/glusterfs/operations_test.go
@@ -57,7 +57,7 @@ func TestVolumeCreatePendingCreatedCleared(t *testing.T) {
 		return nil
 	})
 
-	e := vc.Build(app.Allocator())
+	e := vc.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got", e)
 
 	// verify volumes, bricks, & pending ops exist
@@ -159,7 +159,7 @@ func TestVolumeCreatePendingRollback(t *testing.T) {
 		return nil
 	})
 
-	e := vc.Build(app.Allocator())
+	e := vc.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got", e)
 
 	// verify volumes, bricks, & pending ops exist
@@ -248,7 +248,7 @@ func TestVolumeCreatePendingNoSpace(t *testing.T) {
 		return nil
 	})
 
-	e := vc.Build(app.Allocator())
+	e := vc.Build()
 	// verify that we failed to allocate due to lack of space
 	tests.Assert(t, e == ErrNoSpace, "expected e == ErrNoSpace, got", e)
 
@@ -305,7 +305,7 @@ func TestVolumeCreatePendingBrickMissing(t *testing.T) {
 		return nil
 	})
 
-	e := vc.Build(app.Allocator())
+	e := vc.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got", e)
 
 	// verify volumes, bricks, & pending ops exist
@@ -417,7 +417,7 @@ func TestVolumeDeleteOperation(t *testing.T) {
 	vol := NewVolumeEntryFromRequest(req)
 	vc := NewVolumeCreateOperation(vol, app.db)
 
-	e := vc.Build(app.Allocator())
+	e := vc.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got:", e)
 	e = vc.Exec(app.executor)
 	tests.Assert(t, e == nil, "expected e == nil, got:", e)
@@ -435,7 +435,7 @@ func TestVolumeDeleteOperation(t *testing.T) {
 	})
 
 	vd := NewVolumeDeleteOperation(vol, app.db)
-	e = vd.Build(app.Allocator())
+	e = vd.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got:", e)
 
 	app.db.View(func(tx *bolt.Tx) error {
@@ -489,7 +489,7 @@ func TestVolumeDeleteOperationRollback(t *testing.T) {
 	vol := NewVolumeEntryFromRequest(req)
 	vc := NewVolumeCreateOperation(vol, app.db)
 
-	e := vc.Build(app.Allocator())
+	e := vc.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got:", e)
 	e = vc.Exec(app.executor)
 	tests.Assert(t, e == nil, "expected e == nil, got:", e)
@@ -507,7 +507,7 @@ func TestVolumeDeleteOperationRollback(t *testing.T) {
 	})
 
 	vd := NewVolumeDeleteOperation(vol, app.db)
-	e = vd.Build(app.Allocator())
+	e = vd.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got:", e)
 
 	app.db.View(func(tx *bolt.Tx) error {
@@ -562,7 +562,7 @@ func TestVolumeExpandOperation(t *testing.T) {
 	vol := NewVolumeEntryFromRequest(req)
 	vc := NewVolumeCreateOperation(vol, app.db)
 
-	e := vc.Build(app.Allocator())
+	e := vc.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got:", e)
 	e = vc.Exec(app.executor)
 	tests.Assert(t, e == nil, "expected e == nil, got:", e)
@@ -580,7 +580,7 @@ func TestVolumeExpandOperation(t *testing.T) {
 	})
 
 	ve := NewVolumeExpandOperation(vol, app.db, 100)
-	e = ve.Build(app.Allocator())
+	e = ve.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got:", e)
 
 	app.db.View(func(tx *bolt.Tx) error {
@@ -664,7 +664,7 @@ func TestBlockVolumeCreateOperation(t *testing.T) {
 		return nil
 	})
 
-	e := vc.Build(app.Allocator())
+	e := vc.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got", e)
 
 	// verify there is one pending op, volume and some bricks
@@ -729,7 +729,7 @@ func TestBlockVolumeCreateOperationExistingHostVol(t *testing.T) {
 	vol := NewVolumeEntryFromRequest(vreq)
 	vc := NewVolumeCreateOperation(vol, app.db)
 
-	e := vc.Build(app.Allocator())
+	e := vc.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got:", e)
 	e = vc.Exec(app.executor)
 	tests.Assert(t, e == nil, "expected e == nil, got:", e)
@@ -758,7 +758,7 @@ func TestBlockVolumeCreateOperationExistingHostVol(t *testing.T) {
 	bvol := NewBlockVolumeEntryFromRequest(breq)
 	bco := NewBlockVolumeCreateOperation(bvol, app.db)
 
-	e = bco.Build(app.Allocator())
+	e = bco.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got:", e)
 
 	// at this point we shouldn't have a new volume or bricks,
@@ -839,7 +839,7 @@ func TestBlockVolumeCreateOperationRollback(t *testing.T) {
 		return nil
 	})
 
-	e := vc.Build(app.Allocator())
+	e := vc.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got", e)
 
 	// verify there is one pending op, volume and some bricks
@@ -908,7 +908,7 @@ func TestBlockVolumeCreateOperationExistingHostVolRollback(t *testing.T) {
 	vol := NewVolumeEntryFromRequest(vreq)
 	vc := NewVolumeCreateOperation(vol, app.db)
 
-	e := vc.Build(app.Allocator())
+	e := vc.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got:", e)
 	e = vc.Exec(app.executor)
 	tests.Assert(t, e == nil, "expected e == nil, got:", e)
@@ -937,7 +937,7 @@ func TestBlockVolumeCreateOperationExistingHostVolRollback(t *testing.T) {
 	bvol := NewBlockVolumeEntryFromRequest(breq)
 	bco := NewBlockVolumeCreateOperation(bvol, app.db)
 
-	e = bco.Build(app.Allocator())
+	e = bco.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got:", e)
 
 	// at this point we shouldn't have a new volume or bricks,
@@ -1019,7 +1019,7 @@ func TestBlockVolumeDeleteOperation(t *testing.T) {
 		return nil
 	})
 
-	e := vc.Build(app.Allocator())
+	e := vc.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got", e)
 	e = vc.Exec(app.executor)
 	tests.Assert(t, e == nil, "expected e == nil, got", e)
@@ -1045,7 +1045,7 @@ func TestBlockVolumeDeleteOperation(t *testing.T) {
 
 	bdel := NewBlockVolumeDeleteOperation(vol, app.db)
 
-	e = bdel.Build(app.Allocator())
+	e = bdel.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got", e)
 
 	// we should now have a pending op for the delete
@@ -1125,7 +1125,7 @@ func TestBlockVolumeDeleteOperationRollback(t *testing.T) {
 		return nil
 	})
 
-	e := vc.Build(app.Allocator())
+	e := vc.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got", e)
 	e = vc.Exec(app.executor)
 	tests.Assert(t, e == nil, "expected e == nil, got", e)
@@ -1151,7 +1151,7 @@ func TestBlockVolumeDeleteOperationRollback(t *testing.T) {
 
 	bdel := NewBlockVolumeDeleteOperation(vol, app.db)
 
-	e = bdel.Build(app.Allocator())
+	e = bdel.Build()
 	tests.Assert(t, e == nil, "expected e == nil, got", e)
 
 	// we should now have a pending op for the delete
@@ -1226,11 +1226,11 @@ func TestDeviceRemoveOperationEmpty(t *testing.T) {
 	})
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	err = d.SetState(app.db, app.executor, api.EntryStateOffline)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
-	dro := NewDeviceRemoveOperation(d.Info.Id, app.Allocator(), app.db)
-	err = dro.Build(app.Allocator())
+	dro := NewDeviceRemoveOperation(d.Info.Id, app.db)
+	err = dro.Build()
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	// because there are no bricks on this device it can be disabled
@@ -1272,7 +1272,7 @@ func TestDeviceRemoveOperationWithBricks(t *testing.T) {
 	// create two volumes
 	for i := 0; i < 5; i++ {
 		v := NewVolumeEntryFromRequest(vreq)
-		err = v.Create(app.db, app.executor, app.Allocator())
+		err = v.Create(app.db, app.executor)
 		tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	}
 
@@ -1297,11 +1297,11 @@ func TestDeviceRemoveOperationWithBricks(t *testing.T) {
 	})
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	err = d.SetState(app.db, app.executor, api.EntryStateOffline)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
-	dro := NewDeviceRemoveOperation(d.Info.Id, app.Allocator(), app.db)
-	err = dro.Build(app.Allocator())
+	dro := NewDeviceRemoveOperation(d.Info.Id, app.db)
+	err = dro.Build()
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	// because there were bricks on this device it needs to perform
@@ -1377,7 +1377,7 @@ func TestDeviceRemoveOperationTooFewDevices(t *testing.T) {
 	// create two volumes
 	for i := 0; i < 5; i++ {
 		v := NewVolumeEntryFromRequest(vreq)
-		err = v.Create(app.db, app.executor, app.Allocator())
+		err = v.Create(app.db, app.executor)
 		tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	}
 
@@ -1402,11 +1402,11 @@ func TestDeviceRemoveOperationTooFewDevices(t *testing.T) {
 	})
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	err = d.SetState(app.db, app.executor, api.EntryStateOffline)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
-	dro := NewDeviceRemoveOperation(d.Info.Id, app.Allocator(), app.db)
-	err = dro.Build(app.Allocator())
+	dro := NewDeviceRemoveOperation(d.Info.Id, app.db)
+	err = dro.Build()
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	// because there were bricks on this device it needs to perform
@@ -1484,7 +1484,7 @@ func TestDeviceRemoveOperationOtherPendingOps(t *testing.T) {
 	// create two volumes
 	for i := 0; i < 4; i++ {
 		v := NewVolumeEntryFromRequest(vreq)
-		err = v.Create(app.db, app.executor, app.Allocator())
+		err = v.Create(app.db, app.executor)
 		tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	}
 
@@ -1512,7 +1512,7 @@ func TestDeviceRemoveOperationOtherPendingOps(t *testing.T) {
 	// now start a volume create operation but don't finish it
 	vol := NewVolumeEntryFromRequest(vreq)
 	vc := NewVolumeCreateOperation(vol, app.db)
-	err = vc.Build(app.Allocator())
+	err = vc.Build()
 	tests.Assert(t, err == nil, "expected e == nil, got", err)
 	// we should have one pending operation
 	err = app.db.View(func(tx *bolt.Tx) error {
@@ -1522,11 +1522,11 @@ func TestDeviceRemoveOperationOtherPendingOps(t *testing.T) {
 		return nil
 	})
 
-	err = d.SetState(app.db, app.executor, app.Allocator(), api.EntryStateOffline)
+	err = d.SetState(app.db, app.executor, api.EntryStateOffline)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
-	dro := NewDeviceRemoveOperation(d.Info.Id, app.Allocator(), app.db)
-	err = dro.Build(app.Allocator())
+	dro := NewDeviceRemoveOperation(d.Info.Id, app.db)
+	err = dro.Build()
 	tests.Assert(t, err == ErrConflict, "expected err == ErrConflict, got:", err)
 
 	// we should have one pending operation (the volume create)
@@ -1555,7 +1555,7 @@ func (o *testOperation) ResourceUrl() string {
 	return o.rurl
 }
 
-func (o *testOperation) Build(allocator Allocator) error {
+func (o *testOperation) Build() error {
 	if o.build == nil {
 		return nil
 	}
@@ -1839,7 +1839,7 @@ func TestRunOperationRollbackFailure(t *testing.T) {
 		rollback_cc++
 		return fmt.Errorf("rollbackfail")
 	}
-	e := RunOperation(o, app.Allocator(), app.executor)
+	e := RunOperation(o, app.executor)
 	// even if rollback fails we expect the error from Exec
 	tests.Assert(t, strings.Contains(e.Error(), "execfail"),
 		`expected strings.Contains(e.Error(), "execfail"), got:`, e)
@@ -1860,7 +1860,7 @@ func TestRunOperationFinalizeFailure(t *testing.T) {
 		return fmt.Errorf("finfail")
 	}
 
-	e := RunOperation(o, app.Allocator(), app.executor)
+	e := RunOperation(o, app.executor)
 	// check error from finalize
 	tests.Assert(t, strings.Contains(e.Error(), "finfail"),
 		`expected strings.Contains(e.Error(), "finfail"), got:`, e)

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -273,7 +273,8 @@ func (v *VolumeEntry) allocBrickReplacement(db wdb.DB,
 	err = db.Update(func(tx *bolt.Tx) error {
 		txdb := wdb.WrapTx(tx)
 		// Check the ring for devices to place the brick
-		deviceCh, done, err := allocator.GetNodes(txdb, v.Info.Cluster, newBrickId)
+		a := NewSimpleAllocator()
+		deviceCh, done, err := a.GetNodes(txdb, v.Info.Cluster, newBrickId)
 		defer close(done)
 		if err != nil {
 			return err

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -486,7 +486,7 @@ func TestVolumeEntryCreateMissingCluster(t *testing.T) {
 	})
 	tests.Assert(t, err == nil)
 
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == ErrNoSpace)
 
 }
@@ -511,7 +511,7 @@ func TestVolumeEntryCreateRunOutOfSpaceMinBrickSizeLimit(t *testing.T) {
 	// Create a 100 GB volume
 	// Shouldn't be able to break it down enough to allocate volume
 	v := createSampleReplicaVolumeEntry(100, 2)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == ErrNoSpace)
 	tests.Assert(t, v.Info.Cluster == "")
 
@@ -559,7 +559,7 @@ func TestVolumeEntryCreateRunOutOfSpaceMaxBrickLimit(t *testing.T) {
 	// Create a volume who will be broken down to
 	// Shouldn't be able to break it down enough to allocate volume
 	v := createSampleReplicaVolumeEntry(BrickMaxNum*2*int(BrickMinSize/GB), 2)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == ErrNoSpace)
 
 	// Check database volume does not exist
@@ -626,7 +626,7 @@ func TestVolumeEntryCreateTwoBricks(t *testing.T) {
 	// Set a GID
 	v.Info.Gid = gid
 
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil, err)
 	tests.Assert(t, brickCreateCount == 2)
 
@@ -732,7 +732,7 @@ func TestVolumeEntryCreateBrickDivision(t *testing.T) {
 	// Create a volume which is so big that it does
 	// not fit into a single replica set
 	v := createSampleReplicaVolumeEntry(2000, 2)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	var info *api.VolumeInfoResponse
@@ -813,7 +813,7 @@ func TestVolumeEntryCreateMaxBrickSize(t *testing.T) {
 
 	// Create a volume whose bricks must be at most BrickMaxSize
 	v := createSampleReplicaVolumeEntry(int(BrickMaxSize/GB*4), 2)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Get volume information
@@ -877,7 +877,7 @@ func TestVolumeEntryCreateOnClustersRequested(t *testing.T) {
 	v.Info.Clusters = []string{clusters[0]}
 
 	// Create volume
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Check database volume does not exist
@@ -903,7 +903,7 @@ func TestVolumeEntryCreateOnClustersRequested(t *testing.T) {
 	clusterset := clusters[2:5]
 	v = createSampleReplicaVolumeEntry(1024, 2)
 	v.Info.Clusters = clusterset
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Check database volume exists
@@ -980,7 +980,7 @@ func TestVolumeEntryCreateCheckingClustersForSpace(t *testing.T) {
 	v := createSampleReplicaVolumeEntry(1024, 2)
 
 	// Create volume
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Check database volume exists
@@ -1027,7 +1027,7 @@ func TestVolumeEntryCreateWithSnapshot(t *testing.T) {
 	v.Info.Snapshot.Enable = true
 	v.Info.Snapshot.Factor = 1.5
 
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Check database volume exists
@@ -1092,7 +1092,7 @@ func TestVolumeEntryCreateBrickCreationFailure(t *testing.T) {
 	// For a 200G vol, it would get a brick size of 100G, with a thin pool
 	// size of 100G * 1.5 = 150GB.
 	v := createSampleReplicaVolumeEntry(200, 2)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == mockerror, err, mockerror)
 
 	// Check database is still clean. No bricks and No volumes
@@ -1146,7 +1146,7 @@ func TestVolumeEntryCreateVolumeCreationFailure(t *testing.T) {
 	// For a 200G vol, it would get a brick size of 100G, with a thin pool
 	// size of 100G * 1.5 = 150GB.
 	v := createSampleReplicaVolumeEntry(200, 2)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == mockerror)
 
 	// Check database is still clean. No bricks and No volumes
@@ -1199,7 +1199,7 @@ func TestVolumeEntryDestroy(t *testing.T) {
 	v.Info.Snapshot.Enable = true
 	v.Info.Snapshot.Factor = 1.5
 
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Destroy the volume
@@ -1284,7 +1284,7 @@ func TestVolumeEntryExpandNoSpace(t *testing.T) {
 
 	// Create large volume
 	v := createSampleReplicaVolumeEntry(1190, 2)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Save a copy of the volume before expansion
@@ -1292,11 +1292,11 @@ func TestVolumeEntryExpandNoSpace(t *testing.T) {
 	*vcopy = *v
 
 	// Asking for a large amount will require too many little bricks
-	err = v.Expand(app.db, app.executor, app.Allocator(), 5000)
+	err = v.Expand(app.db, app.executor, 5000)
 	tests.Assert(t, err == ErrMaxBricks, err)
 
 	// Asking for a small amount will set the bricks too small
-	err = v.Expand(app.db, app.executor, app.Allocator(), 10)
+	err = v.Expand(app.db, app.executor, 10)
 	tests.Assert(t, err == ErrMinimumBrickSize, err)
 
 	// Check db is the same as before expansion
@@ -1330,7 +1330,7 @@ func TestVolumeEntryExpandMaxBrickLimit(t *testing.T) {
 
 	// Create large volume
 	v := createSampleReplicaVolumeEntry(100, 2)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Add a bunch of bricks until the limit
@@ -1339,7 +1339,7 @@ func TestVolumeEntryExpandMaxBrickLimit(t *testing.T) {
 
 	// Try to expand the volume, but it will return that the max number
 	// of bricks has been reached
-	err = v.Expand(app.db, app.executor, app.Allocator(), 100)
+	err = v.Expand(app.db, app.executor, 100)
 	tests.Assert(t, err == ErrMaxBricks, err)
 }
 
@@ -1362,7 +1362,7 @@ func TestVolumeEntryExpandCreateBricksFailure(t *testing.T) {
 
 	// Create volume
 	v := createSampleReplicaVolumeEntry(100, 2)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Save a copy of the volume before expansion
@@ -1376,7 +1376,7 @@ func TestVolumeEntryExpandCreateBricksFailure(t *testing.T) {
 	}
 
 	// Expand volume
-	err = v.Expand(app.db, app.executor, app.Allocator(), 500)
+	err = v.Expand(app.db, app.executor, 500)
 	tests.Assert(t, err == ErrMock)
 
 	// Check db is the same as before expansion
@@ -1410,13 +1410,13 @@ func TestVolumeEntryExpand(t *testing.T) {
 
 	// Create volume
 	v := createSampleReplicaVolumeEntry(1024, 2)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, v.Info.Size == 1024)
 	tests.Assert(t, len(v.Bricks) == 2)
 
 	// Expand volume
-	err = v.Expand(app.db, app.executor, app.Allocator(), 1234)
+	err = v.Expand(app.db, app.executor, 1234)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, v.Info.Size == 1024+1234)
 	tests.Assert(t, len(v.Bricks) == 4)
@@ -1453,12 +1453,12 @@ func TestVolumeEntryDoNotAllowDeviceOnSameNode(t *testing.T) {
 
 	// Create volume
 	v := createSampleReplicaVolumeEntry(100, 2)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err != nil, err)
 	tests.Assert(t, err == ErrNoSpace)
 
 	v = createSampleReplicaVolumeEntry(10000, 2)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err != nil, err)
 	tests.Assert(t, err == ErrNoSpace)
 }
@@ -1487,7 +1487,7 @@ func TestVolumeEntryDestroyCheck(t *testing.T) {
 	v.Info.Snapshot.Enable = true
 	v.Info.Snapshot.Factor = 1.5
 
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Test that a volume that is sharing space in a thin pool
@@ -1538,13 +1538,13 @@ func TestVolumeEntryNameConflictSingleCluster(t *testing.T) {
 	// Create volume
 	v := createSampleReplicaVolumeEntry(1024, 2)
 	v.Info.Name = "myvol"
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil)
 
 	// Create another volume same name
 	v = createSampleReplicaVolumeEntry(10000, 2)
 	v.Info.Name = "myvol"
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err != nil, err)
 }
 
@@ -1569,7 +1569,7 @@ func TestVolumeEntryNameConflictMultiCluster(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		v := createSampleReplicaVolumeEntry(1024, 2)
 		v.Info.Name = "myvol"
-		err = v.Create(app.db, app.executor, app.Allocator())
+		err = v.Create(app.db, app.executor)
 		logger.Info("%v", v.Info.Cluster)
 		tests.Assert(t, err == nil, err)
 	}
@@ -1577,7 +1577,7 @@ func TestVolumeEntryNameConflictMultiCluster(t *testing.T) {
 	// Create another volume same name
 	v := createSampleReplicaVolumeEntry(10000, 2)
 	v.Info.Name = "myvol"
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err != nil, err)
 }
 
@@ -1599,7 +1599,7 @@ func TestReplaceBrickInVolume(t *testing.T) {
 
 	v := createSampleReplicaVolumeEntry(100, 3)
 
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil, err)
 	var brickNames []string
 	var be *BrickEntry
@@ -1652,7 +1652,7 @@ func TestReplaceBrickInVolume(t *testing.T) {
 		return h, nil
 	}
 	brickId := be.Id()
-	err = v.replaceBrickInVolume(app.db, app.executor, app.Allocator(), brickId)
+	err = v.replaceBrickInVolume(app.db, app.executor, brickId)
 	tests.Assert(t, err == nil, err)
 
 	oldNode := be.Info.NodeId
@@ -1712,7 +1712,7 @@ func TestNewVolumeEntryWithVolumeOptions(t *testing.T) {
 	tests.Assert(t, len(v.Bricks) == 0)
 	tests.Assert(t, v.GlusterVolumeOptions[0] == "test-option")
 
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	logger.Info("%v", v.Info.Cluster)
 	tests.Assert(t, err == nil, err)
 
@@ -1753,7 +1753,7 @@ func TestNewVolumeEntryWithTSPForMountHosts(t *testing.T) {
 	tests.Assert(t, len(v.Info.Id) != 0)
 	tests.Assert(t, len(v.Bricks) == 0)
 
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	logger.Info("%v", v.Info.Cluster)
 	tests.Assert(t, err == nil, err)
 
@@ -1787,7 +1787,7 @@ func TestReplaceBrickInVolumeSelfHeal1(t *testing.T) {
 
 	v := createSampleReplicaVolumeEntry(100, 3)
 
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil, err)
 	var brickNames []string
 	var be *BrickEntry
@@ -1838,7 +1838,7 @@ func TestReplaceBrickInVolumeSelfHeal1(t *testing.T) {
 		return h, nil
 	}
 	brickId := be.Id()
-	err = v.replaceBrickInVolume(app.db, app.executor, app.Allocator(), brickId)
+	err = v.replaceBrickInVolume(app.db, app.executor, brickId)
 	tests.Assert(t, err == nil, err)
 
 	oldNode := be.Info.NodeId
@@ -1888,7 +1888,7 @@ func TestReplaceBrickInVolumeSelfHeal2(t *testing.T) {
 
 	v := createSampleReplicaVolumeEntry(100, 3)
 
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil, err)
 	var brickNames []string
 	var be *BrickEntry
@@ -1942,7 +1942,7 @@ func TestReplaceBrickInVolumeSelfHeal2(t *testing.T) {
 		return h, nil
 	}
 	brickId := be.Id()
-	err = v.replaceBrickInVolume(app.db, app.executor, app.Allocator(), brickId)
+	err = v.replaceBrickInVolume(app.db, app.executor, brickId)
 	tests.Assert(t, err != nil, err)
 
 	oldNode := be.Info.NodeId
@@ -1992,7 +1992,7 @@ func TestReplaceBrickInVolumeSelfHealQuorumNotMet(t *testing.T) {
 
 	v := createSampleReplicaVolumeEntry(100, 3)
 
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil, err)
 	var brickNames []string
 	var be *BrickEntry
@@ -2043,7 +2043,7 @@ func TestReplaceBrickInVolumeSelfHealQuorumNotMet(t *testing.T) {
 		return h, nil
 	}
 	brickId := be.Id()
-	err = v.replaceBrickInVolume(app.db, app.executor, app.Allocator(), brickId)
+	err = v.replaceBrickInVolume(app.db, app.executor, brickId)
 	tests.Assert(t, err != nil, err)
 
 	oldNode := be.Info.NodeId
@@ -2113,7 +2113,7 @@ func TestVolumeEntryNoMatchingFlags(t *testing.T) {
 	v.Info.Name = "blockhead"
 	// request block volume
 	v.Info.Block = true
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	// expect no space error due to no clusters able to satifsy block volume
 	tests.Assert(t, err == ErrNoSpace)
 }
@@ -2154,7 +2154,7 @@ func TestVolumeEntryMissingFlags(t *testing.T) {
 
 	// Create volume
 	v := createSampleReplicaVolumeEntry(1024, 2)
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	// expect no space error due to no clusters able to satifsy block volume
 	tests.Assert(t, err == ErrNoSpace)
 }
@@ -2181,7 +2181,7 @@ func TestVolumeCreateBrickAlloc(t *testing.T) {
 	req.Durability.Replicate.Replica = 3
 	v := NewVolumeEntryFromRequest(req)
 
-	err = v.Create(app.db, app.executor, app.Allocator())
+	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	// check that the volume has exactly 3 bricks
@@ -2194,7 +2194,7 @@ func TestVolumeCreateBrickAlloc(t *testing.T) {
 	req.Durability.Replicate.Replica = 3
 	v2 := NewVolumeEntryFromRequest(req)
 
-	err = v2.Create(app.db, app.executor, app.Allocator())
+	err = v2.Create(app.db, app.executor)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	// check that the volume has exactly 12 bricks
@@ -2240,7 +2240,7 @@ func TestVolumeCreateConcurrent(t *testing.T) {
 		sg.Add(1)
 		go func() {
 			defer sg.Done()
-			err := v.Create(app.db, app.executor, app.Allocator())
+			err := v.Create(app.db, app.executor)
 			sg.Err(err)
 		}()
 	}


### PR DESCRIPTION
This allows to remove App.Allocator() altogether.
It makes the allocator config setting useless.

based on #1086