### PR TITLE
Add concept of tags to devices and nodes

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -385,6 +385,11 @@ func (a *App) SetRoutes(router *mux.Router) error {
 			Method:      "POST",
 			Pattern:     "/nodes/{id:[A-Fa-f0-9]+}/state",
 			HandlerFunc: a.NodeSetState},
+		rest.Route{
+			Name:        "NodeSetTags",
+			Method:      "POST",
+			Pattern:     "/nodes/{id:[A-Fa-f0-9]+}/tags",
+			HandlerFunc: a.NodeSetTags},
 
 		// Devices
 		rest.Route{
@@ -412,6 +417,11 @@ func (a *App) SetRoutes(router *mux.Router) error {
 			Method:      "GET",
 			Pattern:     "/devices/{id:[A-Fa-f0-9]+}/resync",
 			HandlerFunc: a.DeviceResync},
+		rest.Route{
+			Name:        "DeviceSetTags",
+			Method:      "POST",
+			Pattern:     "/devices/{id:[A-Fa-f0-9]+}/tags",
+			HandlerFunc: a.DeviceSetTags},
 
 		// Volume
 		rest.Route{

--- a/apps/glusterfs/device_entry.go
+++ b/apps/glusterfs/device_entry.go
@@ -63,6 +63,7 @@ func NewDeviceEntryFromRequest(req *api.DeviceAddRequest) *DeviceEntry {
 	device.Info.Id = utils.GenUUID()
 	device.Info.Name = req.Name
 	device.NodeId = req.NodeId
+	device.Info.Tags = copyTags(req.Tags)
 
 	return device
 }
@@ -275,6 +276,7 @@ func (d *DeviceEntry) NewInfoResponse(tx *bolt.Tx) (*api.DeviceInfoResponse, err
 	info.Storage = d.Info.Storage
 	info.State = d.State
 	info.Bricks = make([]api.BrickInfo, 0)
+	info.Tags = copyTags(d.Info.Tags)
 
 	// Add each drive information
 	for _, id := range d.Bricks {
@@ -591,5 +593,17 @@ func (d *DeviceEntry) DeleteBricksWithEmptyPath(tx *bolt.Tx) error {
 			return err
 		}
 	}
+	return nil
+}
+
+func (d *DeviceEntry) AllTags() map[string]string {
+	if d.Info.Tags == nil {
+		return map[string]string{}
+	}
+	return d.Info.Tags
+}
+
+func (d *DeviceEntry) SetTags(t map[string]string) error {
+	d.Info.Tags = t
 	return nil
 }

--- a/apps/glusterfs/node_entry.go
+++ b/apps/glusterfs/node_entry.go
@@ -46,6 +46,7 @@ func NewNodeEntryFromRequest(req *api.NodeAddRequest) *NodeEntry {
 	node.Info.ClusterId = req.ClusterId
 	node.Info.Hostnames = req.Hostnames
 	node.Info.Zone = req.Zone
+	node.Info.Tags = copyTags(req.Tags)
 
 	return node
 }
@@ -391,6 +392,7 @@ func (n *NodeEntry) NewInfoReponse(tx *bolt.Tx) (*api.NodeInfoResponse, error) {
 	info.Zone = n.Info.Zone
 	info.State = n.State
 	info.DevicesInfo = make([]api.DeviceInfoResponse, 0)
+	info.Tags = copyTags(n.Info.Tags)
 
 	// Add each drive information
 	for _, deviceid := range n.Devices {
@@ -469,5 +471,17 @@ func (n *NodeEntry) DeleteBricksWithEmptyPath(tx *bolt.Tx) error {
 			return err
 		}
 	}
+	return nil
+}
+
+func (n *NodeEntry) AllTags() map[string]string {
+	if n.Info.Tags == nil {
+		return map[string]string{}
+	}
+	return n.Info.Tags
+}
+
+func (n *NodeEntry) SetTags(t map[string]string) error {
+	n.Info.Tags = t
 	return nil
 }

--- a/apps/glusterfs/placer_arbiter_test.go
+++ b/apps/glusterfs/placer_arbiter_test.go
@@ -360,11 +360,11 @@ func TestArbiterBrickPlacerBrickOnArbiterDevice(t *testing.T) {
 	}
 
 	abplacer := NewArbiterBrickPlacer()
-	abplacer.canHostArbiter = func(d *DeviceEntry) bool {
+	abplacer.canHostArbiter = func(d *DeviceEntry, ds DeviceSource) bool {
 		return d.Info.Id[0] == 'a'
 	}
-	abplacer.canHostData = func(d *DeviceEntry) bool {
-		return !abplacer.canHostArbiter(d)
+	abplacer.canHostData = func(d *DeviceEntry, ds DeviceSource) bool {
+		return !abplacer.canHostArbiter(d, ds)
 	}
 	ba, err := abplacer.PlaceAll(dsrc, opts, nil)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
@@ -450,11 +450,11 @@ func TestArbiterBrickPlacerBrickThreeSetsOnArbiterDevice(t *testing.T) {
 	}
 
 	abplacer := NewArbiterBrickPlacer()
-	abplacer.canHostArbiter = func(d *DeviceEntry) bool {
+	abplacer.canHostArbiter = func(d *DeviceEntry, ds DeviceSource) bool {
 		return d.Info.Id[0] == 'a'
 	}
-	abplacer.canHostData = func(d *DeviceEntry) bool {
-		return !abplacer.canHostArbiter(d)
+	abplacer.canHostData = func(d *DeviceEntry, ds DeviceSource) bool {
+		return !abplacer.canHostArbiter(d, ds)
 	}
 	ba, err := abplacer.PlaceAll(dsrc, opts, nil)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
@@ -718,11 +718,11 @@ func TestArbiterBrickPlacerReplaceTooFewArbiter(t *testing.T) {
 	}
 
 	abplacer := NewArbiterBrickPlacer()
-	abplacer.canHostArbiter = func(d *DeviceEntry) bool {
+	abplacer.canHostArbiter = func(d *DeviceEntry, ds DeviceSource) bool {
 		return d.Info.Id[0] == 'a'
 	}
-	abplacer.canHostData = func(d *DeviceEntry) bool {
-		return !abplacer.canHostArbiter(d)
+	abplacer.canHostData = func(d *DeviceEntry, ds DeviceSource) bool {
+		return !abplacer.canHostArbiter(d, ds)
 	}
 
 	ba, err := abplacer.PlaceAll(dsrc, opts, nil)

--- a/apps/glusterfs/tags.go
+++ b/apps/glusterfs/tags.go
@@ -42,12 +42,18 @@ func ApplyTags(t Taggable, req api.TagsChangeRequest) {
 		t.SetTags(req.Tags)
 	case api.UpdateTags:
 		newTags := t.AllTags()
+		if newTags == nil {
+			newTags = map[string]string{}
+		}
 		for k, v := range req.Tags {
 			newTags[k] = v
 		}
 		t.SetTags(newTags)
 	case api.DeleteTags:
 		newTags := t.AllTags()
+		if newTags == nil {
+			newTags = map[string]string{}
+		}
 		for k, _ := range req.Tags {
 			delete(newTags, k)
 		}

--- a/apps/glusterfs/tags.go
+++ b/apps/glusterfs/tags.go
@@ -13,6 +13,18 @@ import (
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
+// Well-known tags
+const (
+	TAG_ARBITER string = "arbiter"
+)
+
+// Well-known tag values
+const (
+	TAG_VAL_ARBITER_REQUIRED  string = "required"
+	TAG_VAL_ARBITER_SUPPORTED        = "supported"
+	TAG_VAL_ARBITER_DISABLED         = "disabled"
+)
+
 // Generic tagging related functions
 
 type Taggable interface {
@@ -52,4 +64,19 @@ func copyTags(t map[string]string) map[string]string {
 		out[k] = v
 	}
 	return out
+}
+
+// ArbiterTag returns the current arbiter tag value from the given
+// tag map. If the tag is not present or is an unexpected value
+// the default tag value is returned.
+func ArbiterTag(t map[string]string) string {
+	v := t[TAG_ARBITER]
+	switch v {
+	case TAG_VAL_ARBITER_REQUIRED,
+		TAG_VAL_ARBITER_SUPPORTED,
+		TAG_VAL_ARBITER_DISABLED:
+		return v
+	default:
+		return TAG_VAL_ARBITER_SUPPORTED
+	}
 }

--- a/apps/glusterfs/tags.go
+++ b/apps/glusterfs/tags.go
@@ -37,7 +37,22 @@ type Taggable interface {
 // such that in the future we could support add/exclusive-add/
 // delete for individual keys.
 func ApplyTags(t Taggable, req api.TagsChangeRequest) {
-	t.SetTags(req.SetTags)
+	switch req.Change {
+	case api.SetTags:
+		t.SetTags(req.Tags)
+	case api.UpdateTags:
+		newTags := t.AllTags()
+		for k, v := range req.Tags {
+			newTags[k] = v
+		}
+		t.SetTags(newTags)
+	case api.DeleteTags:
+		newTags := t.AllTags()
+		for k, _ := range req.Tags {
+			delete(newTags, k)
+		}
+		t.SetTags(newTags)
+	}
 }
 
 // MergeTags combines all the tags from the taggable items in the

--- a/apps/glusterfs/tags.go
+++ b/apps/glusterfs/tags.go
@@ -1,0 +1,55 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+)
+
+// Generic tagging related functions
+
+type Taggable interface {
+	AllTags() map[string]string
+	SetTags(map[string]string) error
+}
+
+// ApplyTags takes the request from the user and updates the
+// tags on the object accordingly. This api has been designed
+// such that in the future we could support add/exclusive-add/
+// delete for individual keys.
+func ApplyTags(t Taggable, req api.TagsChangeRequest) {
+	t.SetTags(req.SetTags)
+}
+
+// MergeTags combines all the tags from the taggable items in the
+// function arguments, with the rightmost items having priority.
+func MergeTags(t ...Taggable) map[string]string {
+	out := map[string]string{}
+	for _, src := range t {
+		for k, v := range src.AllTags() {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// copyTags makes a new tags map with the same contents
+// as the input map t. If the input map is nil an empty
+// map is returned rather than nil.
+func copyTags(t map[string]string) map[string]string {
+	out := map[string]string{}
+	if t == nil || len(t) == 0 {
+		return out
+	}
+	for k, v := range t {
+		out[k] = v
+	}
+	return out
+}

--- a/apps/glusterfs/tags_test.go
+++ b/apps/glusterfs/tags_test.go
@@ -1,0 +1,217 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"testing"
+
+	"github.com/heketi/tests"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+)
+
+type testTaggable struct {
+	T map[string]string
+}
+
+func (t *testTaggable) AllTags() map[string]string {
+	return t.T
+}
+
+func (t *testTaggable) SetTags(tags map[string]string) error {
+	t.T = tags
+	return nil
+}
+
+func TestApplyTagsSet(t *testing.T) {
+	tt := &testTaggable{}
+	r := api.TagsChangeRequest{
+		Tags: map[string]string{
+			"testcase": "TestApplyTagsSet",
+			"success":  "yes, please",
+		},
+		Change: api.SetTags,
+	}
+	ApplyTags(tt, r)
+	tests.Assert(t, len(tt.T) == 2, "expected len(tt.T) == 2, got:", len(tt.T))
+	tests.Assert(t, tt.T["testcase"] == "TestApplyTagsSet",
+		`expected tt.T["testcase"] == "TestApplyTagsSet", got:`,
+		tt.T["testcase"])
+}
+
+func TestApplyTagsUpdate(t *testing.T) {
+	tt := &testTaggable{}
+	r := api.TagsChangeRequest{
+		Tags: map[string]string{
+			"testcase": "TestApplyTagsUpdate",
+			"success":  "yes, please",
+		},
+		Change: api.UpdateTags,
+	}
+	ApplyTags(tt, r)
+	tests.Assert(t, len(tt.T) == 2, "expected len(tt.T) == 2, got:", len(tt.T))
+	tests.Assert(t, tt.T["testcase"] == "TestApplyTagsUpdate",
+		`expected tt.T["testcase"] == "TestApplyTagsUpdate", got:`,
+		tt.T["testcase"])
+
+	r = api.TagsChangeRequest{
+		Tags: map[string]string{
+			"testcase": "i already told you",
+			"king":     "buzzo",
+		},
+		Change: api.UpdateTags,
+	}
+	ApplyTags(tt, r)
+	tests.Assert(t, len(tt.T) == 3, "expected len(tt.T) == 3, got:", len(tt.T))
+	tests.Assert(t, tt.T["testcase"] == "i already told you",
+		`expected tt.T["testcase"] == "i already told you", got:`,
+		tt.T["testcase"])
+}
+
+func TestApplyTagsDelete(t *testing.T) {
+	tt := &testTaggable{}
+	r := api.TagsChangeRequest{
+		Tags: map[string]string{
+			"rock": "",
+		},
+		Change: api.DeleteTags,
+	}
+	ApplyTags(tt, r)
+	tests.Assert(t, len(tt.T) == 0, "expected len(tt.T) == 0, got:", len(tt.T))
+
+	r = api.TagsChangeRequest{
+		Tags: map[string]string{
+			"rock":     "yes",
+			"roll":     "yes",
+			"testcase": "TestApplyTagsDelete",
+		},
+		Change: api.UpdateTags,
+	}
+	ApplyTags(tt, r)
+	tests.Assert(t, len(tt.T) == 3, "expected len(tt.T) == 3, got:", len(tt.T))
+
+	r = api.TagsChangeRequest{
+		Tags: map[string]string{
+			"rock": "",
+			"roll": "xxx",
+		},
+		Change: api.DeleteTags,
+	}
+	ApplyTags(tt, r)
+	tests.Assert(t, len(tt.T) == 1, "expected len(tt.T) == 1, got:", len(tt.T))
+}
+
+func TestMergeTags(t *testing.T) {
+	tt1 := &testTaggable{map[string]string{
+		"king": "buzzo",
+		"rock": "n roll",
+		"road": "bull",
+	}}
+	tt2 := &testTaggable{map[string]string{
+		"king": "elvis",
+		"rock": "igneous",
+	}}
+
+	// entries in tt2 "have priority"
+	m := MergeTags(tt1, tt2)
+	tests.Assert(t, len(m) == 3, "expected len(m) == 3, got:", len(m))
+	tests.Assert(t, m["king"] == "elvis",
+		`expected m["king"] == "elvis", got:`, m["king"])
+	tests.Assert(t, m["rock"] == "igneous",
+		`expected m["rock"] == "igneous", got:`, m["rock"])
+	tests.Assert(t, m["road"] == "bull",
+		`expected m["road"] == "bull", got:`, m["road"])
+
+	// entries in tt1 "have priority"
+	m = MergeTags(tt2, tt1)
+	tests.Assert(t, len(m) == 3, "expected len(m) == 3, got:", len(m))
+	tests.Assert(t, m["king"] == "buzzo",
+		`expected m["king"] == "buzzo", got:`, m["king"])
+	tests.Assert(t, m["rock"] == "n roll",
+		`expected m["rock"] == "n roll", got:`, m["rock"])
+	tests.Assert(t, m["road"] == "bull",
+		`expected m["road"] == "bull", got:`, m["road"])
+
+	// entries in tt1 "have priority" + dummy items
+	ttx := &testTaggable{map[string]string{}}
+	m = MergeTags(tt2, ttx, tt1, ttx)
+	tests.Assert(t, len(m) == 3, "expected len(m) == 3, got:", len(m))
+	tests.Assert(t, m["king"] == "buzzo",
+		`expected m["king"] == "buzzo", got:`, m["king"])
+	tests.Assert(t, m["rock"] == "n roll",
+		`expected m["rock"] == "n roll", got:`, m["rock"])
+	tests.Assert(t, m["road"] == "bull",
+		`expected m["road"] == "bull", got:`, m["road"])
+}
+
+func TestCopyTags(t *testing.T) {
+	tags := copyTags(nil)
+	tests.Assert(t, tags != nil, "expected tags != nil")
+	tests.Assert(t, len(tags) == 0, "expected len(tags) == 0, got:", len(tags))
+
+	tags = copyTags(map[string]string{})
+	tests.Assert(t, tags != nil, "expected tags != nil")
+	tests.Assert(t, len(tags) == 0, "expected len(tags) == 0, got:", len(tags))
+
+	tags = copyTags(map[string]string{
+		"foo":  "bar",
+		"blip": "blap",
+	})
+	tests.Assert(t, tags != nil, "expected tags != nil")
+	tests.Assert(t, len(tags) == 2, "expected len(tags) == 2, got:", len(tags))
+
+	tags2 := copyTags(tags)
+	tests.Assert(t, tags != nil, "expected tags != nil")
+	tests.Assert(t, len(tags) == 2, "expected len(tags) == 2, got:", len(tags))
+	tags["foo"] = "oof"
+	tags["mumble"] = "jumble"
+
+	tests.Assert(t, len(tags) == 3, "expected len(tags) == 3, got:", len(tags))
+	tests.Assert(t, len(tags2) == 2, "expected len(tags) == 2, got:", len(tags))
+	tests.Assert(t, tags["foo"] == "oof",
+		`expected tags["foo"] == "oof", got:`, tags["foo"])
+	tests.Assert(t, tags2["foo"] == "bar",
+		`expected tags2["foo"] == "bar", got:`, tags2["foo"])
+}
+
+func TestArbiterTag(t *testing.T) {
+	tags := map[string]string{
+		"flim": "flam",
+	}
+
+	// no explicit arbiter tag
+	a := ArbiterTag(tags)
+	tests.Assert(t, a == TAG_VAL_ARBITER_SUPPORTED,
+		"expected a == TAG_VAL_ARBITER_SUPPORTED, got", a)
+
+	// explicit arbiter tag (supported)
+	tags["arbiter"] = "supported"
+	a = ArbiterTag(tags)
+	tests.Assert(t, a == TAG_VAL_ARBITER_SUPPORTED,
+		"expected a == TAG_VAL_ARBITER_SUPPORTED, got", a)
+
+	// explicit arbiter tag (disabled)
+	tags["arbiter"] = "disabled"
+	a = ArbiterTag(tags)
+	tests.Assert(t, a == TAG_VAL_ARBITER_DISABLED,
+		"expected a == TAG_VAL_ARBITER_DISABLED, got", a)
+
+	// explicit arbiter tag (supported)
+	tags["arbiter"] = "required"
+	a = ArbiterTag(tags)
+	tests.Assert(t, a == TAG_VAL_ARBITER_REQUIRED,
+		"expected a == TAG_VAL_ARBITER_REQUIRED, got", a)
+
+	// garbage value
+	tags["arbiter"] = "retibra"
+	a = ArbiterTag(tags)
+	tests.Assert(t, a == TAG_VAL_ARBITER_SUPPORTED,
+		"expected a == TAG_VAL_ARBITER_SUPPORTED, got", a)
+}

--- a/client/api/go-client/device.go
+++ b/client/api/go-client/device.go
@@ -215,3 +215,35 @@ func (c *Client) DeviceResync(id string) error {
 
 	return nil
 }
+
+func (c *Client) DeviceSetTags(id string, request *api.TagsChangeRequest) error {
+	buffer, err := json.Marshal(request)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST",
+		c.host+"/devices/"+id+"/tags",
+		bytes.NewBuffer(buffer))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Set token
+	err = c.setToken(req)
+	if err != nil {
+		return err
+	}
+
+	// Get info
+	r, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		return utils.GetErrorFromResponse(r)
+	}
+	return nil
+}

--- a/client/api/go-client/node.go
+++ b/client/api/go-client/node.go
@@ -185,3 +185,35 @@ func (c *Client) NodeState(id string, request *api.StateRequest) error {
 
 	return nil
 }
+
+func (c *Client) NodeSetTags(id string, request *api.TagsChangeRequest) error {
+	buffer, err := json.Marshal(request)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST",
+		c.host+"/nodes/"+id+"/tags",
+		bytes.NewBuffer(buffer))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Set token
+	err = c.setToken(req)
+	if err != nil {
+		return err
+	}
+
+	// Get info
+	r, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		return utils.GetErrorFromResponse(r)
+	}
+	return nil
+}

--- a/client/api/python/heketi/__init__.py
+++ b/client/api/python/heketi/__init__.py
@@ -8,4 +8,4 @@ __license__ = 'Apache License (2.0) or LGPLv3+'
 __copyright__ = 'Copyright 2016 Heketi authors'
 
 
-from .heketi import HeketiClient
+from .heketi import HeketiClient, TAGS_SET, TAGS_UPDATE, TAGS_DELETE

--- a/client/api/python/heketi/heketi.py
+++ b/client/api/python/heketi/heketi.py
@@ -23,6 +23,12 @@ import time
 import json
 
 
+# Constants related to setting tags
+TAGS_SET = 'set'
+TAGS_UPDATE = 'update'
+TAGS_DELETE = 'delete'
+
+
 class HeketiClient(object):
 
     def __init__(self, host, user, key):
@@ -158,6 +164,16 @@ class HeketiClient(object):
         return req.status_code == requests.codes.ok
         '''
 
+    def node_set_tags(self, node_id, tags_options):
+        '''Set, update, or delete tags on a node.
+        Specify tags with options key "tags" and a dict of tags & values,
+        specify change type with options key "change_type" and a
+        string value of "set", "update", "delete" (or use TAGS_* constants).
+        '''
+        uri = '/nodes/' + node_id + '/tags'
+        req = self._make_request('POST', uri, tags_options)
+        return req.status_code == requests.codes.ok
+
     def device_add(self, device_options={}):
         ''' device_options is a dict with parameters to be passed \
             in the json request: \
@@ -191,6 +207,16 @@ class HeketiClient(object):
         uri = '/devices/' + device_id + '/resync'
         req = self._make_request('GET', uri)
         return req.status_code == requests.codes.NO_CONTENT
+
+    def device_set_tags(self, device_id, tags_options):
+        '''Set, update, or delete tags on a device.
+        Specify tags with options key "tags" and a dict of tags & values,
+        specify change type with options key "change_type" and a
+        string value of "set", "update", "delete" (or use TAGS_* constants).
+        '''
+        uri = '/devices/' + device_id + '/tags'
+        req = self._make_request('POST', uri, tags_options)
+        return req.status_code == requests.codes.ok
 
     def volume_create(self, volume_options={}):
         ''' volume_options is a dict with volume creation options:

--- a/client/cli/go/cmds/device.go
+++ b/client/cli/go/cmds/device.go
@@ -194,6 +194,12 @@ var deviceInfoCommand = &cobra.Command{
 				info.Storage.Total/(1024*1024),
 				info.Storage.Used/(1024*1024),
 				info.Storage.Free/(1024*1024))
+			if len(info.Tags) != 0 {
+				fmt.Fprintf(stdout, "Tags:\n")
+				for k, v := range info.Tags {
+					fmt.Fprintf(stdout, "  %v: %v\n", k, v)
+				}
+			}
 
 			fmt.Fprintf(stdout, "Bricks:\n")
 			for _, d := range info.Bricks {

--- a/client/cli/go/cmds/device.go
+++ b/client/cli/go/cmds/device.go
@@ -324,19 +324,7 @@ var deviceSetTagsCommand = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		heketi := client.NewClient(options.Url, options.User, options.Key)
-		return setTagsCommand(cmd,
-			func(id string) (map[string]string, error) {
-				di, err := heketi.DeviceInfo(id)
-				if err != nil {
-					return nil, err
-				}
-				return di.Tags, nil
-			},
-			func(id string, tags map[string]string) error {
-				return heketi.DeviceSetTags(id, &api.TagsChangeRequest{
-					SetTags: tags,
-				})
-			})
+		return setTagsCommand(cmd, heketi.DeviceSetTags)
 	},
 }
 
@@ -349,18 +337,6 @@ var deviceRmTagsCommand = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		heketi := client.NewClient(options.Url, options.User, options.Key)
-		return rmTagsCommand(cmd,
-			func(id string) (map[string]string, error) {
-				di, err := heketi.DeviceInfo(id)
-				if err != nil {
-					return nil, err
-				}
-				return di.Tags, nil
-			},
-			func(id string, tags map[string]string) error {
-				return heketi.DeviceSetTags(id, &api.TagsChangeRequest{
-					SetTags: tags,
-				})
-			})
+		return rmTagsCommand(cmd, heketi.DeviceSetTags)
 	},
 }

--- a/client/cli/go/cmds/node.go
+++ b/client/cli/go/cmds/node.go
@@ -364,19 +364,7 @@ var nodeSetTagsCommand = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		heketi := client.NewClient(options.Url, options.User, options.Key)
-		return setTagsCommand(cmd,
-			func(id string) (map[string]string, error) {
-				ni, err := heketi.NodeInfo(id)
-				if err != nil {
-					return nil, err
-				}
-				return ni.Tags, nil
-			},
-			func(id string, tags map[string]string) error {
-				return heketi.NodeSetTags(id, &api.TagsChangeRequest{
-					SetTags: tags,
-				})
-			})
+		return setTagsCommand(cmd, heketi.NodeSetTags)
 	},
 }
 
@@ -389,18 +377,6 @@ var nodeRmTagsCommand = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		heketi := client.NewClient(options.Url, options.User, options.Key)
-		return rmTagsCommand(cmd,
-			func(id string) (map[string]string, error) {
-				ni, err := heketi.NodeInfo(id)
-				if err != nil {
-					return nil, err
-				}
-				return ni.Tags, nil
-			},
-			func(id string, tags map[string]string) error {
-				return heketi.NodeSetTags(id, &api.TagsChangeRequest{
-					SetTags: tags,
-				})
-			})
+		return rmTagsCommand(cmd, heketi.NodeSetTags)
 	},
 }

--- a/client/cli/go/cmds/node.go
+++ b/client/cli/go/cmds/node.go
@@ -289,6 +289,12 @@ var nodeInfoCommand = &cobra.Command{
 				info.Zone,
 				info.Hostnames.Manage[0],
 				info.Hostnames.Storage[0])
+			if len(info.Tags) != 0 {
+				fmt.Fprintf(stdout, "Tags:\n")
+				for k, v := range info.Tags {
+					fmt.Fprintf(stdout, "  %v: %v\n", k, v)
+				}
+			}
 			fmt.Fprintf(stdout, "Devices:\n")
 			for _, d := range info.DevicesInfo {
 				fmt.Fprintf(stdout, "Id:%-35v"+

--- a/client/cli/go/cmds/utils.go
+++ b/client/cli/go/cmds/utils.go
@@ -1,0 +1,115 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package cmds
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func setTagsCommand(cmd *cobra.Command,
+	fetchTags func(id string) (map[string]string, error),
+	submitTags func(id string, tags map[string]string) error) error {
+
+	//ensure proper number of args
+	s := cmd.Flags().Args()
+	if len(s) < 1 {
+		return errors.New("id required")
+	}
+	if len(s) < 2 {
+		return errors.New("at least one tag:value pair expected")
+	}
+
+	exact, err := cmd.Flags().GetBool("exact")
+	if err != nil {
+		return err
+	}
+
+	id = s[0]
+
+	newTags := map[string]string{}
+	for _, t := range s[1:] {
+		parts := strings.SplitN(t, ":", 2)
+		if len(parts) < 2 {
+			return fmt.Errorf(
+				"expected colon (:) between tag name and value, got: %v",
+				t)
+		}
+		newTags[parts[0]] = parts[1]
+	}
+
+	var setTags map[string]string
+	if exact {
+		setTags = newTags
+	} else {
+		oldTags, err := fetchTags(id)
+		if err != nil {
+			return err
+		}
+		if oldTags == nil {
+			setTags = map[string]string{}
+		} else {
+			setTags = oldTags
+		}
+		for k, v := range newTags {
+			setTags[k] = v
+		}
+	}
+
+	return submitTags(id, setTags)
+}
+
+func rmTagsCommand(cmd *cobra.Command,
+	fetchTags func(id string) (map[string]string, error),
+	submitTags func(id string, tags map[string]string) error) error {
+
+	//ensure proper number of args
+	s := cmd.Flags().Args()
+	if len(s) < 1 {
+		return errors.New("id required")
+	}
+
+	id := s[0]
+
+	removeAll, err := cmd.Flags().GetBool("all")
+	if err != nil {
+		return err
+	}
+
+	if len(s) < 2 && !removeAll {
+		return errors.New("at least one tag expected")
+	}
+	if len(s) >= 2 && removeAll {
+		return errors.New("--all may not be combined with named tags")
+	}
+
+	var setTags map[string]string
+	if removeAll {
+		setTags = map[string]string{}
+	} else {
+		oldTags, err := fetchTags(id)
+		if err != nil {
+			return err
+		}
+		if oldTags == nil {
+			setTags = map[string]string{}
+		} else {
+			setTags = oldTags
+		}
+		for _, k := range s[1:] {
+			delete(setTags, k)
+		}
+	}
+
+	return submitTags(id, setTags)
+}

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -13,10 +13,12 @@
     * [Nodes](#nodes)
         * [Add node](#add-node)
         * [Node Information](#node-information)
+        * [Set Node Tags](#set-node-tags)
         * [Delete node](#delete-node)
     * [Devices](#devices)
         * [Add device](#add-device)
         * [Device Information](#device-information)
+        * [Set Device Tags](#set-device-tags)
         * [Delete device](#delete-device)
     * [Volumes](#volumes)
         * [Create a Volume](#create-a-volume)
@@ -385,6 +387,39 @@ The _node_ RESTful endpoint is used to register a storage system for Heketi to m
 }
 ```
 
+### Set Node Tags
+
+Allows setting, updating, and deleting user specified metadata tags
+on a node. Tags are key-value pairs that are stored on the server.
+Certain well-known tags may be used by the server for configuration.
+
+Specifying a `change_type` of _set_ overwrites the tags on the object
+with exactly the set of tags in this request. A `change_type` of
+_update_ adds new tags and updates existing tags without changing
+tags not specified in the request. A `change_type` of _delete_ will
+remove tags names in the request (tag values in the request will
+be ignored).
+
+* **Method**: POST
+* **Endpoint**: `/nodes/{id}/tags`
+* **Response HTTP Status Code**: 200
+* **JSON Request**: None
+    * `change_type`: _string_, one of "set", "update", "delete"
+    * `tags`: _map of strings_, a mapping of tag-names to tag-values
+    * Example:
+
+```json
+{
+    "change_type": "set",
+    "tags": {
+        "arbiter": "supported",
+        "rack": "7,4",
+        "os_version": "linux 4.15.8"
+    }
+}
+```
+* **JSON Response**: Ignored
+
 ### Delete Node
 * **Method:** _DELETE_  
 * **Endpoint**:`/nodes/{id}`
@@ -457,6 +492,39 @@ The `devices` endpoint allows management of raw devices in the cluster.
     ]
 }
 ```
+
+### Set Device Tags
+
+Allows setting, updating, and deleting user specified metadata tags
+on a device. Tags are key-value pairs that are stored on the server.
+Certain well-known tags may be used by the server for configuration.
+
+Specifying a `change_type` of _set_ overwrites the tags on the object
+with exactly the set of tags in this request. A `change_type` of
+_update_ adds new tags and updates existing tags without changing
+tags not specified in the request. A `change_type` of _delete_ will
+remove tags names in the request (tag values in the request will
+be ignored).
+
+* **Method**: POST
+* **Endpoint**: `/devices/{id}/tags`
+* **Response HTTP Status Code**: 200
+* **JSON Request**: None
+    * `change_type`: _string_, one of "set", "update", "delete"
+    * `tags`: _map of strings_, a mapping of tag-names to tag-values
+    * Example:
+
+```json
+{
+    "change_type": "set",
+    "tags": {
+        "arbiter": "required",
+        "drivebay": "3",
+        "serial_number": "a109-84338af8e43-48dd9d43-919231"
+    }
+}
+```
+* **JSON Response**: Ignored
 
 ### Delete Device
 * **Method:** _DELETE_  

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -346,6 +346,7 @@ The _node_ RESTful endpoint is used to register a storage system for Heketi to m
         * manage: _array of strings_, List of node management hostnames.  Heketi needs to be able to SSH to the host on any of the supplied management hostnames.
         * storage: _array of strings_, List of node storage network hostnames.  These storage network addresses will be used to create and access the volume.
     * devices: _array maps_, See [Device Information](#device_info)
+    * tags: _map_, (omitted if empty) a mapping of tag-names to tag-values
     * Example:
 
 ```json
@@ -360,6 +361,10 @@ The _node_ RESTful endpoint is used to register a storage system for Heketi to m
         "storage": [
             "node1-storage.gluster.lab.com"
         ]
+    },
+    "tags": {
+        "arbiter": "supported",
+        "rack": "7,4"
     },
     "devices": [
         {
@@ -463,6 +468,7 @@ The `devices` endpoint allows management of raw devices in the cluster.
         * id: _string_, UUID of brick
         * path: _string_, Path of brick on the node
         * size: _uint64_, Size of brick in KB
+    * tags: _map_, (omitted if empty) a mapping of tag-names to tag-values
     * Example:
 
 ```json
@@ -474,6 +480,10 @@ The `devices` endpoint allows management of raw devices in the cluster.
         "used": 0
     },
     "id": "49a9bd2e40df882180479024ac4c24c8",
+    "tags": {
+        "arbiter": "required",
+        "drivebay": "3"
+    },
     "bricks": [
         {
             "id": "aaaaaad2e40df882180479024ac4c24c8",

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -316,6 +316,7 @@ The _node_ RESTful endpoint is used to register a storage system for Heketi to m
             * _NOTE:_  Even though it takes a list of hostnames, only one is supported at the moment.  The plan is to support multiple hostnames when glusterd-2 is used.  For Kubernetes and OpenShift, this must be the name of the Pod file, not the name of the node.
         * storage: _array of strings_, List of node storage network hostnames.  These storage network addresses will be used to create and access the volume.  It is *highly* recommended to use hostnames instead of IP addresses. _NOTE:_  Even though it takes a list of hostnames, only one is supported at the moment.  The plan is to support multiple ip address when glusterd-2 is used.
     * cluster: _string_, UUID of cluster to whom this node should be part of.
+    * tags: _map of strings_, (optional) a mapping of tag-names to tag-values
     * Example:
 
 ```json
@@ -328,6 +329,9 @@ The _node_ RESTful endpoint is used to register a storage system for Heketi to m
         "storage": [
             "node1-storage.gluster.lab.com"
         ]
+    },
+    "tags": {
+        "incantation": "abracadabra"
     },
     "cluster": "67e267ea403dfcdf80731165b300d1ca"
 }
@@ -444,12 +448,16 @@ The `devices` endpoint allows management of raw devices in the cluster.
 * **JSON Request**:
     * node: _string_, UUID of node which the devices belong to.
     * name: _string_, Device name
+    * tags: _map of strings_, (optional) a mapping of tag-names to tag-values
     * Example:
 
 ```json
 {
     "node": "714c510140c20e808002f2b074bc0c50",
-    "name": "/dev/sdb"
+    "name": "/dev/sdb",
+    "tags": {
+        "serial_number": "a109-84338af8e43-48dd9d43-919231"
+    }
 }
 ```
 

--- a/docs/man/heketi-cli.8
+++ b/docs/man/heketi-cli.8
@@ -209,6 +209,51 @@ $ heketi-cli device resync 886a86a868711bef83001
 .fi
 .RE
 .RE
+.PP
+\fBheketi\-cli device settags <DEVICE-ID> <TAG>:<VALUE> ...\fP
+.RS
+Set metadata tags on a given device. Tags are free-form key value pairs
+that are stored by Heketi and may be used for extra configuration.
+One or more <TAG>:<TAG-VALUE> pairs may be provided.
+.PP
+.B Options
+.RS
+.TP
+\fB\-\-exact
+Optional:
+Overwrite the existing tags with the exactly set of tags (and values)
+specified on this command line. Without this option, the command will
+add or update tags.
+.RE
+.PP
+\fBExample\fP
+.RS
+.nf
+$ heketi-cli device settags 886a86a868711bef83001 arbiter:required flavor:strawberry
+.fi
+.RE
+.RE
+.PP
+\fBheketi\-cli device rmtags <DEVICE-ID> <TAG> ...\fP
+.RS
+Remove metadata tags from a given device.
+.PP
+.B Options
+.RS
+.TP
+\fB\-\-all
+Optional:
+Remove all tags from the specified device. May not be combined with
+specifying tag names.
+.RE
+.PP
+\fBExample\fP
+.RS
+.nf
+$ heketi-cli device rmtags 886a86a868711bef83001 arbiter
+.fi
+.RE
+.RE
 .SS "Node Commands"
 .PP
 \fBheketi\-cli node add \-\-zone=<ZONE-NUMBER> \-\-cluster=<CLUSTER-ID> \-\-management\-host\-name=<MANAGEMENT-HOSTNAME> \-\-storage-host-name=<STORAGE-HOSTNAME>\fP
@@ -299,6 +344,51 @@ List all nodes in cluster
 .RE
 .nf
 $ heketi\-cli node list
+.fi
+.RE
+.RE
+.PP
+\fBheketi\-cli node settags <NODE-ID> <TAG>:<VALUE> ...\fP
+.RS
+Set metadata tags on a given node. Tags are free-form key value pairs
+that are stored by Heketi and may be used for extra configuration.
+One or more <TAG>:<TAG-VALUE> pairs may be provided.
+.PP
+.B Options
+.RS
+.TP
+\fB\-\-exact
+Optional:
+Overwrite the existing tags with the exactly set of tags (and values)
+specified on this command line. Without this option, the command will
+add or update tags.
+.RE
+.PP
+\fBExample\fP
+.RS
+.nf
+$ heketi-cli node settags 886a86a868711bef83001 arbiter:required flavor:strawberry
+.fi
+.RE
+.RE
+.PP
+\fBheketi\-cli node rmtags <NODE-ID> <TAG> ...\fP
+.RS
+Remove metadata tags from a given node.
+.PP
+.B Options
+.RS
+.TP
+\fB\-\-all
+Optional:
+Remove all tags from the specified node. May not be combined with
+specifying tag names.
+.RE
+.PP
+\fBExample\fP
+.RS
+.nf
+$ heketi-cli node rmtags 886a86a868711bef83001 arbiter
 .fi
 .RE
 .RE

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -387,14 +387,27 @@ type LogLevelInfo struct {
 	LogLevel map[string]string `json:"loglevel"`
 }
 
+type TagsChangeType string
+
+const (
+	UnknownTagsChangeType TagsChangeType = ""
+	SetTags               TagsChangeType = "set"
+	UpdateTags            TagsChangeType = "update"
+	DeleteTags            TagsChangeType = "delete"
+)
+
 // Common tag post body
 type TagsChangeRequest struct {
-	SetTags map[string]string `json:"settags"`
+	Tags   map[string]string `json:"tags"`
+	Change TagsChangeType    `json:"change_type"`
 }
 
 func (tcr TagsChangeRequest) Validate() error {
 	return validation.ValidateStruct(&tcr,
-		validation.Field(&tcr.SetTags, validation.By(ValidateTags)))
+		validation.Field(&tcr.Tags, validation.By(ValidateTags)),
+		validation.Field(&tcr.Change,
+			validation.Required,
+			validation.In(SetTags, UpdateTags, DeleteTags)))
 }
 
 func ValidateTags(v interface{}) error {

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -150,7 +150,8 @@ type BrickInfo struct {
 
 // Device
 type Device struct {
-	Name string `json:"name"`
+	Name string            `json:"name"`
+	Tags map[string]string `json:"tags,omitempty"`
 }
 
 func (dev Device) Validate() error {
@@ -185,9 +186,10 @@ type DeviceInfoResponse struct {
 
 // Node
 type NodeAddRequest struct {
-	Zone      int           `json:"zone"`
-	Hostnames HostAddresses `json:"hostnames"`
-	ClusterId string        `json:"cluster"`
+	Zone      int               `json:"zone"`
+	Hostnames HostAddresses     `json:"hostnames"`
+	ClusterId string            `json:"cluster"`
+	Tags      map[string]string `json:"tags,omitempty"`
 }
 
 func (req NodeAddRequest) Validate() error {
@@ -379,6 +381,11 @@ type BlockVolumeListResponse struct {
 type LogLevelInfo struct {
 	// should contain one or more logger to log-level-name mapping
 	LogLevel map[string]string `json:"loglevel"`
+}
+
+// Common tag post body
+type TagsChangeRequest struct {
+	SetTags map[string]string `json:"settags"`
 }
 
 // Constructors

--- a/tests/functional/TestSmokeTest/tests/arbiter_test.go
+++ b/tests/functional/TestSmokeTest/tests/arbiter_test.go
@@ -76,6 +76,123 @@ func TestArbiterFlatCluster(t *testing.T) {
 	t.Run("testArbiterReplaceArbiterBrick", testArbiterReplaceArbiterBrick)
 }
 
+func TestArbiterTagging(t *testing.T) {
+	setupCluster(t, 4, 8)
+	defer teardownCluster(t)
+
+	cl, err := heketi.ClusterList()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(cl.Clusters) > 0,
+		"expected len(cl.Clusters) > 0, got:", len(cl.Clusters))
+	clusterId := cl.Clusters[0]
+
+	clusterInfo, err := heketi.ClusterInfo(clusterId)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	nid := clusterInfo.Nodes[0]
+	n, err := heketi.NodeInfo(nid)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	tests.Assert(t, len(n.Tags) == 0,
+		"expected len(n.Tags) == 0, got:", len(n.Tags))
+
+	err = heketi.NodeSetTags(nid, &api.TagsChangeRequest{
+		SetTags: map[string]string{
+			"flourpower": "300",
+			"zamboni":    "yes please",
+		},
+	})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	n, err = heketi.NodeInfo(nid)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(n.Tags) == 2,
+		"expected len(n.Tags) == 2, got:", len(n.Tags))
+
+	err = heketi.NodeSetTags(nid, &api.TagsChangeRequest{})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	n, err = heketi.NodeInfo(nid)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(n.Tags) == 0,
+		"expected len(n.Tags) == 0, got:", len(n.Tags))
+
+	err = heketi.NodeSetTags(nid, &api.TagsChangeRequest{
+		SetTags: map[string]string{
+			"arbiter": "disabled",
+		},
+	})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	n, err = heketi.NodeInfo(nid)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(n.Tags) == 1,
+		"expected len(n.Tags) == 1, got:", len(n.Tags))
+}
+
+func TestArbiterTaggedNodes(t *testing.T) {
+	setupCluster(t, 4, 8)
+	defer teardownCluster(t)
+
+	// first we're going to test that we cannot create
+	// an arbiter volume if none of the devices support arbiter
+	cl, err := heketi.ClusterList()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(cl.Clusters) > 0,
+		"expected len(cl.Clusters) > 0, got:", len(cl.Clusters))
+	clusterId := cl.Clusters[0]
+
+	clusterInfo, err := heketi.ClusterInfo(clusterId)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	for _, nid := range clusterInfo.Nodes {
+		n, err := heketi.NodeInfo(nid)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(n.Tags) == 0,
+			"expected len(n.Tags) == 0, got:", len(n.Tags))
+
+		err = heketi.NodeSetTags(nid, &api.TagsChangeRequest{
+			SetTags: map[string]string{
+				"arbiter": "disabled",
+			},
+		})
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	}
+
+	volReq := &api.VolumeCreateRequest{}
+	volReq.Size = 10
+	volReq.Durability.Type = api.DurabilityReplicate
+	volReq.Durability.Replicate.Replica = 3
+	volReq.GlusterVolumeOptions = []string{"user.heketi.arbiter true"}
+
+	_, err = heketi.VolumeCreate(volReq)
+	tests.Assert(t, err != nil, "expected err != nil, got:", err)
+
+	vl, err := heketi.VolumeList()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(vl.Volumes) == 0,
+		"expected len(vl.Volumes) == 0, got:", len(vl.Volumes))
+
+	// now tag one of the nodes for arbiter, and things should work
+	nid := clusterInfo.Nodes[0]
+	err = heketi.NodeSetTags(nid, &api.TagsChangeRequest{
+		SetTags: map[string]string{
+			"arbiter": "required",
+		},
+	})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	t.Run("testArbiterCreateSimple", testArbiterCreateSimple)
+	teardownVolumes(t)
+	t.Run("testArbiterCreateAndVerify", testArbiterCreateAndVerify)
+	teardownVolumes(t)
+	t.Run("testNonArbiterIsNotArbiter", testNonArbiterIsNotArbiter)
+	teardownVolumes(t)
+	t.Run("testArbiterReplaceDataBrick", testArbiterReplaceDataBrick)
+	teardownVolumes(t)
+	t.Run("testArbiterReplaceArbiterBrick", testArbiterReplaceArbiterBrick)
+}
+
 func testArbiterCreateSimple(t *testing.T) {
 	vl, err := heketi.VolumeList()
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)

--- a/tests/functional/TestSmokeTest/tests/arbiter_test.go
+++ b/tests/functional/TestSmokeTest/tests/arbiter_test.go
@@ -97,10 +97,11 @@ func TestArbiterTagging(t *testing.T) {
 		"expected len(n.Tags) == 0, got:", len(n.Tags))
 
 	err = heketi.NodeSetTags(nid, &api.TagsChangeRequest{
-		SetTags: map[string]string{
+		Tags: map[string]string{
 			"flourpower": "300",
 			"zamboni":    "yes please",
 		},
+		Change: api.SetTags,
 	})
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
@@ -109,7 +110,7 @@ func TestArbiterTagging(t *testing.T) {
 	tests.Assert(t, len(n.Tags) == 2,
 		"expected len(n.Tags) == 2, got:", len(n.Tags))
 
-	err = heketi.NodeSetTags(nid, &api.TagsChangeRequest{})
+	err = heketi.NodeSetTags(nid, &api.TagsChangeRequest{Change: api.SetTags})
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	n, err = heketi.NodeInfo(nid)
@@ -118,9 +119,10 @@ func TestArbiterTagging(t *testing.T) {
 		"expected len(n.Tags) == 0, got:", len(n.Tags))
 
 	err = heketi.NodeSetTags(nid, &api.TagsChangeRequest{
-		SetTags: map[string]string{
+		Tags: map[string]string{
 			"arbiter": "disabled",
 		},
+		Change: api.SetTags,
 	})
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
@@ -128,6 +130,47 @@ func TestArbiterTagging(t *testing.T) {
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, len(n.Tags) == 1,
 		"expected len(n.Tags) == 1, got:", len(n.Tags))
+
+	// now add a new tag
+	err = heketi.NodeSetTags(nid, &api.TagsChangeRequest{
+		Tags: map[string]string{
+			"foo-bar": "yes",
+		},
+		Change: api.UpdateTags,
+	})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	n, err = heketi.NodeInfo(nid)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(n.Tags) == 2,
+		"expected len(n.Tags) == 2, got:", len(n.Tags))
+
+	// add and remove a tag
+	err = heketi.NodeSetTags(nid, &api.TagsChangeRequest{
+		Tags: map[string]string{
+			"flim-flam": "no",
+		},
+		Change: api.UpdateTags,
+	})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	n, err = heketi.NodeInfo(nid)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(n.Tags) == 3,
+		"expected len(n.Tags) == 3, got:", len(n.Tags))
+
+	err = heketi.NodeSetTags(nid, &api.TagsChangeRequest{
+		Tags: map[string]string{
+			"flim-flam": "",
+		},
+		Change: api.DeleteTags,
+	})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	n, err = heketi.NodeInfo(nid)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(n.Tags) == 2,
+		"expected len(n.Tags) == 2, got:", len(n.Tags))
 }
 
 func TestArbiterTaggedNodes(t *testing.T) {
@@ -152,9 +195,10 @@ func TestArbiterTaggedNodes(t *testing.T) {
 			"expected len(n.Tags) == 0, got:", len(n.Tags))
 
 		err = heketi.NodeSetTags(nid, &api.TagsChangeRequest{
-			SetTags: map[string]string{
+			Tags: map[string]string{
 				"arbiter": "disabled",
 			},
+			Change: api.SetTags,
 		})
 		tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	}
@@ -176,9 +220,10 @@ func TestArbiterTaggedNodes(t *testing.T) {
 	// now tag one of the nodes for arbiter, and things should work
 	nid := clusterInfo.Nodes[0]
 	err = heketi.NodeSetTags(nid, &api.TagsChangeRequest{
-		SetTags: map[string]string{
+		Tags: map[string]string{
 			"arbiter": "required",
 		},
+		Change: api.SetTags,
 	})
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Tags are short-ish user controlled metadata
that Heketi can choose to interpret but are otherwise free-form. We will be using our first well known tag "arbiter" to control how the system places arbiter bricks.

The following features have been implemented:
* Ability to store and retrieve tags from the node and device entries in the DB.
* Utility file for tags management
* Server API for setting tags on nodes and devices
* Go client api for setting tags on nodes and devices
* heketi-cli subcommands to set and remove tags on nodes and devices
* heketi-cli support for tags within the topology file
* Support for the arbiter tag
* Hooks for the arbiter placer to use the tag
* Functional tests for tags and arbiter tag


