### PR TITLE
tests: don't write files when running functional test compile check

### DIFF
--- a/tests/100-compile-functest-go.sh
+++ b/tests/100-compile-functest-go.sh
@@ -4,4 +4,4 @@ TAGS="functional dbexamples"
 find tests/functional -name '*.go' -print0 | \
 	xargs -0 dirname | sort -u | \
 	sed -e 's,^/*,github.com/heketi/heketi/,' | \
-	xargs -L1 go test -c -tags "$TAGS"
+	xargs -L1 go test -c -o /dev/null -tags "$TAGS"


### PR DESCRIPTION
We recently added a script to compile the functional test go code as
a faster (and more frequently run) sanity check. However, the
go command line tool defaults to writing a <pkg>.test binary when
asked to compile test code. We tell the go tool to write the result
to /dev/null so we don't generate unwanted artifacts any more.