### PR TITLE
Add a node health monitor & cache subsystem

### DIFF
--- a/apps/glusterfs/allocator_simple.go
+++ b/apps/glusterfs/allocator_simple.go
@@ -30,6 +30,8 @@ func loadRingFromDB(tx *bolt.Tx, clusterId string) (*SimpleAllocatorRing, error)
 		return nil, err
 	}
 
+	nodeUp := currentNodeHealthStatus()
+
 	ring := NewSimpleAllocatorRing()
 
 	for _, nodeId := range cluster.Info.Nodes {
@@ -40,6 +42,11 @@ func loadRingFromDB(tx *bolt.Tx, clusterId string) (*SimpleAllocatorRing, error)
 
 		// Check node is online
 		if !node.isOnline() {
+			continue
+		}
+		if up, found := nodeUp[nodeId]; found && !up {
+			// if the node is in the cache and we know it was not
+			// recently healthy, skip it
 			continue
 		}
 

--- a/apps/glusterfs/app_config.go
+++ b/apps/glusterfs/app_config.go
@@ -35,7 +35,10 @@ type GlusterFSConfig struct {
 	BlockHostingVolumeSize    int  `json:"block_hosting_volume_size"`
 
 	// server behaviors
-	IgnoreStaleOperations bool `json:"ignore_stale_operations"`
+	IgnoreStaleOperations          bool   `json:"ignore_stale_operations"`
+	MonitorGlusterNodes            bool   `json:"monitor_gluster_nodes"`
+	RefreshTimeMonitorGlusterNodes uint32 `json:"refresh_time_monitor_gluster_nodes"`
+	StartTimeMonitorGlusterNodes   uint32 `json:"start_time_monitor_gluster_nodes"`
 }
 
 type ConfigFile struct {

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -249,6 +249,8 @@ func (cds *ClusterDeviceSource) Devices() ([]DeviceAndNode, error) {
 		return nil, err
 	}
 
+	nodeUp := currentNodeHealthStatus()
+
 	valid := [](DeviceAndNode){}
 	for _, nodeId := range cluster.Info.Nodes {
 		node, err := NewNodeEntryFromId(cds.tx, nodeId)
@@ -256,6 +258,11 @@ func (cds *ClusterDeviceSource) Devices() ([]DeviceAndNode, error) {
 			return nil, err
 		}
 		if !node.isOnline() {
+			continue
+		}
+		if up, found := nodeUp[nodeId]; found && !up {
+			// if the node is in the cache and we know it was not
+			// recently healthy, skip it
 			continue
 		}
 

--- a/apps/glusterfs/health_cache.go
+++ b/apps/glusterfs/health_cache.go
@@ -1,0 +1,183 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/boltdb/bolt"
+
+	"github.com/heketi/heketi/executors"
+	wdb "github.com/heketi/heketi/pkg/db"
+)
+
+var (
+	healthNow func() time.Time = time.Now
+)
+
+type NodeHealthStatus struct {
+	NodeId     string
+	Host       string
+	Up         bool
+	LastUpdate time.Time
+}
+
+type NodeHealthCache struct {
+	// tunables
+	StartInterval time.Duration
+	CheckInterval time.Duration
+	Expiration    time.Duration
+
+	db    wdb.RODB
+	exec  executors.Executor
+	nodes map[string]*NodeHealthStatus
+	lock  sync.RWMutex
+
+	// to stop the monitor
+	stop chan<- interface{}
+}
+
+func NewNodeHealthCache(reftime, starttime uint32, db wdb.RODB, e executors.Executor) *NodeHealthCache {
+	return &NodeHealthCache{
+		db:            db,
+		exec:          e,
+		nodes:         map[string](*NodeHealthStatus){},
+		StartInterval: time.Second * time.Duration(starttime),
+		CheckInterval: time.Second * time.Duration(reftime),
+		Expiration:    time.Hour * 2,
+	}
+}
+
+func (hc *NodeHealthCache) Status() map[string]bool {
+	hc.lock.RLock()
+	defer hc.lock.RUnlock()
+	healthy := map[string]bool{}
+	for k, v := range hc.nodes {
+		healthy[k] = v.Up
+	}
+	return healthy
+}
+
+func (hc *NodeHealthCache) Refresh() error {
+	logger.Info("Starting Node Health Status refresh")
+	sl, err := hc.toProbe()
+	if err != nil {
+		return err
+	}
+	for _, s := range sl {
+		hc.updateNode(s)
+	}
+	hc.cleanOld()
+	return nil
+}
+
+func (hc *NodeHealthCache) updateNode(s *NodeHealthStatus) {
+	hc.lock.Lock()
+	defer hc.lock.Unlock()
+	if prev, found := hc.nodes[s.NodeId]; found {
+		s = prev
+	} else {
+		hc.nodes[s.NodeId] = s
+	}
+	s.update(hc.exec)
+}
+
+func (hc *NodeHealthCache) cleanOld() {
+	hc.lock.Lock()
+	defer hc.lock.Unlock()
+	// purge any items that are stale
+	cleaned := 0
+	for k, v := range hc.nodes {
+		if v.old(hc) {
+			delete(hc.nodes, k)
+			cleaned++
+		}
+	}
+	logger.Info("Cleaned %v nodes from health cache", cleaned)
+}
+
+func (hc *NodeHealthCache) Monitor() {
+	startTimer := time.NewTimer(hc.StartInterval)
+	ticker := time.NewTicker(hc.CheckInterval)
+	stop := make(chan interface{})
+	hc.stop = stop
+
+	go func() {
+		logger.Info("Started Node Health Cache Monitor")
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				logger.Info("Stopping Node Health Cache Monitor")
+				return
+			case <-startTimer.C:
+				err := hc.Refresh()
+				if err != nil {
+					logger.LogError("Node Heath Cache Monitor: %v", err.Error())
+				}
+			case <-ticker.C:
+				err := hc.Refresh()
+				if err != nil {
+					logger.LogError("Node Heath Cache Monitor: %v", err.Error())
+				}
+			}
+		}
+	}()
+}
+
+func (hc *NodeHealthCache) Stop() {
+	hc.stop <- true
+}
+
+func (hc *NodeHealthCache) toProbe() ([]*NodeHealthStatus, error) {
+	probeNodes := []*NodeHealthStatus{}
+	err := hc.db.View(func(tx *bolt.Tx) error {
+		n, err := NodeList(tx)
+		if err != nil {
+			return err
+		}
+		for _, nodeId := range n {
+			if strings.HasPrefix(nodeId, "MANAGE") ||
+				strings.HasPrefix(nodeId, "STORAGE") {
+				continue
+			}
+			node, err := NewNodeEntryFromId(tx, nodeId)
+			if err != nil {
+				return err
+			}
+			// Ignore if the node is not online
+			if !node.isOnline() {
+				continue
+			}
+			nhs := &NodeHealthStatus{
+				NodeId: nodeId,
+				Host:   node.Info.Hostnames.Manage[0],
+			}
+			probeNodes = append(probeNodes, nhs)
+		}
+		return nil
+	})
+	return probeNodes, err
+}
+
+func (s *NodeHealthStatus) update(e executors.Executor) {
+	// TODO: add ability to skip check if node was already recently checked
+	err := e.GlusterdCheck(s.Host)
+	s.Up = (err == nil)
+	s.LastUpdate = healthNow()
+	logger.Info("Periodic health check status: node %v up=%v",
+		s.NodeId, s.Up)
+}
+
+func (s *NodeHealthStatus) old(hc *NodeHealthCache) bool {
+	return healthNow().Sub(s.LastUpdate) >= hc.Expiration
+}

