### PR TITLE
tests: add an environment var to disable sudo in functional tests

### DIFF
--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -44,6 +44,11 @@ To run a specific functional test, go into that functionl test's directory and t
 $ ./run.sh
 ```
 
+Some of the test setup code assumes that root privileges are needed.
+If the user is not already root the test setup code will run sudo, if
+you know this is not needed on your system you can disable this by
+setting `HEKETI_TEST_USE_SUDO=no` in your environment.
+
 ## Adding new tests
 
 Create a new directory under tests/functional matching the style of

--- a/tests/functional/lib.sh
+++ b/tests/functional/lib.sh
@@ -10,7 +10,7 @@ println() {
 }
 
 _sudo() {
-    if [ ${UID} = 0 ] ; then
+    if [[ ${UID} = 0 || "$HEKETI_TEST_USE_SUDO" = "no" ]]; then
         "${@}"
     else
         sudo -E "${@}"


### PR DESCRIPTION
It can be inconvenient or downright wrong to always use sudo in
the functional tests, it depends on the local environment.
Add a new environment variable to allow all steps to run
as the current user.

Signed-off-by: John Mulligan <jmulligan@redhat.com>
