### PR TITLE
Arbiter brick placer

### DIFF
--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -33,6 +33,23 @@ func (bs *BrickSet) Add(b *BrickEntry) {
 	bs.Bricks = append(bs.Bricks, b)
 }
 
+func (bs *BrickSet) Insert(index int, b *BrickEntry) {
+	switch {
+	case index >= bs.SetSize:
+		panic(fmt.Errorf("Insert index (%v) out of bounds", index))
+	case index == len(bs.Bricks):
+		// we grow the bricks slice by one item
+		bs.Bricks = append(bs.Bricks, b)
+	case index < len(bs.Bricks):
+		// we replace an existing item
+		bs.Bricks[index] = b
+	default:
+		panic(fmt.Errorf(
+			"Brick set may only be extended one (index=%v, len=%v)",
+			index, len(bs.Bricks)))
+	}
+}
+
 func (bs *BrickSet) Full() bool {
 	return len(bs.Bricks) == bs.SetSize
 }
@@ -66,6 +83,23 @@ func NewDeviceSet(s int) *DeviceSet {
 func (ds *DeviceSet) Add(d *DeviceEntry) {
 	godbc.Require(!ds.Full())
 	ds.Devices = append(ds.Devices, d)
+}
+
+func (ds *DeviceSet) Insert(index int, d *DeviceEntry) {
+	switch {
+	case index >= ds.SetSize:
+		panic(fmt.Errorf("Insert index (%v) out of bounds", index))
+	case index == len(ds.Devices):
+		// we grow the bricks slice by one item
+		ds.Devices = append(ds.Devices, d)
+	case index < len(ds.Devices):
+		// we replace an existing item
+		ds.Devices[index] = d
+	default:
+		panic(fmt.Errorf(
+			"Brick set may only be extended one (index=%v, len=%v)",
+			index, len(ds.Devices)))
+	}
 }
 
 func (ds *DeviceSet) Full() bool {

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -398,6 +398,11 @@ func (bp *StandardBrickPlacer) Replace(
 	}
 	newBrickEntry.SetId(brickId)
 
+	// if this all seems like an awful lot of boilerplate
+	// and busy work, consider that in real gluster the positions
+	// of the bricks w/in the brickset are meaningful and
+	// this will make more sense in future position-aware placers
+	// (e.g. arbiter)
 	newBricks := make([]*BrickEntry, bs.SetSize)
 	newDevices := make([]*DeviceEntry, bs.SetSize)
 	for i := 0; i < bs.SetSize; i++ {

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -218,7 +218,7 @@ func allocateBricks(
 	err := db.View(func(tx *bolt.Tx) error {
 		var err error
 		dsrc := NewClusterDeviceSource(tx, cluster)
-		placer := NewStandardBrickPlacer()
+		placer := PlacerForVolume(v)
 		r, err = placer.PlaceAll(dsrc, opts, nil)
 		return err
 	})

--- a/apps/glusterfs/placer_arbiter.go
+++ b/apps/glusterfs/placer_arbiter.go
@@ -1,0 +1,297 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"fmt"
+
+	"github.com/heketi/heketi/pkg/utils"
+)
+
+var (
+	tryPlaceAgain error = fmt.Errorf("Placement failed. Try again.")
+)
+
+// ArbiterBrickPlacer is a Brick Placer implementation that can
+// place bricks for arbiter volumes. It works primarily by
+// dividing the devices into two "pools" - one for data bricks
+// and one for arbiter bricks and understanding that only
+// the last brick in the brick set is an arbiter brick.
+type ArbiterBrickPlacer struct {
+	// the following two function vars are to better support
+	// dep. injection & unit testing
+	canHostArbiter func(*DeviceEntry) bool
+	canHostData    func(*DeviceEntry) bool
+}
+
+// NewArbiterBrickPlacer returns a new placer for bricks in
+// a volume that supports the arbiter feature.
+func NewArbiterBrickPlacer() *ArbiterBrickPlacer {
+	return &ArbiterBrickPlacer{
+		canHostArbiter: func(d *DeviceEntry) bool { return true },
+		canHostData:    func(d *DeviceEntry) bool { return true },
+	}
+}
+
+// PlaceAll constructs a full BrickAllocation for a volume that
+// supports the arbiter feature.
+func (bp *ArbiterBrickPlacer) PlaceAll(
+	dsrc DeviceSource,
+	opts PlacementOpts,
+	pred DeviceFilter) (
+	*BrickAllocation, error) {
+
+	r := &BrickAllocation{
+		BrickSets:  []*BrickSet{},
+		DeviceSets: []*DeviceSet{},
+	}
+
+	numBrickSets := opts.SetCount()
+	for sn := 0; sn < numBrickSets; sn++ {
+		logger.Info("Allocating brick set #%v", sn)
+		bs, ds, err := bp.newSets(
+			dsrc,
+			opts,
+			pred)
+		if err != nil {
+			return r, err
+		}
+		r.BrickSets = append(r.BrickSets, bs)
+		r.DeviceSets = append(r.DeviceSets, ds)
+	}
+
+	return r, nil
+}
+
+// Replace swaps out a brick & device in the input brick set at the
+// given index for a new brick.
+func (bp *ArbiterBrickPlacer) Replace(
+	dsrc DeviceSource,
+	opts PlacementOpts,
+	pred DeviceFilter,
+	bs *BrickSet,
+	index int) (
+	*BrickAllocation, error) {
+
+	if index < 0 || index >= bs.SetSize {
+		return nil, fmt.Errorf(
+			"brick replace index out of bounds (got %v, set size %v)",
+			index, bs.SetSize)
+	}
+	logger.Info("Replace brick in brick set %v with index %v",
+		bs, index)
+
+	// we return a brick allocation for symmetry with PlaceAll
+	// but it only contains one pair of sets
+	r := &BrickAllocation{
+		BrickSets:  []*BrickSet{NewBrickSet(bs.SetSize)},
+		DeviceSets: []*DeviceSet{NewDeviceSet(bs.SetSize)},
+	}
+	wbs := r.BrickSets[0]
+	wds := r.DeviceSets[0]
+
+	dscan, err := bp.Scanner(dsrc)
+	if err != nil {
+		return r, err
+	}
+	defer dscan.Close()
+
+	// copy input brick set to working brick set and get the
+	// corresponding device entries for the device set
+	for i, b := range bs.Bricks {
+		d, err := dsrc.Device(b.Info.DeviceId)
+		if err != nil {
+			return r, err
+		}
+		wbs.Insert(i, b)
+		wds.Insert(i, d)
+	}
+	err = bp.placeBrickInSet(dsrc, dscan, opts, pred, wbs, wds, index)
+	return r, err
+}
+
+// newSets returns a new fully populated pair of brick and device sets.
+// If new sets can not be placed err will be non-nil.
+func (bp *ArbiterBrickPlacer) newSets(
+	dsrc DeviceSource,
+	opts PlacementOpts,
+	pred DeviceFilter) (*BrickSet, *DeviceSet, error) {
+
+	ssize := opts.SetSize()
+	bs := NewBrickSet(ssize)
+	ds := NewDeviceSet(ssize)
+	dscan, err := bp.Scanner(dsrc)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer dscan.Close()
+
+	for index := 0; index < ssize; index++ {
+		err := bp.placeBrickInSet(dsrc, dscan, opts, pred, bs, ds, index)
+		if err != nil {
+			return bs, ds, err
+		}
+	}
+	return bs, ds, nil
+}
+
+// placeBrickInSet uses the device scanner to find a device suitable
+// for a new brick at the given index. If no devices can be found for
+// the brick err will be non-nil.
+func (bp *ArbiterBrickPlacer) placeBrickInSet(
+	dsrc DeviceSource,
+	dscan *arbiterDeviceScanner,
+	opts PlacementOpts,
+	pred DeviceFilter,
+	bs *BrickSet,
+	ds *DeviceSet,
+	index int) error {
+
+	logger.Info("Placing brick in brick set at position %v", index)
+	for deviceId := range dscan.Scan(index) {
+
+		device, err := dsrc.Device(deviceId)
+		if err != nil {
+			return err
+		}
+
+		err = bp.tryPlaceBrickOnDevice(
+			opts, pred, bs, ds, index, device)
+		switch err {
+		case tryPlaceAgain:
+			continue
+		case nil:
+			logger.Debug("Placed brick at index %v on device %v",
+				index, deviceId)
+			return nil
+		default:
+			return err
+		}
+	}
+
+	// we exhausted all possible devices for this brick
+	logger.Debug("Can not find any device for brick (index=%v)", index)
+	return ErrNoSpace
+}
+
+// tryPlaceBrickOnDevice attempts to place a brick on the given device.
+// If placement is successful the brick and device sets are updated,
+// and the error is nil.
+// If placement fails then tryPlaceAgain error is returned.
+func (bp *ArbiterBrickPlacer) tryPlaceBrickOnDevice(
+	opts PlacementOpts,
+	pred DeviceFilter,
+	bs *BrickSet,
+	ds *DeviceSet,
+	index int,
+	device *DeviceEntry) error {
+
+	logger.Debug("Trying to place brick on device %v", device.Info.Id)
+
+	for _, b := range bs.Bricks {
+		if b.Info.NodeId == device.NodeId {
+			// this node is used by an existing brick in the set
+			// we can not use this device
+			logger.Debug("Node %v already in use by brick set (device %v)",
+				device.NodeId, device.Info.Id)
+			return tryPlaceAgain
+		}
+	}
+
+	if pred != nil && !pred(bs, device) {
+		logger.Debug("Device %v rejected by predicate function", device.Info.Id)
+		return tryPlaceAgain
+	}
+
+	// Try to allocate a brick on this device
+	brickSize, snapFactor := opts.BrickSizes()
+	brick := device.NewBrickEntry(brickSize, snapFactor,
+		opts.BrickGid(), opts.BrickOwner())
+	if brick == nil {
+		logger.Debug(
+			"Unable to place a brick of size %v & factor %v on device %v",
+			brickSize, snapFactor, device.Info.Id)
+		return tryPlaceAgain
+	}
+
+	device.BrickAdd(brick.Id())
+	bs.Insert(index, brick)
+	ds.Insert(index, device)
+	return nil
+}
+
+type arbiterDeviceScanner struct {
+	arbiterDevs <-chan string
+	arbiterDone chan struct{}
+	dataDevs    <-chan string
+	dataDone    chan struct{}
+}
+
+// Scanner returns a pointer to an arbiterDeviceScanner helper object.
+// This object can be used to range over the devices that a brick
+// may be placed on. The .Close method must be called to release
+// resources associated with this object.
+func (bp *ArbiterBrickPlacer) Scanner(dsrc DeviceSource) (
+	*arbiterDeviceScanner, error) {
+
+	dataRing := NewSimpleAllocatorRing()
+	arbiterRing := NewSimpleAllocatorRing()
+	dnl, err := dsrc.Devices()
+	if err != nil {
+		return nil, err
+	}
+	for _, dan := range dnl {
+		sd := &SimpleDevice{
+			zone:     dan.Node.Info.Zone,
+			nodeId:   dan.Node.Info.Id,
+			deviceId: dan.Device.Info.Id,
+		}
+		// it is perfectly fine for a device to host data & arbiter
+		// bricks if it is so configured. Thus both the following
+		// blocks may be true.
+		if bp.canHostArbiter(dan.Device) {
+			arbiterRing.Add(sd)
+		}
+		if bp.canHostData(dan.Device) {
+			dataRing.Add(sd)
+		}
+	}
+
+	id := utils.GenUUID()
+	dataDevs, dataDone := make(chan string), make(chan struct{})
+	generateDevices(dataRing.GetDeviceList(id), dataDevs, dataDone)
+	arbiterDevs, arbiterDone := make(chan string), make(chan struct{})
+	generateDevices(arbiterRing.GetDeviceList(id), arbiterDevs, arbiterDone)
+	return &arbiterDeviceScanner{
+		arbiterDevs: arbiterDevs,
+		arbiterDone: arbiterDone,
+		dataDevs:    dataDevs,
+		dataDone:    dataDone,
+	}, nil
+}
+
+// Close releases the resources held by the scanner.
+func (dscan *arbiterDeviceScanner) Close() {
+	close(dscan.arbiterDone)
+	close(dscan.dataDone)
+}
+
+// Scan returns a channel that may be ranged over for eligible devices
+// for a brick in a brick set with the position specified by index.
+func (dscan *arbiterDeviceScanner) Scan(index int) <-chan string {
+	// currently this is hard-coded such that the index of
+	// an arbiter brick is always two (the 3rd brick in the set of three)
+	// In the future we may want to be smarter here, but this
+	// works for now.
+	if index == 2 {
+		return dscan.arbiterDevs
+	}
+	return dscan.dataDevs
+}

--- a/apps/glusterfs/placer_arbiter.go
+++ b/apps/glusterfs/placer_arbiter.go
@@ -231,7 +231,15 @@ func (bp *ArbiterBrickPlacer) tryPlaceBrickOnDevice(
 
 	logger.Debug("Trying to place brick on device %v", device.Info.Id)
 
-	for _, b := range bs.Bricks {
+	for i, b := range bs.Bricks {
+		// do not check the brick in the brick set for the current
+		// index. If this is a new brick set we won't have the index
+		// populated. If this is a replace, we will have the old brick
+		// at the index and we are OK with re-using its node (as the
+		// standard placer does)
+		if i == index {
+			continue
+		}
 		if b.Info.NodeId == device.NodeId {
 			// this node is used by an existing brick in the set
 			// we can not use this device

--- a/apps/glusterfs/placer_arbiter_test.go
+++ b/apps/glusterfs/placer_arbiter_test.go
@@ -1,0 +1,717 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/heketi/tests"
+)
+
+type TestDeviceSource struct {
+	devices      map[string]*DeviceEntry
+	nodes        map[string]*NodeEntry
+	devicesError error
+}
+
+func NewTestDeviceSource() *TestDeviceSource {
+	return &TestDeviceSource{
+		devices: map[string]*DeviceEntry{},
+		nodes:   map[string]*NodeEntry{},
+	}
+}
+
+func (tds *TestDeviceSource) AddDevice(d *DeviceEntry) {
+	tds.devices[d.Info.Id] = d
+}
+
+func (tds *TestDeviceSource) AddNode(n *NodeEntry) {
+	tds.nodes[n.Info.Id] = n
+}
+
+func (tds *TestDeviceSource) QuickAdd(
+	nodeId, deviceId, dname string, size uint64) {
+
+	tds.MultiAdd(nodeId)(deviceId, dname, size)
+}
+
+func (tds *TestDeviceSource) MultiAdd(nodeId string) func(string, string, uint64) {
+
+	n := NewNodeEntry()
+	n.Info.Id = nodeId
+	n.Info.Zone = 1
+	n.Info.Hostnames.Manage = []string{"mng-" + nodeId}
+	n.Info.Hostnames.Storage = []string{"stor-" + nodeId}
+	n.Info.ClusterId = "0000000000c"
+	tds.AddNode(n)
+
+	return func(deviceId, dname string, size uint64) {
+		d := NewDeviceEntry()
+		d.Info.Id = deviceId
+		d.Info.Name = dname
+		d.Info.Storage.Total = size
+		d.Info.Storage.Free = size
+		d.NodeId = nodeId
+
+		n.Devices = append(n.Devices, d.Info.Id)
+		tds.AddDevice(d)
+	}
+}
+
+func (tds *TestDeviceSource) Devices() ([]DeviceAndNode, error) {
+	if tds.devicesError != nil {
+		return nil, tds.devicesError
+	}
+	valid := [](DeviceAndNode){}
+	for _, node := range tds.nodes {
+		for _, deviceId := range node.Devices {
+			device, ok := tds.devices[deviceId]
+			if !ok {
+				return nil, ErrNotFound
+			}
+			valid = append(valid, DeviceAndNode{
+				Device: device,
+				Node:   node,
+			})
+		}
+	}
+	return valid, nil
+}
+
+func (tds *TestDeviceSource) Device(id string) (*DeviceEntry, error) {
+	if device, ok := tds.devices[id]; ok {
+		return device, nil
+	}
+	return nil, ErrNotFound
+}
+
+func (tds *TestDeviceSource) Node(id string) (*NodeEntry, error) {
+	if node, ok := tds.nodes[id]; ok {
+		return node, nil
+	}
+	return nil, ErrNotFound
+}
+
+type TestPlacementOpts struct {
+	brickSize       uint64
+	brickSnapFactor float64
+	brickOwner      string
+	brickGid        int64
+	setSize         int
+	setCount        int
+}
+
+func (tpo *TestPlacementOpts) BrickSizes() (uint64, float64) {
+	return tpo.brickSize, tpo.brickSnapFactor
+}
+
+func (tpo *TestPlacementOpts) BrickOwner() string {
+	return tpo.brickOwner
+}
+
+func (tpo *TestPlacementOpts) BrickGid() int64 {
+	return tpo.brickGid
+}
+
+func (tpo *TestPlacementOpts) SetSize() int {
+	return tpo.setSize
+}
+
+func (tpo *TestPlacementOpts) SetCount() int {
+	return tpo.setCount
+}
+
+func TestTestDeviceSource(t *testing.T) {
+	dsrc := NewTestDeviceSource()
+	dsrc.QuickAdd(
+		"10000000",
+		"11111111",
+		"/dev/foobar",
+		1100)
+	dsrc.QuickAdd(
+		"20000000",
+		"22222222",
+		"/dev/foobar",
+		1200)
+	dsrc.QuickAdd(
+		"30000000",
+		"33333333",
+		"/dev/foobar",
+		1300)
+
+	tests.Assert(t, len(dsrc.devices) == 3,
+		"expected len(dsrc.devices) == 3, got:", len(dsrc.devices))
+	tests.Assert(t, len(dsrc.nodes) == 3,
+		"expected len(dsrc.nodes) == 3, got:", len(dsrc.nodes))
+
+	d, err := dsrc.Device("22222222")
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, d.Info.Storage.Total == 1200,
+		"expected d.Info.Storage.Total == 1200, got:", d.Info.Storage.Total)
+
+	d, err = dsrc.Device("10000000")
+	tests.Assert(t, err == ErrNotFound, "expected err == ErrNotFound, got:", err)
+
+	n, err := dsrc.Node("30000000")
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, n.Info.Hostnames.Manage[0] == "mng-30000000",
+		"expected n.Info.Hostnames.Manage[0] == \"mng-30000000\", got:",
+		n.Info.Hostnames.Manage[0])
+
+	n, err = dsrc.Node("abcdefgh")
+	tests.Assert(t, err == ErrNotFound, "expected err == ErrNotFound, got:", err)
+
+	dnl, err := dsrc.Devices()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(dnl) == 3,
+		"expected len(dnl) == 3, got:", len(dnl))
+}
+
+func TestTestDeviceSourceMultiAdd(t *testing.T) {
+	dsrc := NewTestDeviceSource()
+	addDev := dsrc.MultiAdd("abcd")
+	addDev("d1", "/dev/x1", 10)
+	addDev("d2", "/dev/x2", 20)
+	addDev("d3", "/dev/x3", 30)
+	addDev = dsrc.MultiAdd("foo")
+	addDev("d4", "/dev/x1", 40)
+	addDev("d5", "/dev/x2", 50)
+	dsrc.MultiAdd("bar")("d6", "/dev/x1", 60)
+
+	tests.Assert(t, len(dsrc.devices) == 6,
+		"expected len(dsrc.devices) == 6, got:", len(dsrc.devices))
+	tests.Assert(t, len(dsrc.nodes) == 3,
+		"expected len(dsrc.nodes) == 3, got:", len(dsrc.nodes))
+
+	dnl, err := dsrc.Devices()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(dnl) == 6,
+		"expected len(dnl) == 6, got:", len(dnl))
+}
+
+func TestArbiterBrickPlacer(t *testing.T) {
+	dsrc := NewTestDeviceSource()
+	dsrc.QuickAdd(
+		"10000000",
+		"11111111",
+		"/dev/foobar",
+		11000)
+	dsrc.QuickAdd(
+		"20000000",
+		"22222222",
+		"/dev/foobar",
+		12000)
+	dsrc.QuickAdd(
+		"30000000",
+		"33333333",
+		"/dev/foobar",
+		13000)
+	opts := &TestPlacementOpts{
+		brickSize:       50,
+		brickSnapFactor: 0.3,
+		brickOwner:      "asdfasdf",
+		setSize:         3,
+		setCount:        1,
+	}
+
+	abplacer := NewArbiterBrickPlacer()
+	ba, err := abplacer.PlaceAll(dsrc, opts, nil)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(ba.BrickSets) == 1,
+		"expected len(ba.BrickSets) == 1, got:", len(ba.BrickSets))
+}
+
+func TestArbiterBrickPlacerTooSmall(t *testing.T) {
+	dsrc := NewTestDeviceSource()
+	dsrc.QuickAdd(
+		"10000000",
+		"11111111",
+		"/dev/foobar",
+		110)
+	dsrc.QuickAdd(
+		"20000000",
+		"22222222",
+		"/dev/foobar",
+		120)
+	dsrc.QuickAdd(
+		"30000000",
+		"33333333",
+		"/dev/foobar",
+		130)
+	opts := &TestPlacementOpts{
+		brickSize:       50,
+		brickSnapFactor: 0.3,
+		brickOwner:      "asdfasdf",
+		setSize:         3,
+		setCount:        1,
+	}
+
+	abplacer := NewArbiterBrickPlacer()
+	_, err := abplacer.PlaceAll(dsrc, opts, nil)
+	tests.Assert(t, err == ErrNoSpace, "expected err == ErrNoSpace, got:", err)
+}
+
+func TestArbiterBrickPlacerDevicesFail(t *testing.T) {
+	dsrc := NewTestDeviceSource()
+	dsrc.devicesError = fmt.Errorf("Zonk!")
+
+	opts := &TestPlacementOpts{
+		brickSize:       50,
+		brickSnapFactor: 0.3,
+		brickOwner:      "asdfasdf",
+		setSize:         3,
+		setCount:        1,
+	}
+
+	abplacer := NewArbiterBrickPlacer()
+	_, err := abplacer.PlaceAll(dsrc, opts, nil)
+	tests.Assert(t, err == dsrc.devicesError,
+		"expected err == dsrc.devicesError, got:", err)
+}
+
+func TestArbiterBrickPlacerPredicateBlock(t *testing.T) {
+	dsrc := NewTestDeviceSource()
+	dsrc.QuickAdd(
+		"10000000",
+		"11111111",
+		"/dev/foobar",
+		110)
+	dsrc.QuickAdd(
+		"20000000",
+		"22222222",
+		"/dev/foobar",
+		120)
+	dsrc.QuickAdd(
+		"30000000",
+		"33333333",
+		"/dev/foobar",
+		130)
+	opts := &TestPlacementOpts{
+		brickSize:       50,
+		brickSnapFactor: 0.3,
+		brickOwner:      "asdfasdf",
+		setSize:         3,
+		setCount:        1,
+	}
+
+	abplacer := NewArbiterBrickPlacer()
+	pred := func(bs *BrickSet, d *DeviceEntry) bool {
+		return false
+	}
+	_, err := abplacer.PlaceAll(dsrc, opts, pred)
+	tests.Assert(t, err == ErrNoSpace, "expected err == ErrNoSpace, got:", err)
+}
+
+func TestArbiterBrickPlacerBrickOnArbiterDevice(t *testing.T) {
+	dsrc := NewTestDeviceSource()
+	dsrc.QuickAdd(
+		"10000000",
+		"11111111",
+		"/dev/foobar",
+		21000)
+	dsrc.QuickAdd(
+		"20000000",
+		"22222222",
+		"/dev/foobar",
+		22000)
+	dsrc.QuickAdd(
+		"30000000",
+		"a3333333",
+		"/dev/foobar",
+		23000)
+	opts := &TestPlacementOpts{
+		brickSize:       10,
+		brickSnapFactor: 0.3,
+		brickOwner:      "asdfasdf",
+		setSize:         3,
+		setCount:        1,
+	}
+
+	abplacer := NewArbiterBrickPlacer()
+	abplacer.canHostArbiter = func(d *DeviceEntry) bool {
+		return d.Info.Id[0] == 'a'
+	}
+	abplacer.canHostData = func(d *DeviceEntry) bool {
+		return !abplacer.canHostArbiter(d)
+	}
+	ba, err := abplacer.PlaceAll(dsrc, opts, nil)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(ba.BrickSets) == 1,
+		"expected len(ba.BrickSets) == 1, got:", len(ba.BrickSets))
+	tests.Assert(t, ba.BrickSets[0].Bricks[2].Info.DeviceId == "a3333333",
+		`expected ba.BrickSets[0].Bricks[2].Info.DeviceId == "a3333333", got:`,
+		ba.BrickSets[0].Bricks[2].Info.DeviceId)
+	tests.Assert(t, ba.DeviceSets[0].Devices[2].Info.Id == "a3333333",
+		`expected ba.DeviceSets[0].Devices[2].Info.Id == "a3333333", got`,
+		ba.DeviceSets[0].Devices[2].Info.Id)
+}
+
+func TestArbiterBrickPlacerBrickThreeSets(t *testing.T) {
+	dsrc := NewTestDeviceSource()
+	addDev := dsrc.MultiAdd("10000000")
+	addDev("11111111", "/dev/d1", 10001)
+	addDev("21111111", "/dev/d2", 10002)
+	addDev("31111111", "/dev/d3", 10003)
+	addDev = dsrc.MultiAdd("20000000")
+	addDev("41111111", "/dev/d1", 10001)
+	addDev("51111111", "/dev/d2", 10002)
+	addDev("61111111", "/dev/d3", 10003)
+	addDev = dsrc.MultiAdd("30000000")
+	addDev("71111111", "/dev/d1", 10001)
+	addDev("81111111", "/dev/d2", 10002)
+	addDev("91111111", "/dev/d3", 10003)
+
+	opts := &TestPlacementOpts{
+		brickSize:       100,
+		brickSnapFactor: 0.3,
+		brickOwner:      "asdfasdf",
+		setSize:         3,
+		setCount:        3,
+	}
+
+	abplacer := NewArbiterBrickPlacer()
+	ba, err := abplacer.PlaceAll(dsrc, opts, nil)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(ba.BrickSets) == 3,
+		"expected len(ba.BrickSets) == 3, got:", len(ba.BrickSets))
+}
+
+func TestArbiterBrickPlacerBrickThreeSetsOnArbiterDevice(t *testing.T) {
+	dsrc := NewTestDeviceSource()
+	addDev := dsrc.MultiAdd("10000000")
+	// data nodes
+	addDev("11111111", "/dev/d1", 10001)
+	addDev("21111111", "/dev/d2", 10002)
+	addDev = dsrc.MultiAdd("20000000")
+	addDev("31111111", "/dev/d1", 10001)
+	addDev("41111111", "/dev/d2", 10002)
+	addDev = dsrc.MultiAdd("30000000")
+	addDev("51111111", "/dev/d1", 10001)
+	addDev("61111111", "/dev/d2", 10002)
+	addDev = dsrc.MultiAdd("40000000")
+	addDev("71111111", "/dev/d1", 10001)
+	addDev("81111111", "/dev/d2", 10002)
+	// arbiter nodes
+	addDev = dsrc.MultiAdd("50000000")
+	addDev("a1111111", "/dev/d1", 10001)
+	addDev = dsrc.MultiAdd("60000000")
+	addDev("a2111111", "/dev/d1", 10001)
+	addDev = dsrc.MultiAdd("70000000")
+	addDev("a3111111", "/dev/d1", 10001)
+	// the above configuration is pretty artificial and reflects
+	// a downside to the current approach. because of the
+	// non-deterministic way the ring provides devices and
+	// the (hard) requirement not to reuse a node within the brick
+	// set its fairly easy with small devices to run into a situation
+	// where the placement fails even though the configuration could
+	// have hosted the volume. There are things we can do to
+	// improve this but not now and not for this test. :-\
+
+	opts := &TestPlacementOpts{
+		brickSize:       100,
+		brickSnapFactor: 0.3,
+		brickOwner:      "asdfasdf",
+		setSize:         3,
+		setCount:        3,
+	}
+
+	abplacer := NewArbiterBrickPlacer()
+	abplacer.canHostArbiter = func(d *DeviceEntry) bool {
+		return d.Info.Id[0] == 'a'
+	}
+	abplacer.canHostData = func(d *DeviceEntry) bool {
+		return !abplacer.canHostArbiter(d)
+	}
+	ba, err := abplacer.PlaceAll(dsrc, opts, nil)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(ba.BrickSets) == 3,
+		"expected len(ba.BrickSets) == 3, got:", len(ba.BrickSets))
+	for i := 0; i < 3; i++ {
+		for j := 0; j < 3; j++ {
+			brickDeviceId := ba.BrickSets[i].Bricks[j].Info.DeviceId
+			prefixA := (brickDeviceId[0] == 'a')
+			if j == 2 {
+				tests.Assert(t, prefixA, "expected prefixA true on index", j)
+			} else {
+				tests.Assert(t, !prefixA, "expected prefixA false on index", j)
+			}
+		}
+	}
+}
+
+func TestArbiterBrickPlacerSimpleReplace(t *testing.T) {
+	dsrc := NewTestDeviceSource()
+	dsrc.QuickAdd(
+		"10000000",
+		"11111111",
+		"/dev/foobar",
+		21000)
+	dsrc.QuickAdd(
+		"20000000",
+		"22222222",
+		"/dev/foobar",
+		22000)
+	dsrc.QuickAdd(
+		"30000000",
+		"33333333",
+		"/dev/foobar",
+		23000)
+	dsrc.QuickAdd(
+		"40000000",
+		"44444444",
+		"/dev/foobar",
+		23000)
+
+	opts := &TestPlacementOpts{
+		brickSize:       50,
+		brickSnapFactor: 0.3,
+		brickOwner:      "asdfasdf",
+		setSize:         3,
+		setCount:        1,
+	}
+
+	abplacer := NewArbiterBrickPlacer()
+	ba, err := abplacer.PlaceAll(dsrc, opts, nil)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(ba.BrickSets) == 1,
+		"expected len(ba.BrickSets) == 1, got:", len(ba.BrickSets))
+	tests.Assert(t, len(ba.BrickSets[0].Bricks) == 3,
+		"expected len(ba.BrickSets[0].Bricks) == 3, got:",
+		len(ba.BrickSets[0].Bricks))
+
+	ba2, err := abplacer.Replace(dsrc, opts, nil, ba.BrickSets[0], 0)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(ba2.BrickSets) == 1,
+		"expected len(ba2.BrickSets) == 1, got:", len(ba2.BrickSets))
+	tests.Assert(t, len(ba2.BrickSets[0].Bricks) == 3,
+		"expected len(ba2.BrickSets[0].Bricks) == 3, got:",
+		len(ba2.BrickSets[0].Bricks))
+
+	bs1 := ba.BrickSets[0]
+	bs2 := ba2.BrickSets[0]
+	// we replaced the 1st brick, thus it should differ
+	tests.Assert(t,
+		bs1.Bricks[0].Info.Id != bs2.Bricks[0].Info.Id,
+		"expected bs1.Bricks[0].Info.Id == bs2.Bricks[0].Info.Id, got:",
+		bs1.Bricks[0].Info.Id, bs2.Bricks[0].Info.Id)
+	// the remaining bricks will be the same
+	tests.Assert(t,
+		bs1.Bricks[1].Info.Id == bs2.Bricks[1].Info.Id,
+		"expected bs1.Bricks[1].Info.Id == bs2.Bricks[1].Info.Id, got:",
+		bs1.Bricks[1].Info.Id, bs2.Bricks[1].Info.Id)
+	tests.Assert(t,
+		bs1.Bricks[2].Info.Id == bs2.Bricks[2].Info.Id,
+		"expected bs1.Bricks[2].Info.Id == bs2.Bricks[2].Info.Id, got:",
+		bs1.Bricks[2].Info.Id, bs2.Bricks[2].Info.Id)
+}
+
+func TestArbiterBrickPlacerReplaceIndexOOB(t *testing.T) {
+	dsrc := NewTestDeviceSource()
+	dsrc.QuickAdd(
+		"10000000",
+		"11111111",
+		"/dev/foobar",
+		21000)
+	dsrc.QuickAdd(
+		"20000000",
+		"22222222",
+		"/dev/foobar",
+		22000)
+	dsrc.QuickAdd(
+		"30000000",
+		"33333333",
+		"/dev/foobar",
+		23000)
+
+	opts := &TestPlacementOpts{
+		brickSize:       50,
+		brickSnapFactor: 0.3,
+		brickOwner:      "asdfasdf",
+		setSize:         3,
+		setCount:        1,
+	}
+
+	abplacer := NewArbiterBrickPlacer()
+	ba, err := abplacer.PlaceAll(dsrc, opts, nil)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(ba.BrickSets) == 1,
+		"expected len(ba.BrickSets) == 1, got:", len(ba.BrickSets))
+	tests.Assert(t, len(ba.BrickSets[0].Bricks) == 3,
+		"expected len(ba.BrickSets[0].Bricks) == 3, got:",
+		len(ba.BrickSets[0].Bricks))
+
+	_, err = abplacer.Replace(dsrc, opts, nil, ba.BrickSets[0], -1)
+	tests.Assert(t, strings.Contains(err.Error(), "out of bounds"),
+		`expected strings.Contains(err.Error(), "out of bounds"), got:`,
+		err.Error())
+
+	_, err = abplacer.Replace(dsrc, opts, nil, ba.BrickSets[0], 9)
+	tests.Assert(t, strings.Contains(err.Error(), "out of bounds"),
+		`expected strings.Contains(err.Error(), "out of bounds"), got:`,
+		err.Error())
+}
+
+func TestArbiterBrickPlacerReplaceDevicesFail(t *testing.T) {
+	dsrc := NewTestDeviceSource()
+	dsrc.QuickAdd(
+		"10000000",
+		"11111111",
+		"/dev/foobar",
+		21000)
+	dsrc.QuickAdd(
+		"20000000",
+		"22222222",
+		"/dev/foobar",
+		22000)
+	dsrc.QuickAdd(
+		"30000000",
+		"33333333",
+		"/dev/foobar",
+		23000)
+	dsrc.QuickAdd(
+		"40000000",
+		"44444444",
+		"/dev/foobar",
+		23000)
+
+	opts := &TestPlacementOpts{
+		brickSize:       50,
+		brickSnapFactor: 0.3,
+		brickOwner:      "asdfasdf",
+		setSize:         3,
+		setCount:        1,
+	}
+
+	abplacer := NewArbiterBrickPlacer()
+	ba, err := abplacer.PlaceAll(dsrc, opts, nil)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(ba.BrickSets) == 1,
+		"expected len(ba.BrickSets) == 1, got:", len(ba.BrickSets))
+	tests.Assert(t, len(ba.BrickSets[0].Bricks) == 3,
+		"expected len(ba.BrickSets[0].Bricks) == 3, got:",
+		len(ba.BrickSets[0].Bricks))
+
+	dsrc.devicesError = fmt.Errorf("Zonk!")
+	_, err = abplacer.Replace(dsrc, opts, nil, ba.BrickSets[0], 0)
+	tests.Assert(t, err == dsrc.devicesError,
+		"expected err == dsrc.devicesError, got:", err)
+}
+
+func TestArbiterBrickPlacerReplaceTooFew(t *testing.T) {
+	dsrc := NewTestDeviceSource()
+	dsrc.QuickAdd(
+		"10000000",
+		"11111111",
+		"/dev/foobar",
+		21000)
+	dsrc.QuickAdd(
+		"20000000",
+		"22222222",
+		"/dev/foobar",
+		22000)
+	dsrc.QuickAdd(
+		"30000000",
+		"33333333",
+		"/dev/foobar",
+		23000)
+
+	opts := &TestPlacementOpts{
+		brickSize:       50,
+		brickSnapFactor: 0.3,
+		brickOwner:      "asdfasdf",
+		setSize:         3,
+		setCount:        1,
+	}
+
+	abplacer := NewArbiterBrickPlacer()
+	ba, err := abplacer.PlaceAll(dsrc, opts, nil)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(ba.BrickSets) == 1,
+		"expected len(ba.BrickSets) == 1, got:", len(ba.BrickSets))
+	tests.Assert(t, len(ba.BrickSets[0].Bricks) == 3,
+		"expected len(ba.BrickSets[0].Bricks) == 3, got:",
+		len(ba.BrickSets[0].Bricks))
+
+	_, err = abplacer.Replace(dsrc, opts, nil, ba.BrickSets[0], 0)
+	tests.Assert(t, err == ErrNoSpace,
+		"expected err == ErrNoSpace, got:", err)
+}
+
+func TestArbiterBrickPlacerReplaceTooFewArbiter(t *testing.T) {
+	dsrc := NewTestDeviceSource()
+	dsrc.QuickAdd(
+		"10000000",
+		"11111111",
+		"/dev/foobar",
+		21000)
+	dsrc.QuickAdd(
+		"20000000",
+		"22222222",
+		"/dev/foobar",
+		22000)
+	dsrc.QuickAdd(
+		"30000000",
+		"33333333",
+		"/dev/foobar",
+		23000)
+	dsrc.QuickAdd(
+		"40000000",
+		"44444444",
+		"/dev/foobar",
+		24000)
+	dsrc.QuickAdd(
+		"50000000",
+		"a5555555",
+		"/dev/foobar",
+		25000)
+	// we have enough devices for a generic replace but not
+	// when we're limited to certain devices
+
+	opts := &TestPlacementOpts{
+		brickSize:       50,
+		brickSnapFactor: 0.3,
+		brickOwner:      "asdfasdf",
+		setSize:         3,
+		setCount:        1,
+	}
+
+	abplacer := NewArbiterBrickPlacer()
+	abplacer.canHostArbiter = func(d *DeviceEntry) bool {
+		return d.Info.Id[0] == 'a'
+	}
+	abplacer.canHostData = func(d *DeviceEntry) bool {
+		return !abplacer.canHostArbiter(d)
+	}
+
+	ba, err := abplacer.PlaceAll(dsrc, opts, nil)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(ba.BrickSets) == 1,
+		"expected len(ba.BrickSets) == 1, got:", len(ba.BrickSets))
+	tests.Assert(t, len(ba.BrickSets[0].Bricks) == 3,
+		"expected len(ba.BrickSets[0].Bricks) == 3, got:",
+		len(ba.BrickSets[0].Bricks))
+
+	// this will fail because we have no more "arbiter devices"
+	_, err = abplacer.Replace(dsrc, opts, nil, ba.BrickSets[0], 2)
+	tests.Assert(t, err == ErrNoSpace,
+		"expected err == ErrNoSpace, got:", err)
+
+	// this one will work because the free device is not arbiter
+	// and the 1 position is a data brick
+	ba2, err := abplacer.Replace(dsrc, opts, nil, ba.BrickSets[0], 1)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(ba2.BrickSets) == 1,
+		"expected len(ba2.BrickSets) == 1, got:", len(ba2.BrickSets))
+	tests.Assert(t, len(ba2.BrickSets[0].Bricks) == 3,
+		"expected len(ba2.BrickSets[0].Bricks) == 3, got:",
+		len(ba2.BrickSets[0].Bricks))
+}

