### PR TITLE
client: Add 'volume clone' CLI and API

### DIFF
--- a/client/api/go-client/volume.go
+++ b/client/api/go-client/volume.go
@@ -232,3 +232,52 @@ func (c *Client) VolumeDelete(id string) error {
 
 	return nil
 }
+
+func (c *Client) VolumeClone(id string, request *api.VolumeCloneRequest) (*api.VolumeInfoResponse, error) {
+	// Marshal request to JSON
+	buffer, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a request
+	req, err := http.NewRequest("POST", c.host+"/volumes/"+id+"/clone", bytes.NewBuffer(buffer))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Set token
+	err = c.setToken(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Send request
+	r, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusAccepted {
+		return nil, utils.GetErrorFromResponse(r)
+	}
+
+	// Wait for response
+	r, err = c.waitForResponseWithTimer(r, time.Second)
+	if err != nil {
+		return nil, err
+	}
+	if r.StatusCode != http.StatusOK {
+		return nil, utils.GetErrorFromResponse(r)
+	}
+
+	// Read JSON response
+	var volume api.VolumeInfoResponse
+	err = utils.GetJsonFromResponse(r, &volume)
+	if err != nil {
+		return nil, err
+	}
+
+	return &volume, nil
+}

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -330,6 +330,16 @@ func (volExpandReq VolumeExpandRequest) Validate() error {
 	)
 }
 
+type VolumeCloneRequest struct {
+	Name string `json:"name,omitempty"`
+}
+
+func (vcr VolumeCloneRequest) Validate() error {
+	return validation.ValidateStruct(&vcr,
+		validation.Field(&vcr.Name, validation.Match(volumeNameRe)),
+	)
+}
+
 // BlockVolume
 
 type BlockVolumeCreateRequest struct {


### PR DESCRIPTION
This change depends on the service-side implementation that is currently still being cleaned up. The API and CLI for the volume cloning is expected to be stable, other projects will be able to consume the current state.

@humblec, is this what you need for the [gluster-fiile external storage provider](https://github.com/kubernetes-incubator/external-storage/tree/master/gluster/file)?