### PR TITLE
travis: Do coverage on all go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ git:
 matrix:
   include:
   - go: 1.7.5
-    env: OPTIONS="-race"
+    env: COVERAGE="true"
   - go: 1.8.2
     env: COVERAGE="true"
   - go: 1.9.4


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

OPTIONS="-race" has no effect any more.
This was a leftover from earlier cleanup work.
So remove it and rather do coverage on all
go versions for now.

<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### Notes for the reviewer

Happy reviewing.


