### PR TITLE
New brick placer interface and standard implementation

### DIFF
--- a/apps/glusterfs/allocator_simple.go
+++ b/apps/glusterfs/allocator_simple.go
@@ -112,6 +112,32 @@ func (s *SimpleAllocator) GetNodes(db wdb.RODB, clusterId,
 		return device, done, err
 	}
 
+	generateDevices(devicelist, device, done)
+	return device, done, nil
+}
+
+// GetNodesFromDeviceSource is a shim function that should only
+// exist as long as we keep the intermediate simple allocator.
+func (s *SimpleAllocator) GetNodesFromDeviceSource(dsrc DeviceSource,
+	brickId string) (
+	<-chan string, chan<- struct{}, error) {
+
+	device, done := make(chan string), make(chan struct{})
+
+	ring, err := loadRingFromDeviceSource(dsrc)
+	if err != nil {
+		close(device)
+		return device, done, err
+	}
+	devicelist := ring.GetDeviceList(brickId)
+
+	generateDevices(devicelist, device, done)
+	return device, done, nil
+}
+
+func generateDevices(devicelist SimpleDevices,
+	device chan<- string, done <-chan struct{}) {
+
 	// Start generator in a new goroutine
 	go func() {
 		defer func() {
@@ -125,8 +151,5 @@ func (s *SimpleAllocator) GetNodes(db wdb.RODB, clusterId,
 				return
 			}
 		}
-
 	}()
-
-	return device, done, nil
 }

--- a/apps/glusterfs/allocator_simple.go
+++ b/apps/glusterfs/allocator_simple.go
@@ -66,6 +66,24 @@ func loadRingFromDB(tx *bolt.Tx, clusterId string) (*SimpleAllocatorRing, error)
 	return ring, nil
 }
 
