### PR TITLE
cli: support alternative names for setup-openshift-heketi-storage

### DIFF
--- a/client/cli/go/cmds/heketi_storage.go
+++ b/client/cli/go/cmds/heketi_storage.go
@@ -282,7 +282,11 @@ func createHeketiCopyJob(volume *api.VolumeInfoResponse) *batch.Job {
 }
 
 var setupHeketiStorageCommand = &cobra.Command{
-	Use:   "setup-openshift-heketi-storage",
+	Use: "setup-openshift-heketi-storage",
+	Aliases: []string{
+		"setup-heketi-db-storage",
+		"setup-kubernetes-heketi-storage",
+	},
 	Short: "Setup OpenShift/Kubernetes persistent storage for Heketi",
 	Long: "Creates a dedicated GlusterFS volume for Heketi.\n" +
 		"Once the volume is created, a Kubernetes/OpenShift\n" +


### PR DESCRIPTION
This is an only partially serious suggestion triggered by a
comment @jarrpa made a while back.
(see
https://github.com/gluster/gluster-kubernetes/issues/434#issuecomment-366006365
)

Using cobra's aliases feature we no longer have to be embarrassed by
an overly openshift specific command name, but can now refer to it
via much more generic names. In the future we could even swap
the "true" name for one of these fine aliases.