--- a/apps/glusterfs/placer_arbiter_test.go
+++ b/apps/glusterfs/placer_arbiter_test.go
@@ -654,7 +654,10 @@ func TestArbiterBrickPlacerReplaceTooFew(t *testing.T) {
 		"expected len(ba.BrickSets[0].Bricks) == 3, got:",
 		len(ba.BrickSets[0].Bricks))
 
-	_, err = abplacer.Replace(dsrc, opts, nil, ba.BrickSets[0], 0)
+	pred := func(bs *BrickSet, d *DeviceEntry) bool {
+		return ba.BrickSets[0].Bricks[0].Info.DeviceId != d.Info.Id
+	}
+	_, err = abplacer.Replace(dsrc, opts, pred, ba.BrickSets[0], 0)
 	tests.Assert(t, err == ErrNoSpace,
 		"expected err == ErrNoSpace, got:", err)
 }
@@ -714,7 +717,10 @@ func TestArbiterBrickPlacerReplaceTooFewArbiter(t *testing.T) {
 		len(ba.BrickSets[0].Bricks))
 
 	// this will fail because we have no more "arbiter devices"
-	_, err = abplacer.Replace(dsrc, opts, nil, ba.BrickSets[0], 2)
+	pred := func(bs *BrickSet, d *DeviceEntry) bool {
+		return ba.BrickSets[0].Bricks[2].Info.DeviceId != d.Info.Id
+	}
+	_, err = abplacer.Replace(dsrc, opts, pred, ba.BrickSets[0], 2)
 	tests.Assert(t, err == ErrNoSpace,
 		"expected err == ErrNoSpace, got:", err)
 

