### PR TITLE
apps: deny creation of block-hosting volumes if disabled.

### DIFF
--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -46,6 +46,12 @@ func NewVolumeEntryForBlockHosting(clusters []string) (*VolumeEntry, error) {
 
 	vol := NewVolumeEntryFromRequest(&msg)
 
+	if !CreateBlockHostingVolumes {
+		return nil, fmt.Errorf("Block Hosting Volume Creation is " +
+			"disabled. Create a Block hosting volume and try " +
+			"again.")
+	}
+
 	if uint64(msg.Size)*GB < vol.Durability.MinVolumeSize() {
 		return nil, fmt.Errorf("Requested volume size (%v GB) is "+
 			"smaller than the minimum supported volume size (%v)",


### PR DESCRIPTION
In the move to operations, the check for the
CreateBlockHostingVolumes setting was somehow
dropped accidentially. Re-introduce it.

Fixes #1092

Signed-off-by: Michael Adam <obnox@redhat.com>