### PR TITLE
fix panic during rollback of blockvolume create

### DIFF
--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -152,7 +152,7 @@ func (v *BlockVolumeEntry) Unmarshal(buffer []byte) error {
 }
 
 func (v *BlockVolumeEntry) eligibleClustersAndVolumes(db wdb.RODB) (
-	possibleClusters []string, volumes []string, e error) {
+	possibleClusters []string, volumes []*VolumeEntry, e error) {
 
 	if len(v.Info.Clusters) == 0 {
 		err := db.View(func(tx *bolt.Tx) error {
@@ -212,7 +212,7 @@ func (v *BlockVolumeEntry) eligibleClustersAndVolumes(db wdb.RODB) (
 				return err
 			}
 			if ok, err := canHostBlockVolume(tx, v, volEntry); ok {
-				volumes = append(volumes, vol)
+				volumes = append(volumes, volEntry)
 			} else if err != nil {
 				return err
 			}

--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -480,7 +480,8 @@ func (bvc *BlockVolumeCreateOperation) Build() error {
 		}
 
 		if len(volumes) > 0 {
-			bvc.bvol.Info.BlockHostingVolume = volumes[0]
+			bvc.bvol.Info.BlockHostingVolume = volumes[0].Info.Id
+			bvc.bvol.Info.Cluster = volumes[0].Info.Cluster
 		} else if bvc.bvol.Info.Size > BlockHostingVolumeSize {
 			return fmt.Errorf("The size configured for "+
 				"automatic creation of block hosting volumes "+
@@ -511,6 +512,7 @@ func (bvc *BlockVolumeCreateOperation) Build() error {
 				return e
 			}
 			bvc.bvol.Info.BlockHostingVolume = vol.Info.Id
+			bvc.bvol.Info.Cluster = vol.Info.Cluster
 		}
 
 		// we've figured out what block-volume, hosting volume, and bricks we

--- a/apps/glusterfs/operations_test.go
+++ b/apps/glusterfs/operations_test.go
@@ -1783,6 +1783,72 @@ func TestBlockVolumeCreatePendingBHV(t *testing.T) {
 	})
 }
 
+// TestBlockVolumeCreatePendingBHV tests the behavior of the system
+// when a block hosting volume exists but is pending and another
+// block volume request is received.
+func TestBlockVolumeCreateBuildRollback(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		1,    // clusters
+		3,    // nodes_per_cluster
+		2,    // devices_per_node,
+		2*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	req := &api.BlockVolumeCreateRequest{}
+	req.Size = 1024
+
+	vol := NewBlockVolumeEntryFromRequest(req)
+	vc := NewBlockVolumeCreateOperation(vol, app.db)
+
+	// verify that there are no volumes, bricks or pending operations
+	app.db.View(func(tx *bolt.Tx) error {
+		vl, e := VolumeList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(vl) == 0, "expected len(vl) == 0, got", len(vl))
+		bl, e := BrickList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(bl) == 0, "expected len(bl) == 0, got", len(bl))
+		pol, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(pol) == 0, "expected len(pol) == 0, got", len(pol))
+		return nil
+	})
+
+	e := vc.Build()
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	app.db.View(func(tx *bolt.Tx) error {
+		vl, e := VolumeList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(vl) == 1, "expected len(vl) == 1, got", len(vl))
+		pol, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(pol) == 1, "expected len(pol) == 1, got", len(pol))
+		return nil
+	})
+
+	e = vc.Rollback(app.executor)
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	app.db.View(func(tx *bolt.Tx) error {
+		vl, e := VolumeList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(vl) == 0, "expected len(vl) == 0, got", len(vl))
+		pol, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(pol) == 0, "expected len(pol) == 0, got", len(pol))
+		return nil
+	})
+}
+
 type testOperation struct {
 	label    string
 	rurl     string


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

This fixes a panic encountered during the rollback of the block volume create operation if the another function had not already set the BlockVolumeEntry object's cluster id.

### Does this PR fix issues?

Fixes #1102

### Notes for the reviewer

Now, Block volumes entries are always updated with the cluster id during the Build step.
