### PR TITLE
cli: show number of bricks in 'node info' output

### DIFF
--- a/client/cli/go/cmds/node.go
+++ b/client/cli/go/cmds/node.go
@@ -296,13 +296,15 @@ var nodeInfoCommand = &cobra.Command{
 					"State:%-10v"+
 					"Size (GiB):%-8v"+
 					"Used (GiB):%-8v"+
-					"Free (GiB):%-8v\n",
+					"Free (GiB):%-8v"+
+					"Bricks:%-8v\n",
 					d.Id,
 					d.Name,
 					d.State,
 					d.Storage.Total/(1024*1024),
 					d.Storage.Used/(1024*1024),
-					d.Storage.Free/(1024*1024))
+					d.Storage.Free/(1024*1024),
+					len(d.Bricks))
 			}
 		}
 		return nil


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

While working on the volume cloning feature, it is useful to know how
many bricks are located on a device. Extending the 'node info' command
in the heketi-cli makes it easier to find devices where the cloned
volumes (bricks get cloned on the same device) are placed.

Example:

    $ hekti-cli node info 86736cdb27764fd767ae8a4f566deffa
    ...
    Devices:
    Id:29d625b5ca3c51a50c03795fabc2446f   Name:/dev/vdc            State:online    Size (GiB):499     Used (GiB):120     Free (GiB):379     Bricks:3
    Id:de13a0e3322f653ae3ec69e991a5e3c2   Name:/dev/vdf            State:online    Size (GiB):499     Used (GiB):32      Free (GiB):467     Bricks:1
    Id:e659c56fde5b75ce18e9815457a2558a   Name:/dev/vde            State:online    Size (GiB):499     Used (GiB):308     Free (GiB):191     Bricks:2
    Id:e94c1d0e58843ed0333d0e202f0fb375   Name:/dev/vdb            State:online    Size (GiB):499     Used (GiB):0       Free (GiB):499     Bricks:0
    Id:f4b1a94f99d5ac39df5c877903335c0f   Name:/dev/vdd            State:online    Size (GiB):499     Used (GiB):64      Free (GiB):435     Bricks:1
