### PR TITLE
design: remove "description" argument for volume cloning

### DIFF
--- a/docs/design/snapshot.md
+++ b/docs/design/snapshot.md
@@ -153,13 +153,11 @@ only interested in the clone and not in the snapshots.
 * **Temporary Resource Response HTTP Status Code**: 303, `Location` header will contain `/volumes/{new_volume_uuid}`. See [Volume Info](#volume_info) for JSON response.
 * **JSON Request**:
     * name: _string_, _optional_, Name of the clone. If not provided, the name of the snapshot will be `snap_{id}`, for example `snap_728faa5522838746abce2980`
-    * description: _string_, _optional_, Description of the snapshot. If not provided, the description will be empty.
     * Example:
 
 ```json
 {
     "name": "my_clone",
-    "description": "my own clone"
 }
 ```
 


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

It is possible to pass a "description" when a snapshot is created. But
this is not useful for cloning a volume from an other volume. The
temporary snapshot (that could have a description) will be removed as
part of the volume clone procedure.

The "description" argument was likely introduced by a bad copy/paste.