### PR TITLE
Internally retry volume creation

### DIFF
--- a/apps/glusterfs/app_test.go
+++ b/apps/glusterfs/app_test.go
@@ -264,6 +264,7 @@ func TestCannotStartWhenPendingOperations(t *testing.T) {
 	// trigger a panic the next time an app is instantiated
 	err := app.db.Update(func(tx *bolt.Tx) error {
 		op := NewPendingOperationEntry(NEW_ID)
+		op.Type = OperationCreateVolume
 		op.Save(tx)
 		return nil
 	})
@@ -298,6 +299,7 @@ func TestCanStartWhenPendingOperationsIgnored(t *testing.T) {
 	// this would trigger a panic
 	err := app.db.Update(func(tx *bolt.Tx) error {
 		op := NewPendingOperationEntry(NEW_ID)
+		op.Type = OperationCreateVolume
 		op.Save(tx)
 		return nil
 	})

--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -908,6 +908,7 @@ func bricksFromOp(db wdb.RODB,
 			if a.Change == OpAddBrick || a.Change == OpDeleteBrick {
 				brick, err := NewBrickEntryFromId(tx, a.Id)
 				if err != nil {
+					logger.LogError("failed to find brick with id: %v", a.Id)
 					return err
 				}
 				// this next line is a bit of an unfortunate hack because

--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -19,6 +19,10 @@ import (
 	"github.com/boltdb/bolt"
 )
 
+const (
+	VOLUME_MAX_RETRIES int = 4
+)
+
 type OperationRetryError struct {
 	OriginalError error
 }
@@ -103,8 +107,8 @@ func (om *OperationManager) Id() string {
 // create a new volume.
 type VolumeCreateOperation struct {
 	OperationManager
-	vol *VolumeEntry
-	noRetriesOperation
+	vol        *VolumeEntry
+	maxRetries int
 }
 
 // NewVolumeCreateOperation returns a new VolumeCreateOperation populated
@@ -118,7 +122,8 @@ func NewVolumeCreateOperation(
 			db: db,
 			op: NewPendingOperationEntry(NEW_ID),
 		},
-		vol: vol,
+		maxRetries: VOLUME_MAX_RETRIES,
+		vol:        vol,
 	}
 }
 
@@ -128,6 +133,10 @@ func (vc *VolumeCreateOperation) Label() string {
 
 func (vc *VolumeCreateOperation) ResourceUrl() string {
 	return fmt.Sprintf("/volumes/%v", vc.vol.Info.Id)
+}
+
+func (vc *VolumeCreateOperation) MaxRetries() int {
+	return vc.maxRetries
 }
 
 // Build allocates and saves new volume and brick entries (tagged as pending)
@@ -166,8 +175,9 @@ func (vc *VolumeCreateOperation) Exec(executor executors.Executor) error {
 	err = vc.vol.createVolumeExec(vc.db, executor, brick_entries)
 	if err != nil {
 		logger.LogError("Error executing create volume: %v", err)
+		return OperationRetryError{err}
 	}
-	return err
+	return nil
 }
 
 // Finalize marks our new volume and brick db entries as no longer pending.

--- a/apps/glusterfs/pendingop_entry.go
+++ b/apps/glusterfs/pendingop_entry.go
@@ -115,7 +115,15 @@ func (p *PendingOperationEntry) Save(tx *bolt.Tx) error {
 
 // Delete removes a pending operation entry from the db.
 func (p *PendingOperationEntry) Delete(tx *bolt.Tx) error {
+	p.Reset()
 	return EntryDelete(tx, p, p.Id)
+}
+
+// Reset clears the all of PendingOperationEntry's state except for
+// the ID so that it may be reused.
+func (p *PendingOperationEntry) Reset() {
+	p.Type = OperationUnknown
+	p.Actions = []PendingOperationAction{}
 }
 
 // Marshal serializes the object for storage in the db.

--- a/apps/glusterfs/pendingop_entry.go
+++ b/apps/glusterfs/pendingop_entry.go
@@ -109,6 +109,7 @@ func NewPendingOperationEntryFromId(tx *bolt.Tx, id string) (
 func (p *PendingOperationEntry) Save(tx *bolt.Tx) error {
 	godbc.Require(tx != nil)
 	godbc.Require(p.Id != "")
+	godbc.Require(p.Type != OperationUnknown)
 
 	return EntrySave(tx, p, p.Id)
 }


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

This set of changes adds an internal retry to the volume create operation, based on the previously submitted generic operations retry mechanism. It cleans up a few issues found while testing the rety and adds a specific test for the volume create retry.

This change depends on PR #1056.

### Notes for the reviewer

I've opted to use a default value of 4 retries. This means a total of 5 tries. In the test itself I upped the retry count to ten because we want to make sure the test always passes and the mock executor doesn't really take any time.

