### PR TITLE
apps: look for existing brick remove ops and fail gracefully if so

### DIFF
--- a/apps/glusterfs/device_entry.go
+++ b/apps/glusterfs/device_entry.go
@@ -509,6 +509,16 @@ func PendingOperationsOnDevice(db wdb.RODB, deviceId string) (pdev bool, e error
 				return nil
 			}
 		}
+		pdr, err := MapPendingDeviceRemoves(tx)
+		if err != nil {
+			return err
+		}
+		if _, found := pdr[deviceId]; found {
+			logger.Warning(
+				"Device %v used in another pending device remove operation",
+				deviceId)
+			pdev = true
+		}
 		return nil
 	})
 	return

--- a/apps/glusterfs/listing.go
+++ b/apps/glusterfs/listing.go
@@ -96,6 +96,12 @@ func MapPendingBricks(tx *bolt.Tx) (map[string]string, error) {
 	})
 }
 
+func MapPendingDeviceRemoves(tx *bolt.Tx) (map[string]string, error) {
+	return mapPendingItems(tx, func(op *PendingOperationEntry, a PendingOperationAction) bool {
+		return (a.Change == OpRemoveDevice)
+	})
+}
+
 func mapPendingItems(tx *bolt.Tx,
 	pred func(op *PendingOperationEntry, a PendingOperationAction) bool) (
 	items map[string]string, e error) {


### PR DESCRIPTION
The existing check for pending operations on bricks was missing
any non-brick operations on the device, specifically other
existing pending device remove operations. Add a check and a
test for that condition.

Signed-off-by: John Mulligan <jmulligan@redhat.com>