--- a/apps/glusterfs/placer_arbiter_test.go
+++ b/apps/glusterfs/placer_arbiter_test.go
@@ -216,7 +216,7 @@ func TestArbiterBrickPlacer(t *testing.T) {
 		"/dev/foobar",
 		13000)
 	opts := &TestPlacementOpts{
-		brickSize:       50,
+		brickSize:       800,
 		brickSnapFactor: 0.3,
 		brickOwner:      "asdfasdf",
 		setSize:         3,
@@ -228,6 +228,19 @@ func TestArbiterBrickPlacer(t *testing.T) {
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, len(ba.BrickSets) == 1,
 		"expected len(ba.BrickSets) == 1, got:", len(ba.BrickSets))
+
+	tests.Assert(t, ba.BrickSets[0].Full(),
+		"expected ba.BrickSets[0].Full() to be true, was false")
+	tests.Assert(t, ba.BrickSets[0].SetSize == 3,
+		"expected ba.BrickSets[0].SetSize == 3, got:",
+		ba.BrickSets[0].SetSize)
+	bs := ba.BrickSets[0]
+	tests.Assert(t, bs.Bricks[0].Info.Size == bs.Bricks[1].Info.Size,
+		"expected bs.Bricks[0].Info.Size == bs.Bricks[1].Info.Size, got:",
+		bs.Bricks[0].Info.Size, bs.Bricks[1].Info.Size)
+	tests.Assert(t, bs.Bricks[0].Info.Size > bs.Bricks[2].Info.Size,
+		"expected bs.Bricks[0].Info.Size > bs.Bricks[2].Info.Size, got:",
+		bs.Bricks[0].Info.Size, bs.Bricks[2].Info.Size)
 }
 
 func TestArbiterBrickPlacerTooSmall(t *testing.T) {
@@ -236,19 +249,19 @@ func TestArbiterBrickPlacerTooSmall(t *testing.T) {
 		"10000000",
 		"11111111",
 		"/dev/foobar",
-		110)
+		810)
 	dsrc.QuickAdd(
 		"20000000",
 		"22222222",
 		"/dev/foobar",
-		120)
+		820)
 	dsrc.QuickAdd(
 		"30000000",
 		"33333333",
 		"/dev/foobar",
-		130)
+		830)
 	opts := &TestPlacementOpts{
-		brickSize:       50,
+		brickSize:       800,
 		brickSnapFactor: 0.3,
 		brickOwner:      "asdfasdf",
 		setSize:         3,
@@ -265,7 +278,7 @@ func TestArbiterBrickPlacerDevicesFail(t *testing.T) {
 	dsrc.devicesError = fmt.Errorf("Zonk!")
 
 	opts := &TestPlacementOpts{
-		brickSize:       50,
+		brickSize:       800,
 		brickSnapFactor: 0.3,
 		brickOwner:      "asdfasdf",
 		setSize:         3,
@@ -284,19 +297,19 @@ func TestArbiterBrickPlacerPredicateBlock(t *testing.T) {
 		"10000000",
 		"11111111",
 		"/dev/foobar",
-		110)
+		11000)
 	dsrc.QuickAdd(
 		"20000000",
 		"22222222",
 		"/dev/foobar",
-		120)
+		12000)
 	dsrc.QuickAdd(
 		"30000000",
 		"33333333",
 		"/dev/foobar",
-		130)
+		13000)
 	opts := &TestPlacementOpts{
-		brickSize:       50,
+		brickSize:       800,
 		brickSnapFactor: 0.3,
 		brickOwner:      "asdfasdf",
 		setSize:         3,
@@ -329,7 +342,7 @@ func TestArbiterBrickPlacerBrickOnArbiterDevice(t *testing.T) {
 		"/dev/foobar",
 		23000)
 	opts := &TestPlacementOpts{
-		brickSize:       10,
+		brickSize:       800,
 		brickSnapFactor: 0.3,
 		brickOwner:      "asdfasdf",
 		setSize:         3,
@@ -371,7 +384,7 @@ func TestArbiterBrickPlacerBrickThreeSets(t *testing.T) {
 	addDev("91111111", "/dev/d3", 10003)
 
 	opts := &TestPlacementOpts{
-		brickSize:       100,
+		brickSize:       800,
 		brickSnapFactor: 0.3,
 		brickOwner:      "asdfasdf",
 		setSize:         3,
@@ -417,7 +430,7 @@ func TestArbiterBrickPlacerBrickThreeSetsOnArbiterDevice(t *testing.T) {
 	// improve this but not now and not for this test. :-\
 
 	opts := &TestPlacementOpts{
-		brickSize:       100,
+		brickSize:       800,
 		brickSnapFactor: 0.3,
 		brickOwner:      "asdfasdf",
 		setSize:         3,
@@ -472,7 +485,7 @@ func TestArbiterBrickPlacerSimpleReplace(t *testing.T) {
 		23000)
 
 	opts := &TestPlacementOpts{
-		brickSize:       50,
+		brickSize:       800,
 		brickSnapFactor: 0.3,
 		brickOwner:      "asdfasdf",
 		setSize:         3,
@@ -533,7 +546,7 @@ func TestArbiterBrickPlacerReplaceIndexOOB(t *testing.T) {
 		23000)
 
 	opts := &TestPlacementOpts{
-		brickSize:       50,
+		brickSize:       800,
 		brickSnapFactor: 0.3,
 		brickOwner:      "asdfasdf",
 		setSize:         3,
@@ -584,7 +597,7 @@ func TestArbiterBrickPlacerReplaceDevicesFail(t *testing.T) {
 		23000)
 
 	opts := &TestPlacementOpts{
-		brickSize:       50,
+		brickSize:       800,
 		brickSnapFactor: 0.3,
 		brickOwner:      "asdfasdf",
 		setSize:         3,
@@ -625,7 +638,7 @@ func TestArbiterBrickPlacerReplaceTooFew(t *testing.T) {
 		23000)
 
 	opts := &TestPlacementOpts{
-		brickSize:       50,
+		brickSize:       800,
 		brickSnapFactor: 0.3,
 		brickOwner:      "asdfasdf",
 		setSize:         3,
@@ -677,7 +690,7 @@ func TestArbiterBrickPlacerReplaceTooFewArbiter(t *testing.T) {
 	// when we're limited to certain devices
 
 	opts := &TestPlacementOpts{
-		brickSize:       50,
+		brickSize:       800,
 		brickSnapFactor: 0.3,
 		brickOwner:      "asdfasdf",
 		setSize:         3,

--- a/apps/glusterfs/placer_volume.go
+++ b/apps/glusterfs/placer_volume.go
@@ -1,0 +1,14 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+func PlacerForVolume(v *VolumeEntry) BrickPlacer {
+	return NewStandardBrickPlacer()
+}

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -277,7 +277,7 @@ func (v *VolumeEntry) allocBrickReplacement(db wdb.DB,
 		}
 
 		var err error
-		placer := NewStandardBrickPlacer()
+		placer := PlacerForVolume(v)
 		r, err = placer.Replace(
 			NewClusterDeviceSource(tx, v.Info.Cluster),
 			NewVolumePlacementOpts(v, oldBrickEntry.Info.Size, bs.SetSize),


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

The first step towards supporting arbiter volumes. It builds upon the changes in PR #1103 and that PR should be merged first.

### Notes for the reviewer

Currently, this PR is meant as a preview of the first parts of arbiter support. It is intended to give to complain about things early. Currently, this arbiter brick placer is only unit tested and is not used anywhere else in the code. At the very least we need to be able to "know" a volume is an arbiter volume and also make executor changes. We can discuss if those should be in this PR or a later one.
