### PR TITLE
Initial support for creating and managing arbiter volumes

### DIFF
--- a/apps/glusterfs/placer_volume.go
+++ b/apps/glusterfs/placer_volume.go
@@ -10,5 +10,8 @@
 package glusterfs
 
 func PlacerForVolume(v *VolumeEntry) BrickPlacer {
+	if v.HasArbiterOption() {
+		return NewArbiterBrickPlacer()
+	}
 	return NewStandardBrickPlacer()
 }

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -14,6 +14,8 @@ import (
 	"encoding/gob"
 	"fmt"
 	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/boltdb/bolt"
 	"github.com/heketi/heketi/executors"
@@ -36,6 +38,8 @@ const (
 	DEFAULT_EC_DATA               = 4
 	DEFAULT_EC_REDUNDANCY         = 2
 	DEFAULT_THINP_SNAPSHOT_FACTOR = 1.5
+
+	HEKETI_ARBITER_KEY = "user.heketi.arbiter"
 )
 
 // VolumeEntry struct represents a volume in heketi. Serialization is done using
@@ -217,6 +221,20 @@ func (v *VolumeEntry) Unmarshal(buffer []byte) error {
 	}
 
 	return nil
+}
+
+// HasArbiterOption returns true if this volume is flagged for
+// arbiter support.
+func (v *VolumeEntry) HasArbiterOption() bool {
+	for _, s := range v.GlusterVolumeOptions {
+		r := strings.Split(s, " ")
+		if len(r) == 2 && r[0] == HEKETI_ARBITER_KEY {
+			if b, e := strconv.ParseBool(r[1]); e == nil {
+				return b
+			}
+		}
+	}
+	return false
 }
 
 func (v *VolumeEntry) BrickAdd(id string) {

--- a/apps/glusterfs/volume_entry_create.go
+++ b/apps/glusterfs/volume_entry_create.go
@@ -115,6 +115,7 @@ func (v *VolumeEntry) createVolumeRequest(db wdb.RODB,
 	vr.Name = v.Info.Name
 	v.Durability.SetExecutorVolumeRequest(vr)
 	vr.GlusterVolumeOptions = v.GlusterVolumeOptions
+	vr.Arbiter = v.HasArbiterOption()
 
 	return vr, sshhost, nil
 }

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -2270,3 +2270,50 @@ func TestVolumeCreateConcurrent(t *testing.T) {
 	tests.Assert(t, brickCount == 27,
 		"expected brickCount == 27, got:", brickCount)
 }
+
+func TestVolumeCreateArbiter(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+	cc := 0
+	mVolumeCreate := app.xo.MockVolumeCreate
+	app.xo.MockVolumeCreate = func(host string, volume *executors.VolumeRequest) (*executors.Volume, error) {
+		cc++
+		tests.Assert(t, volume.Arbiter, "expected volumeArbiter=true, was false")
+		return mVolumeCreate(host, volume)
+	}
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+
+	req := &api.VolumeCreateRequest{}
+	req.Size = 1024
+	req.Durability.Type = api.DurabilityReplicate
+	req.Durability.Replicate.Replica = 3
+	req.GlusterVolumeOptions = []string{"user.heketi.arbiter true"}
+
+	v := NewVolumeEntryFromRequest(req)
+	tests.Assert(t, v.HasArbiterOption(),
+		"expected v.HasArbiterOption() to be true, got false")
+
+	err = v.Create(app.db, app.executor)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// verify that the mock volume create was called
+	tests.Assert(t, cc == 1, "expected cc == 1, got:", cc)
+
+	app.db.View(func(tx *bolt.Tx) error {
+		bl, err := BrickList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(bl) == 3,
+			"expected len(devices) == 3, got:", len(bl))
+		return nil
+	})
+}