+func loadRingFromDeviceSource(dsrc DeviceSource) (
+	*SimpleAllocatorRing, error) {
+
+	ring := NewSimpleAllocatorRing()
+	dnl, err := dsrc.Devices()
+	if err != nil {
+		return nil, err
+	}
+	for _, dan := range dnl {
+		ring.Add(&SimpleDevice{
+			zone:     dan.Node.Info.Zone,
+			nodeId:   dan.Node.Info.Id,
+			deviceId: dan.Device.Info.Id,
+		})
+	}
+	return ring, nil
+}
+
 func getDeviceListFromDB(db wdb.RODB, clusterId,
 	brickId string) (SimpleDevices, error) {
 

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -122,24 +122,6 @@ func findDeviceAndBrickForSet(
 	return nil, nil, ErrNoSpace
 }
 
-func getCachedDevice(devcache map[string](*DeviceEntry),
-	tx *bolt.Tx,
-	deviceId string) (*DeviceEntry, error) {
-
-	// Get device entry from cache if possible
-	device, ok := devcache[deviceId]
-	if !ok {
-		// Get device entry from db otherwise
-		var err error
-		device, err = NewDeviceEntryFromId(tx, deviceId)
-		if err != nil {
-			return nil, err
-		}
-		devcache[deviceId] = device
-	}
-	return device, nil
-}
-
 func populateBrickSet(
 	opts PlacementOpts,
 	fetchDevice deviceFetcher,

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -37,6 +37,23 @@ func (bs *BrickSet) Full() bool {
 	return len(bs.Bricks) == bs.SetSize
 }
 
+// Drop returns a new brick set with the brick at the given
+// index removed. Does not preserve brick positioning and
+// is not suitable for position dependent allocations.
+func (bs *BrickSet) Drop(index int) *BrickSet {
+	bs2 := NewBrickSet(bs.SetSize)
+	bs2.Bricks = append(bs.Bricks[:index], bs.Bricks[index+1:]...)
+	return bs2
+}
+
+func (bs *BrickSet) String() string {
+	ids := []string{}
+	for _, b := range bs.Bricks {
+		ids = append(ids, b.Id())
+	}
+	return fmt.Sprintf("BrickSet(%v)%v", bs.SetSize, ids)
+}
+
 type DeviceSet struct {
 	SetSize int
 	Devices []*DeviceEntry
@@ -356,6 +373,8 @@ func (bp *StandardBrickPlacer) Replace(
 			"brick replace index out of bounds (got %v, set size %v)",
 			index, bs.SetSize)
 	}
+	logger.Info("Replace brick in brick set %v with index %v",
+		bs, index)
 
 	// we return a brick allocation for symmetry with PlaceAll
 	// but it only contains one pair of sets
@@ -373,7 +392,7 @@ func (bp *StandardBrickPlacer) Replace(
 	}
 
 	newBrickEntry, newDeviceEntry, err := findDeviceAndBrickForSet(
-		opts, dsrc.Device, pred, deviceCh, bs)
+		opts, dsrc.Device, pred, deviceCh, bs.Drop(index))
 	if err != nil {
 		return r, err
 	}

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -58,12 +58,10 @@ type BrickAllocation struct {
 	DeviceSets []*DeviceSet
 }
 
-type deviceFilter func(*BrickSet, *DeviceEntry) bool
-
 type deviceFetcher func(string) (*DeviceEntry, error)
 
 func tryAllocateBrickOnDevice(v *VolumeEntry,
-	pred deviceFilter,
+	pred DeviceFilter,
 	device *DeviceEntry,
 	bs *BrickSet, brick_size uint64) *BrickEntry {
 
@@ -92,7 +90,7 @@ func tryAllocateBrickOnDevice(v *VolumeEntry,
 
 func findDeviceAndBrickForSet(v *VolumeEntry,
 	fetchDevice deviceFetcher,
-	pred deviceFilter,
+	pred DeviceFilter,
 	deviceCh <-chan string,
 	bs *BrickSet,
 	brick_size uint64) (*BrickEntry, *DeviceEntry, error) {
@@ -137,7 +135,7 @@ func getCachedDevice(devcache map[string](*DeviceEntry),
 
 func populateBrickSet(v *VolumeEntry,
 	fetchDevice deviceFetcher,
-	pred deviceFilter,
+	pred DeviceFilter,
 	deviceCh <-chan string,
 	initId string,
 	brick_size uint64,

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -308,3 +308,34 @@ func (cds *ClusterDeviceSource) Node(id string) (*NodeEntry, error) {
 	}
 	return node, nil
 }
+
+type VolumePlacementOpts struct {
+	v            *VolumeEntry
+	brickSize    uint64
+	numBrickSets int
+}
+
+func NewVolumePlacementOpts(v *VolumeEntry,
+	brickSize uint64, numBrickSets int) *VolumePlacementOpts {
+	return &VolumePlacementOpts{v, brickSize, numBrickSets}
+}
+
+func (vp *VolumePlacementOpts) BrickSizes() (uint64, float64) {
+	return vp.brickSize, float64(vp.v.Info.Snapshot.Factor)
+}
+
+func (vp *VolumePlacementOpts) BrickOwner() string {
+	return vp.v.Info.Id
+}
+
+func (vp *VolumePlacementOpts) BrickGid() int64 {
+	return vp.v.Info.Gid
+}
+
+func (vp *VolumePlacementOpts) SetSize() int {
+	return vp.v.Durability.BricksInSet()
+}
+
+func (vp *VolumePlacementOpts) SetCount() int {
+	return vp.numBrickSets
+}

--- a/apps/glusterfs/brick_allocate_test.go
+++ b/apps/glusterfs/brick_allocate_test.go
@@ -37,6 +37,10 @@ func TestClusterDeviceSource(t *testing.T) {
 	)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
+	// this function will both verify that the ClusterDeviceSource
+	// meets the DeviceSource interface (at compile time). When
+	// using the return value it also makes sure we only use the
+	// functions that are part of the interface.
 	interfaceCheck := func(dsrc DeviceSource) DeviceSource {
 		return dsrc
 	}
@@ -173,6 +177,10 @@ func TestVolumePlacementOpts(t *testing.T) {
 	numSets, brickSize, err := gen()
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
+	// this function will both verify that the VolumePlacementOpts
+	// meets the PlacementOpts interface (at compile time). When
+	// using the return value it also makes sure we only use the
+	// functions that are part of the interface.
 	interfaceCheck := func(p PlacementOpts) PlacementOpts {
 		return p
 	}

--- a/apps/glusterfs/placer.go
+++ b/apps/glusterfs/placer.go
@@ -1,0 +1,76 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+type DeviceAndNode struct {
+	Device *DeviceEntry
+	Node   *NodeEntry
+}
+
+// DeviceSource is an abstraction used by the BrickPlacer to
+// get an initial list of devices where bricks can be placed
+// as well as converting device IDs to device entry objects.
+// The idea is to keep db/connection/caching logic away from
+// the placement algorithms in the placer interface.
+type DeviceSource interface {
+	// Devices returns a list of all the Device entries and the
+	// nodes that the device is on that can
+	// be considered for the upcoming brick placement.
+	Devices() ([]DeviceAndNode, error)
+	// Device looks up a device id and resolves it to a Device
+	// entry object.
+	Device(id string) (*DeviceEntry, error)
+	// Node looks up a node id and resolves it to a Node entry
+	// object.
+	Node(id string) (*NodeEntry, error)
+}
+
+// PlacementOpts is an interface that is meant for passing the
+// somewhat complex set of options needed by the placer code
+// and hiding the sources of the these values away from the
+// placer implementations.
+type PlacementOpts interface {
+	// BrickSizes returns values needed to calculate the
+	// size of the brick on disk.
+	BrickSizes() (uint64, float64)
+	// BrickOwner returns the ID of object that will "own" the brick
+	BrickOwner() string
+	// BrickGid return the ID of the GID the brick will use
+	BrickGid() int64
+	// SetSize returns the size of the Brick Sets that will be
+	// allocated.
+	SetSize() int
+	// SetCount returns the total number of Brick Sets that
+	// will be produced.
+	SetCount() int
+}
+
+// DeviceFilter functions can be defined by the caller of a
+// BrickPlacer to define what devices it wants the Placer
+// algorithm to exclude from the brick set.
+type DeviceFilter func(*BrickSet, *DeviceEntry) bool
+
+// BrickPlacer implementations take their source devices and
+// options and place new bricks on devices (if possible).
+// The exact placement depends on the implementation and
+// the input options.
+type BrickPlacer interface {
+	// PlaceAll constructs a full sequence of brick sets and
+	// corresponding device sets for those bricks.
+	PlaceAll(DeviceSource, PlacementOpts, DeviceFilter) (
+		*BrickAllocation, error)
+
+	// Replace constructs a brick allocation constrained to
+	// a single brick set where the brick set is already populated
+	// but a brick with the given index into the set needs to
+	// be replaced.
+	Replace(DeviceSource, PlacementOpts, DeviceFilter, *BrickSet, int) (
+		*BrickAllocation, error)
+}

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -2044,7 +2044,7 @@ func TestReplaceBrickInVolumeSelfHealQuorumNotMet(t *testing.T) {
 	}
 	brickId := be.Id()
 	err = v.replaceBrickInVolume(app.db, app.executor, brickId)
-	tests.Assert(t, err != nil, err)
+	tests.Assert(t, err != nil, "expected err != nil, got:", err)
 
 	oldNode := be.Info.NodeId
 	brickOnOldNode := false


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

This PR defines interfaces for a common Brick Placer that sits between the volume management code and the traditional allocator to abstract out the action of finding devices for bricks. This will be needed for future arbiter work. It also makes a nice clean boundary between the placement (allocation) logic and the rest of the code.

### Notes for the reviewer

I'm marking it RFC because I think this calls for a little discussion before merging, as this is a new "design." Also see notes below:

The functions that implement the placer logic are only slightly changed from their earlier versions. There is more room for refactoring but I figured I could wait until some of the real arbiter work lands to see what's common and what's not.

Everything is kind of crammed into brick_allocate.go. I think I want to break it up but I didn't do the work to handle that yet. I'd like to hear if others think I should do that in this PR.
