### PR TITLE
consolidate server configuration

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -12,7 +12,6 @@ package glusterfs
 import (
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -72,15 +71,11 @@ type App struct {
 }
 
 // Use for tests only
-func NewApp(configIo io.Reader) *App {
+func NewApp(conf *GlusterFSConfig) *App {
 	var err error
 	app := &App{}
 
-	// Load configuration file
-	app.conf = loadConfiguration(configIo)
-	if app.conf == nil {
-		return nil
-	}
+	app.conf = conf
 
 	// We would like to perform rebalance by default
 	// As it is very difficult to distinguish missing parameter from

--- a/apps/glusterfs/app_config.go
+++ b/apps/glusterfs/app_config.go
@@ -10,9 +10,6 @@
 package glusterfs
 
 import (
-	"encoding/json"
-	"io"
-
 	"github.com/heketi/heketi/executors/kubeexec"
 	"github.com/heketi/heketi/executors/sshexec"
 )
@@ -46,20 +43,4 @@ type GlusterFSConfig struct {
 
 	// operation retry amounts
 	RetryLimits RetryLimitConfig `json:"operation_retry_limits"`
-}
-
-type ConfigFile struct {
-	GlusterFS GlusterFSConfig `json:"glusterfs"`
-}
-
-func loadConfiguration(configIo io.Reader) *GlusterFSConfig {
-	configParser := json.NewDecoder(configIo)
-
-	var config ConfigFile
-	if err := configParser.Decode(&config); err != nil {
-		logger.LogError("Unable to parse config file: %v\n",
-			err.Error())
-		return nil
-	}
-	return &config.GlusterFS
 }

--- a/apps/glusterfs/app_volume_test.go
+++ b/apps/glusterfs/app_volume_test.go
@@ -164,22 +164,18 @@ func TestVolumeCreateSmallSize(t *testing.T) {
 	tmpfile := tests.Tempfile()
 	defer os.Remove(tmpfile)
 
-	os.Setenv("HEKETI_EXECUTOR", "mock")
-	defer os.Unsetenv("HEKETI_EXECUTOR")
-
-	data := []byte(`{
-		"glusterfs" : {
-			"db" : "` + tmpfile + `",
-			"brick_min_size_gb" : 4
-		}
-	}`)
+	conf := &GlusterFSConfig{
+		Executor:     "mock",
+		DBfile:       tmpfile,
+		BrickMinSize: 4,
+	}
 
 	bmin := BrickMinSize
 	defer func() {
 		BrickMinSize = bmin
 	}()
 
-	app := NewApp(bytes.NewReader(data))
+	app := NewApp(conf)
 	defer app.Close()
 
 	router := mux.NewRouter()

--- a/apps/glusterfs/testapp_mock.go
+++ b/apps/glusterfs/testapp_mock.go
@@ -10,22 +10,17 @@
 package glusterfs
 
 import (
-	"bytes"
-
 	"github.com/lpabon/godbc"
 )
 
 func NewTestApp(dbfile string) *App {
 
 	// Create simple configuration for unit tests
-	appConfig := bytes.NewBuffer([]byte(`{
-		"glusterfs" : {
-			"executor" : "mock",
-			"allocator" : "simple",
-			"db" : "` + dbfile + `",
-			"auto_create_block_hosting_volume" : true
-		}
-	}`))
+	appConfig := &GlusterFSConfig{
+		DBfile:                    dbfile,
+		Executor:                  "mock",
+		CreateBlockHostingVolumes: true,
+	}
 	app := NewApp(appConfig)
 	godbc.Check(app != nil)
 

--- a/main.go
+++ b/main.go
@@ -18,12 +18,12 @@ import (
 	"syscall"
 
 	"github.com/gorilla/mux"
-	"github.com/heketi/heketi/apps/glusterfs"
-	"github.com/heketi/heketi/middleware"
 	"github.com/spf13/cobra"
 	"github.com/urfave/negroni"
-
 	restclient "k8s.io/client-go/rest"
+
+	"github.com/heketi/heketi/apps/glusterfs"
+	"github.com/heketi/heketi/middleware"
 )
 
 type Config struct {

--- a/main.go
+++ b/main.go
@@ -261,7 +261,7 @@ func setWithEnvVariables(options *config.Config) {
 	}
 }
 
-func setupApp(fp *os.File) (a *glusterfs.App) {
+func setupApp(config *config.Config) (a *glusterfs.App) {
 	defer func() {
 		err := recover()
 		if a == nil || err != nil {
@@ -270,10 +270,6 @@ func setupApp(fp *os.File) (a *glusterfs.App) {
 		}
 	}()
 
-	// Go to the beginning of the file when we pass it
-	// to the application
-	fp.Seek(0, os.SEEK_SET)
-
 	// If one really needs to disable the health monitor for
 	// the server binary we provide only this env var.
 	env := os.Getenv("HEKETI_DISABLE_HEALTH_MONITOR")
@@ -281,7 +277,7 @@ func setupApp(fp *os.File) (a *glusterfs.App) {
 		glusterfs.MonitorGlusterNodes = true
 	}
 
-	return glusterfs.NewApp(fp)
+	return glusterfs.NewApp(config.GlusterFS)
 }
 
 func main() {
@@ -319,7 +315,7 @@ func main() {
 	n := negroni.New(negroni.NewRecovery(), negroni.NewLogger())
 
 	// Setup a new GlusterFS application
-	app := setupApp(fp)
+	app := setupApp(options)
 
 	// Add /hello router
 	router := mux.NewRouter()

--- a/main.go
+++ b/main.go
@@ -292,16 +292,7 @@ func main() {
 	}
 
 	// Read configuration
-	fp, err := os.Open(configfile)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: Unable to open config file %v: %v\n",
-			configfile,
-			err.Error())
-		os.Exit(1)
-	}
-	defer fp.Close()
-
-	options, err := config.ParseConfig(fp)
+	options, err := config.ReadConfig(configfile)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/pkg/heketitest/heketitest.go
+++ b/pkg/heketitest/heketitest.go
@@ -10,7 +10,6 @@
 package heketitest
 
 import (
-	"bytes"
 	"net/http/httptest"
 	"os"
 
@@ -79,14 +78,11 @@ func NewHeketiMockTestServer(
 	}
 
 	// Create simple configuration for unit tests
-	appConfig := bytes.NewBuffer([]byte(`{
-		"glusterfs" : { 
-			"executor" : "mock",
-			"allocator" : "simple",
-			"loglevel" : "` + loglevel + `",
-			"db" : "` + h.DbFile + `"
-		}
-	}`))
+	appConfig := &glusterfs.GlusterFSConfig{
+		Executor: "mock",
+		Loglevel: loglevel,
+		DBfile:   h.DbFile,
+	}
 	h.App = glusterfs.NewApp(appConfig)
 	if h.App == nil {
 		return nil

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -15,7 +15,7 @@ import (
 	"io"
 	"os"
 
-	_ "github.com/heketi/heketi/apps/glusterfs"
+	"github.com/heketi/heketi/apps/glusterfs"
 	"github.com/heketi/heketi/middleware"
 )
 
@@ -27,6 +27,9 @@ type Config struct {
 	EnableTls            bool                     `json:"enable_tls"`
 	CertFile             string                   `json:"cert_file"`
 	KeyFile              string                   `json:"key_file"`
+
+	// pull in the config sub-object for glusterfs app
+	GlusterFS *glusterfs.GlusterFSConfig `json:"glusterfs"`
 }
 
 func ParseConfig(input io.Reader) (config *Config, e error) {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	_ "github.com/heketi/heketi/apps/glusterfs"
+	"github.com/heketi/heketi/middleware"
+)
+
+type Config struct {
+	Port                 string                   `json:"port"`
+	AuthEnabled          bool                     `json:"use_auth"`
+	JwtConfig            middleware.JwtAuthConfig `json:"jwt"`
+	BackupDbToKubeSecret bool                     `json:"backup_db_to_kube_secret"`
+	EnableTls            bool                     `json:"enable_tls"`
+	CertFile             string                   `json:"cert_file"`
+	KeyFile              string                   `json:"key_file"`
+}
+
+func ParseConfig(input io.Reader) (config *Config, e error) {
+	configParser := json.NewDecoder(input)
+	if e = configParser.Decode(&config); e != nil {
+		fmt.Fprintf(os.Stderr,
+			"ERROR: Unable to parse configuration: %v\n",
+			e.Error())
+		return
+	}
+	return
+}
+
+func ReadConfig(configfile string) (config *Config, e error) {
+	fp, e := os.Open(configfile)
+	if e != nil {
+		fmt.Fprintf(os.Stderr,
+			"ERROR: Unable to open config file %v: %v\n",
+			configfile,
+			e.Error())
+		return
+	}
+	defer fp.Close()
+	return ParseConfig(fp)
+}

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -1,0 +1,88 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package config
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/heketi/tests"
+)
+
+func configString(s string) io.Reader {
+	return bytes.NewBuffer([]byte(s))
+}
+
+func TestParseConfigDummy(t *testing.T) {
+	data := configString(`{
+		"pow": "whomp"
+	}`)
+	_, err := ParseConfig(data)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+}
+
+func TestParseConfigSimple(t *testing.T) {
+	data := configString(`{
+		"port": "7890",
+		"glusterfs": {
+			"executor": "fishy",
+			"db": "/tmp/wonderful.db"
+		}
+	}`)
+	c, err := ParseConfig(data)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, c.Port == "7890", `expected c.Port == "7890", got:`, c.Port)
+	tests.Assert(t, c.GlusterFS.Executor == "fishy",
+		`expected c.GlusterFS.Executor == "fishy", got:`, c.GlusterFS.Executor)
+	tests.Assert(t, c.GlusterFS.DBfile == "/tmp/wonderful.db",
+		`expected c.GlusterFS.DBfile == "/tmp/wonderful.db", got:`,
+		c.GlusterFS.DBfile)
+}
+
+func TestParseConfigError(t *testing.T) {
+	data := configString(`{
+		"port": "7890",
+		"glusterfs`)
+	_, err := ParseConfig(data)
+	tests.Assert(t, err != nil, "expected err != nil, got:", err)
+}
+
+func TestReadConfigSimple(t *testing.T) {
+	phonyConfig := tests.Tempfile()
+	defer os.Remove(phonyConfig)
+
+	f, err := os.OpenFile(phonyConfig, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0700)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	defer f.Close()
+	_, err = io.Copy(f, configString(`{
+		"port": "7890",
+		"glusterfs": {
+			"executor": "fishy",
+			"db": "/tmp/wonderful.db"
+		}
+	}`))
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	c, err := ReadConfig(phonyConfig)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, c.Port == "7890", `expected c.Port == "7890", got:`, c.Port)
+	tests.Assert(t, c.GlusterFS.Executor == "fishy",
+		`expected c.GlusterFS.Executor == "fishy", got:`, c.GlusterFS.Executor)
+	tests.Assert(t, c.GlusterFS.DBfile == "/tmp/wonderful.db",
+		`expected c.GlusterFS.DBfile == "/tmp/wonderful.db", got:`,
+		c.GlusterFS.DBfile)
+}
+
+func TestReadConfigError(t *testing.T) {
+	_, err := ReadConfig("/this/path.should/never_exist/asdf")
+	tests.Assert(t, err != nil, "expected err != nil, got:", err)
+}


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

This creates a new package "server/config" and locates all the logic around parsing configuration files into this single location. Instead of parsing the configuration file twice we parse the file once and pass the configuration object around.

Using a new package also provides a foundation for future enhancements around configuring the heketi server process.

### Notes for the reviewer

In order to keep this initial series small it does not tackle re-organizing the environment variables that are spread throughout the codebase. I'm happy to bikeshed the new location but I do think it should be a new package for handling the config loading.