--- a/executors/cmdexec/volume.go
+++ b/executors/cmdexec/volume.go
@@ -39,6 +39,9 @@ func (s *CmdExecutor) VolumeCreate(host string,
 	case executors.DurabilityReplica:
 		logger.Info("Creating volume %v replica %v", volume.Name, volume.Replica)
 		cmd += fmt.Sprintf("replica %v ", volume.Replica)
+		if volume.Arbiter {
+			cmd += "arbiter 1 "
+		}
 		inSet = volume.Replica
 		maxPerSet = 5
 	case executors.DurabilityDispersion:

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -79,6 +79,7 @@ type VolumeRequest struct {
 
 	// Replica
 	Replica int
+	Arbiter bool
 }
 
 type Brick struct {

--- a/tests/functional/TestSmokeTest/tests/arbiter_test.go
+++ b/tests/functional/TestSmokeTest/tests/arbiter_test.go
@@ -1,0 +1,266 @@
+// +build functional
+
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package functional
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/heketi/pkg/utils/ssh"
+	"github.com/heketi/tests"
+)
+
+func teardownVolumes(t *testing.T) {
+	PauseBeforeTeardown()
+	clusters, err := heketi.ClusterList()
+	tests.Assert(t, err == nil, err)
+
+	for _, cluster := range clusters.Clusters {
+		clusterInfo, err := heketi.ClusterInfo(cluster)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		// Delete volumes in this cluster
+		for _, volume := range clusterInfo.Volumes {
+			err := heketi.VolumeDelete(volume)
+			tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		}
+	}
+
+	vl, err := heketi.VolumeList()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(vl.Volumes) == 0,
+		"expected len(vl.Volumes) == 0, got:", len(vl.Volumes))
+}
+
+func PauseBeforeTeardown() {
+	s := os.Getenv("HEKETI_TEST_PAUSE_BEFORE_TEARDOWN")
+	if len(s) == 0 {
+		return
+	}
+	count, err := strconv.Atoi(s)
+	if err != nil {
+		return
+	}
+	fmt.Println("Continuing in ...")
+	for i := 0; i < count; i++ {
+		fmt.Println("   ", count-i)
+		time.Sleep(time.Second)
+	}
+}
+
+func TestArbiterFlatCluster(t *testing.T) {
+	setupCluster(t, 4, 8)
+	defer teardownCluster(t)
+	t.Run("testArbiterCreateSimple", testArbiterCreateSimple)
+	teardownVolumes(t)
+	t.Run("testArbiterCreateAndVerify", testArbiterCreateAndVerify)
+	teardownVolumes(t)
+	t.Run("testNonArbiterIsNotArbiter", testNonArbiterIsNotArbiter)
+	teardownVolumes(t)
+	t.Run("testArbiterReplaceDataBrick", testArbiterReplaceDataBrick)
+	teardownVolumes(t)
+	t.Run("testArbiterReplaceArbiterBrick", testArbiterReplaceArbiterBrick)
+}
+
+func testArbiterCreateSimple(t *testing.T) {
+	vl, err := heketi.VolumeList()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(vl.Volumes) == 0,
+		"expected len(vl.Volumes) == 0, got:", len(vl.Volumes))
+
+	volReq := &api.VolumeCreateRequest{}
+	volReq.Size = 10
+	volReq.Durability.Type = api.DurabilityReplicate
+	volReq.Durability.Replicate.Replica = 3
+	volReq.GlusterVolumeOptions = []string{"user.heketi.arbiter true"}
+
+	_, err = heketi.VolumeCreate(volReq)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	vl, err = heketi.VolumeList()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(vl.Volumes) == 1,
+		"expected len(vl.Volumes) == 1, got:", len(vl.Volumes))
+}
+
+func testArbiterCreateAndVerify(t *testing.T) {
+	volReq := &api.VolumeCreateRequest{}
+	volReq.Size = 10
+	volReq.Durability.Type = api.DurabilityReplicate
+	volReq.Durability.Replicate.Replica = 3
+	volReq.GlusterVolumeOptions = []string{"user.heketi.arbiter true"}
+
+	vcr, err := heketi.VolumeCreate(volReq)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// SSH into system and check that arbiter is really in use
+	s := ssh.NewSshExecWithKeyFile(
+		logger, "vagrant", "../config/insecure_private_key")
+	cmd := []string{
+		fmt.Sprintf("gluster volume info %v | grep -q \"^Brick.* .arbiter.\"", vcr.Name),
+	}
+	_, err = s.ConnectAndExec(storage0ssh, cmd, 10, true)
+	tests.Assert(t, err == nil, "No bricks marked as arbiter")
+}
+
+// Test that a volume not flagged for arbiter support does
+// not have arbiter tagging on gluster side.
+func testNonArbiterIsNotArbiter(t *testing.T) {
+	volReq := &api.VolumeCreateRequest{}
+	volReq.Size = 10
+	volReq.Durability.Type = api.DurabilityReplicate
+	volReq.Durability.Replicate.Replica = 3
+
+	vcr, err := heketi.VolumeCreate(volReq)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// SSH into system and check that arbiter is really in use
+	s := ssh.NewSshExecWithKeyFile(
+		logger, "vagrant", "../config/insecure_private_key")
+	cmd := []string{
+		fmt.Sprintf("gluster volume info %v | grep -q \"^Brick.* .arbiter.\"", vcr.Name),
+	}
+	_, err = s.ConnectAndExec(storage0ssh, cmd, 10, true)
+	tests.Assert(t, err != nil, "Bricks marked as arbiter")
+}
+
+func testArbiterReplaceDataBrick(t *testing.T) {
+	volReq := &api.VolumeCreateRequest{}
+	volReq.Size = 10
+	volReq.Durability.Type = api.DurabilityReplicate
+	volReq.Durability.Replicate.Replica = 3
+	volReq.GlusterVolumeOptions = []string{"user.heketi.arbiter true"}
+
+	vcr, err := heketi.VolumeCreate(volReq)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// determine a device that a data brick landed on
+	size := uint64(0)
+	var deviceId string
+	for _, b := range vcr.Bricks {
+		if b.Size > size {
+			deviceId = b.DeviceId
+			size = b.Size
+		}
+	}
+
+	err = heketi.DeviceState(
+		deviceId, &api.StateRequest{api.EntryStateOffline})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	defer func() {
+		if err = heketi.DeviceState(
+			deviceId, &api.StateRequest{api.EntryStateOnline}); err != nil {
+			logger.Warning("Failed to return device %v to online state",
+				deviceId)
+		}
+	}()
+
+	err = heketi.DeviceState(
+		deviceId, &api.StateRequest{api.EntryStateFailed})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	defer func() {
+		if err = heketi.DeviceState(
+			deviceId, &api.StateRequest{api.EntryStateOffline}); err != nil {
+			logger.Warning("Failed to return device %v to online state",
+				deviceId)
+		}
+	}()
+
+	vi, err := heketi.VolumeInfo(vcr.Id)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	for _, b := range vi.Bricks {
+		tests.Assert(t, deviceId != b.DeviceId,
+			"device still in use by volume", deviceId)
+	}
+}
+
+func testArbiterReplaceArbiterBrick(t *testing.T) {
+	volReq := &api.VolumeCreateRequest{}
+	volReq.Size = 10
+	volReq.Durability.Type = api.DurabilityReplicate
+	volReq.Durability.Replicate.Replica = 3
+	volReq.GlusterVolumeOptions = []string{"user.heketi.arbiter true"}
+
+	vcr, err := heketi.VolumeCreate(volReq)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// determine a device that a data brick landed on
+	size := uint64(0)
+	var deviceId, path string
+	for _, b := range vcr.Bricks {
+		if size == 0 || b.Size < size {
+			deviceId = b.DeviceId
+			size = b.Size
+			path = b.Path
+		}
+	}
+
+	// extra confirmation this is the arbiter brick
+	s := ssh.NewSshExecWithKeyFile(
+		logger, "vagrant", "../config/insecure_private_key")
+	cmd := []string{
+		fmt.Sprintf("gluster volume info %v | grep \"^Brick.* .arbiter.\"", vcr.Name),
+	}
+	o, err := s.ConnectAndExec(storage0ssh, cmd, 10, true)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, strings.Contains(o[0], path),
+		"expected output to contain brick path",
+		"output:", o, "path:", path)
+
+	err = heketi.DeviceState(
+		deviceId, &api.StateRequest{api.EntryStateOffline})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	defer func() {
+		if err = heketi.DeviceState(
+			deviceId, &api.StateRequest{api.EntryStateOnline}); err != nil {
+			logger.Warning("Failed to return device %v to online state",
+				deviceId)
+		}
+	}()
+
+	err = heketi.DeviceState(
+		deviceId, &api.StateRequest{api.EntryStateFailed})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	defer func() {
+		if err = heketi.DeviceState(
+			deviceId, &api.StateRequest{api.EntryStateOffline}); err != nil {
+			logger.Warning("Failed to return device %v to online state",
+				deviceId)
+		}
+	}()
+
+	vi, err := heketi.VolumeInfo(vcr.Id)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	for _, b := range vi.Bricks {
+		tests.Assert(t, deviceId != b.DeviceId,
+			"device still in use by volume", deviceId)
+	}
+
+	s = ssh.NewSshExecWithKeyFile(
+		logger, "vagrant", "../config/insecure_private_key")
+	cmd = []string{
+		fmt.Sprintf("gluster volume info %v | grep \"^Brick.* .arbiter.\"", vcr.Name),
+	}
+	o, err = s.ConnectAndExec(storage0ssh, cmd, 10, true)
+	tests.Assert(t, !strings.Contains(o[0], path),
+		"expected output not to contain old brick path",
+		"output:", o, "path:", path)
+}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

This series builds on the changes in PR #1105 and that series should be merged first.

This series adds initial support for creating and managing arbiter volumes. The core changes are the hooks that causes Heketi to select the arbiter brick placer and to request an arbiter volume from gluster. Additionally, a new function test subdir for arbiter tests is added with some simple tests for arbiter volume create and device remove (brick replace).


### Notes for the reviewer

The key name used for the "virtual" gluster option is intentionally ugly. We never finished discussing the api changes / naming in the design PR, so I picked something funky on purpose.

As discussed offline this change does nothing to try and dedicate devices for either data or arbiter bricks. That will be done later in a separate PR.