--- a/apps/glusterfs/health_cache_test.go
+++ b/apps/glusterfs/health_cache_test.go
@@ -1,0 +1,343 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/boltdb/bolt"
+	"github.com/heketi/tests"
+
+	wdb "github.com/heketi/heketi/pkg/db"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+)
+
+func TestCreateNodeHeathCache(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app (I'm being lazy here. An app is not strictly
+	// needed but it is convenient.
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	hc := NewNodeHealthCache(1, 0, app.db, app.executor)
+	tests.Assert(t, hc != nil, "expected hc != nil, got:", hc)
+
+	nodeUp := hc.Status()
+	tests.Assert(t, len(nodeUp) == 0,
+		"expected len(nodeUp) == 0, got:", len(nodeUp))
+}
+
+func TestNodeHeathCacheHealthy(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app (I'm being lazy here. An app is not strictly
+	// needed but it is convenient.
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	hc := NewNodeHealthCache(1, 0, app.db, app.executor)
+	tests.Assert(t, hc != nil, "expected hc != nil, got:", hc)
+
+	err = hc.Refresh()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	nodeUp := hc.Status()
+	tests.Assert(t, len(nodeUp) == 6,
+		"expected len(nodeUp) == 6, got:", len(nodeUp))
+	for _, v := range nodeUp {
+		tests.Assert(t, v)
+	}
+}
+
+func TestNodeHeathCacheMonitor(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app (I'm being lazy here. An app is not strictly
+	// needed but it is convenient.
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	cc := 0
+	app.xo.MockGlusterdCheck = func(host string) error {
+		cc++
+		return nil
+	}
+
+	hc := NewNodeHealthCache(1, 0, app.db, app.executor)
+	tests.Assert(t, hc != nil, "expected hc != nil, got:", hc)
+
+	hc.CheckInterval = time.Millisecond * 10
+	hc.Monitor()
+
+	time.Sleep(time.Millisecond * 60)
+	hc.Stop()
+
+	tests.Assert(t, cc >= (2*6), "expected cc >= (2 * 6), got:", cc)
+}
+
+func TestNodeHeathCacheSomeUnhealthy(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app (I'm being lazy here. An app is not strictly
+	// needed but it is convenient.
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	cc := 0
+	app.xo.MockGlusterdCheck = func(host string) error {
+		var e error
+		if cc&1 == 1 {
+			e = fmt.Errorf("Bloop %v", cc)
+		}
+		cc++
+		return e
+	}
+	hc := NewNodeHealthCache(1, 0, app.db, app.executor)
+	tests.Assert(t, hc != nil, "expected hc != nil, got:", hc)
+
+	err = hc.Refresh()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	nodeUp := hc.Status()
+	tests.Assert(t, len(nodeUp) == 6,
+		"expected len(nodeUp) == 6, got:", len(nodeUp))
+	var up, down int
+	for _, v := range nodeUp {
+		if v {
+			up++
+		} else {
+			down++
+		}
+	}
+	tests.Assert(t, up == 3, "expected len(up) == 3, got:", up)
+	tests.Assert(t, down == 3, "expected len(down) == 3, got:", down)
+}
+
+func TestNodeHeathCacheMultiRefresh(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app (I'm being lazy here. An app is not strictly
+	// needed but it is convenient.
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	cc := 0
+	app.xo.MockGlusterdCheck = func(host string) error {
+		var e error
+		if cc&1 == 1 {
+			e = fmt.Errorf("Bloop %v", cc)
+		}
+		cc++
+		return e
+	}
+
+	for i := 0; i < 5; i++ {
+		cc = 0
+		hc := NewNodeHealthCache(1, 0, app.db, app.executor)
+		tests.Assert(t, hc != nil, "expected hc != nil, got:", hc)
+
+		err = hc.Refresh()
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		nodeUp := hc.Status()
+		tests.Assert(t, len(nodeUp) == 6,
+			"expected len(nodeUp) == 6, got:", len(nodeUp))
+		var up, down int
+		for _, v := range nodeUp {
+			if v {
+				up++
+			} else {
+				down++
+			}
+		}
+		tests.Assert(t, up == 3, "expected len(up) == 3, got:", up)
+		tests.Assert(t, down == 3, "expected len(down) == 3, got:", down)
+	}
+}
+
+func TestNodeHeathCacheSkipOffline(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app (I'm being lazy here. An app is not strictly
+	// needed but it is convenient.
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// mark some nodes offline
+	app.db.Update(func(tx *bolt.Tx) error {
+		nl, err := NodeList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		for i, nodeId := range nl {
+			if i >= 3 {
+				break
+			}
+			n, err := NewNodeEntryFromId(tx, nodeId)
+			tests.Assert(t, err == nil, "expected err == nil, got:", err)
+			err = n.SetState(wdb.WrapTx(tx), app.executor, api.EntryStateOffline)
+			tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		}
+		return nil
+	})
+
+	cc := 0
+	app.xo.MockGlusterdCheck = func(host string) error {
+		cc++
+		return nil
+	}
+	hc := NewNodeHealthCache(1, 0, app.db, app.executor)
+	tests.Assert(t, hc != nil, "expected hc != nil, got:", hc)
+
+	err = hc.Refresh()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	err = hc.Refresh()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	nodeUp := hc.Status()
+	tests.Assert(t, len(nodeUp) == 3,
+		"expected len(nodeUp) == 6, got:", len(nodeUp))
+	tests.Assert(t, cc == 6,
+		"expected cc == 12, get:", cc)
+}
+
+func TestNodeHeathCacheExpireNodes(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+	nowfunc := healthNow
+	defer func() { healthNow = nowfunc }()
+
+	// Create the app (I'm being lazy here. An app is not strictly
+	// needed but it is convenient.
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	currTime := time.Now()
+	healthNow = func() time.Time { return currTime }
+
+	hc := NewNodeHealthCache(1, 0, app.db, app.executor)
+	tests.Assert(t, hc != nil, "expected hc != nil, got:", hc)
+	hc.Expiration = 1 * time.Hour
+
+	err = hc.Refresh()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	nodeUp := hc.Status()
+	tests.Assert(t, len(nodeUp) == 6,
+		"expected len(nodeUp) == 6, got:", len(nodeUp))
+	for _, v := range nodeUp {
+		tests.Assert(t, v)
+	}
+
+	// mark some nodes offline
+	app.db.Update(func(tx *bolt.Tx) error {
+		nl, err := NodeList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		for i, nodeId := range nl {
+			if i >= 3 {
+				break
+			}
+			n, err := NewNodeEntryFromId(tx, nodeId)
+			tests.Assert(t, err == nil, "expected err == nil, got:", err)
+			err = n.SetState(wdb.WrapTx(tx), app.executor, api.EntryStateOffline)
+			tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		}
+		return nil
+	})
+
+	// advance time a little
+	currTime = currTime.Add(5 * time.Minute)
+	err = hc.Refresh()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	nodeUp = hc.Status()
+	tests.Assert(t, len(nodeUp) == 6,
+		"expected len(nodeUp) == 6, got:", len(nodeUp))
+	for _, v := range nodeUp {
+		tests.Assert(t, v)
+	}
+
+	// advance time a lot
+	currTime = currTime.Add(10 * time.Hour)
+	err = hc.Refresh()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	nodeUp = hc.Status()
+	tests.Assert(t, len(nodeUp) == 3,
+		"expected len(nodeUp) == 3, got:", len(nodeUp))
+	for _, v := range nodeUp {
+		tests.Assert(t, v)
+	}
+}

--- a/etc/heketi.json
+++ b/etc/heketi.json
@@ -55,6 +55,9 @@
     "_db_comment": "Database file name",
     "db": "/var/lib/heketi/heketi.db",
 
+    "_monitor_gluster_nodes": "Periodically check that Gluster nodes are functioning.",
+    "monitor_gluster_nodes": true,
+
      "_refresh_time_monitor_gluster_nodes": "Refresh time in seconds to monitor Gluster nodes",
     "refresh_time_monitor_gluster_nodes": 120,
 

--- a/etc/heketi.json
+++ b/etc/heketi.json
@@ -55,6 +55,12 @@
     "_db_comment": "Database file name",
     "db": "/var/lib/heketi/heketi.db",
 
+     "_refresh_time_monitor_gluster_nodes": "Refresh time in seconds to monitor Gluster nodes",
+    "refresh_time_monitor_gluster_nodes": 120,
+
+    "_start_time_monitor_gluster_nodes": "Start time in seconds to monitor Gluster nodes when the heketi comes up",
+    "start_time_monitor_gluster_nodes": 10,
+
     "_loglevel_comment": [
       "Set log level. Choices are:",
       "  none, critical, error, warning, info, debug",


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

These changes add a new type that can monitor the health of nodes and cache the results in memory for use by other parts of Heketi. The glusterfs app configures and initializes the node heath monitor cache and starts the monitor (goroutine). Later, the functions used to populate the ring used during brick placement can consult the cache and omit any nodes that known to be down/unhealthy. 

### Notes for the reviewer

The configuration file must explicitly enable the monitor. We've updated the default configuration file to include this parameter. However, we may need to consider older instances of Heketi running with preexisting configuration files. We may want to discuss enabling the monitor without needing to have it set to true in the config file. If we choose to do that, then we also need to change the behavior of the glusterfs app in the unit tests.
