### PR TITLE
Fix invalid selection of a pending volume to host block volume

### DIFF
--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -191,7 +191,7 @@ func (v *BlockVolumeEntry) eligibleClustersAndVolumes(db wdb.RODB) (
 				if err != nil {
 					return err
 				}
-				if volEntry.Info.Block {
+				if volEntry.Info.Block && volEntry.Pending.Id == "" {
 					possibleVolumes = append(possibleVolumes, vol)
 				}
 			}

--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -507,7 +507,7 @@ func (bvc *BlockVolumeCreateOperation) Build() error {
 				}
 			}
 			bvc.op.RecordAddHostingVolume(vol)
-			if e := bvc.bvol.Save(tx); e != nil {
+			if e := vol.Save(tx); e != nil {
 				return e
 			}
 			bvc.bvol.Info.BlockHostingVolume = vol.Info.Id


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Prior to this fix, the block hosting volume could select a pending files volume (block hosting volume) by use for a new block volume. This behavior was invalid because the pending block hosting volume may not be ready for use or still fail in it's own creation.
The system should only use fully created files volumes for hosting block volumes.

### Notes for the reviewer

Note that there were two underlying issues:

1. The block volume create code would consider placing the new block volume on a pending files volume.

2.  When file volumes were being created as part of a new block volume, the code was incorrectly failing to update the volume's pending status in the db (it was saving the block volume twice instead).

The first change is a unit test that reveals the issue. Subsequent changes fix the above issues and allow the test to pass.