### PR TITLE
Provide options to change arbiter brick size

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -288,6 +288,10 @@ func (a *App) setAdvSettings() {
 		// Convert to KB
 		BrickMinSize = uint64(a.conf.BrickMinSize) * 1024 * 1024
 	}
+	if a.conf.AverageFileSize != 0 {
+		logger.Info("Average file size on volumes set to %v KiB", a.conf.AverageFileSize)
+		averageFileSize = a.conf.AverageFileSize
+	}
 }
 
 func (a *App) setBlockSettings() {

--- a/apps/glusterfs/app_config.go
+++ b/apps/glusterfs/app_config.go
@@ -26,9 +26,10 @@ type GlusterFSConfig struct {
 	Loglevel   string              `json:"loglevel"`
 
 	// advanced settings
-	BrickMaxSize int `json:"brick_max_size_gb"`
-	BrickMinSize int `json:"brick_min_size_gb"`
-	BrickMaxNum  int `json:"max_bricks_per_volume"`
+	BrickMaxSize    int    `json:"brick_max_size_gb"`
+	BrickMinSize    int    `json:"brick_min_size_gb"`
+	BrickMaxNum     int    `json:"max_bricks_per_volume"`
+	AverageFileSize uint64 `json:"average_file_size_kb"`
 
 	//block settings
 	CreateBlockHostingVolumes bool `json:"auto_create_block_hosting_volume"`

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -353,6 +353,10 @@ func (vp *VolumePlacementOpts) SetCount() int {
 	return vp.numBrickSets
 }
 
+func (vp *VolumePlacementOpts) AverageFileSize() uint64 {
+	return vp.v.GetAverageFileSize()
+}
+
 type StandardBrickPlacer struct{}
 
 func NewStandardBrickPlacer() *StandardBrickPlacer {

--- a/apps/glusterfs/placer.go
+++ b/apps/glusterfs/placer.go
@@ -50,6 +50,8 @@ type PlacementOpts interface {
 	// SetCount returns the total number of Brick Sets that
 	// will be produced.
 	SetCount() int
+	// AverageFileSize returns the average file size for the volume
+	AverageFileSize() uint64
 }
 
 // DeviceFilter functions can be defined by the caller of a

--- a/apps/glusterfs/placer_arbiter.go
+++ b/apps/glusterfs/placer_arbiter.go
@@ -17,9 +17,6 @@ import (
 
 var (
 	tryPlaceAgain error = fmt.Errorf("Placement failed. Try again.")
-
-	// average size of files on a volume
-	AverageFileSize uint64 = 64 * KB
 )
 
 const (
@@ -57,7 +54,7 @@ func newArbiterOpts(opts PlacementOpts) *arbiterOpts {
 func (aopts *arbiterOpts) discount(index int) (err error) {
 	if index == arbiter_index {
 		aopts.brickSize, err = discountBrickSize(
-			aopts.brickSize, AverageFileSize)
+			aopts.brickSize, aopts.o.AverageFileSize())
 	}
 	return
 }

--- a/apps/glusterfs/placer_arbiter.go
+++ b/apps/glusterfs/placer_arbiter.go
@@ -18,8 +18,8 @@ import (
 var (
 	tryPlaceAgain error = fmt.Errorf("Placement failed. Try again.")
 
-	// default discount size of an arbiter brick
-	ArbiterDiscountSize uint64 = 64 * KB
+	// average size of files on a volume
+	AverageFileSize uint64 = 64 * KB
 )
 
 const (
@@ -57,7 +57,7 @@ func newArbiterOpts(opts PlacementOpts) *arbiterOpts {
 func (aopts *arbiterOpts) discount(index int) (err error) {
 	if index == arbiter_index {
 		aopts.brickSize, err = discountBrickSize(
-			aopts.brickSize, ArbiterDiscountSize)
+			aopts.brickSize, AverageFileSize)
 	}
 	return
 }
@@ -344,11 +344,11 @@ func (dscan *arbiterDeviceScanner) Scan(index int) <-chan string {
 	return dscan.dataDevs
 }
 
-func discountBrickSize(size, discountSize uint64) (uint64, error) {
-	if size < discountSize {
+func discountBrickSize(dataBrickSize, averageFileSize uint64) (uint64, error) {
+	if dataBrickSize < averageFileSize {
 		return 0, fmt.Errorf(
-			"Brick size (%v) too small for arbiter (discount size %v)",
-			size, discountSize)
+			"Average file size (%v) is greater than Brick size (%v)",
+			averageFileSize, dataBrickSize)
 	}
-	return (size / discountSize), nil
+	return (dataBrickSize / averageFileSize), nil
 }

--- a/apps/glusterfs/placer_arbiter_test.go
+++ b/apps/glusterfs/placer_arbiter_test.go
@@ -108,6 +108,7 @@ type TestPlacementOpts struct {
 	brickGid        int64
 	setSize         int
 	setCount        int
+	averageFileSize uint64
 }
 
 func (tpo *TestPlacementOpts) BrickSizes() (uint64, float64) {
@@ -128,6 +129,10 @@ func (tpo *TestPlacementOpts) SetSize() int {
 
 func (tpo *TestPlacementOpts) SetCount() int {
 	return tpo.setCount
+}
+
+func (tpo *TestPlacementOpts) AverageFileSize() uint64 {
+	return tpo.averageFileSize
 }
 
 func TestTestDeviceSource(t *testing.T) {
@@ -221,6 +226,7 @@ func TestArbiterBrickPlacer(t *testing.T) {
 		brickOwner:      "asdfasdf",
 		setSize:         3,
 		setCount:        1,
+		averageFileSize: 64 * KB,
 	}
 
 	abplacer := NewArbiterBrickPlacer()
@@ -266,6 +272,7 @@ func TestArbiterBrickPlacerTooSmall(t *testing.T) {
 		brickOwner:      "asdfasdf",
 		setSize:         3,
 		setCount:        1,
+		averageFileSize: 64 * KB,
 	}
 
 	abplacer := NewArbiterBrickPlacer()
@@ -283,6 +290,7 @@ func TestArbiterBrickPlacerDevicesFail(t *testing.T) {
 		brickOwner:      "asdfasdf",
 		setSize:         3,
 		setCount:        1,
+		averageFileSize: 64 * KB,
 	}
 
 	abplacer := NewArbiterBrickPlacer()
@@ -314,6 +322,7 @@ func TestArbiterBrickPlacerPredicateBlock(t *testing.T) {
 		brickOwner:      "asdfasdf",
 		setSize:         3,
 		setCount:        1,
+		averageFileSize: 64 * KB,
 	}
 
 	abplacer := NewArbiterBrickPlacer()
@@ -347,6 +356,7 @@ func TestArbiterBrickPlacerBrickOnArbiterDevice(t *testing.T) {
 		brickOwner:      "asdfasdf",
 		setSize:         3,
 		setCount:        1,
+		averageFileSize: 64 * KB,
 	}
 
 	abplacer := NewArbiterBrickPlacer()
@@ -389,6 +399,7 @@ func TestArbiterBrickPlacerBrickThreeSets(t *testing.T) {
 		brickOwner:      "asdfasdf",
 		setSize:         3,
 		setCount:        3,
+		averageFileSize: 64 * KB,
 	}
 
 	abplacer := NewArbiterBrickPlacer()
@@ -435,6 +446,7 @@ func TestArbiterBrickPlacerBrickThreeSetsOnArbiterDevice(t *testing.T) {
 		brickOwner:      "asdfasdf",
 		setSize:         3,
 		setCount:        3,
+		averageFileSize: 64 * KB,
 	}
 
 	abplacer := NewArbiterBrickPlacer()
@@ -490,6 +502,7 @@ func TestArbiterBrickPlacerSimpleReplace(t *testing.T) {
 		brickOwner:      "asdfasdf",
 		setSize:         3,
 		setCount:        1,
+		averageFileSize: 64 * KB,
 	}
 
 	abplacer := NewArbiterBrickPlacer()
@@ -551,6 +564,7 @@ func TestArbiterBrickPlacerReplaceIndexOOB(t *testing.T) {
 		brickOwner:      "asdfasdf",
 		setSize:         3,
 		setCount:        1,
+		averageFileSize: 64 * KB,
 	}
 
 	abplacer := NewArbiterBrickPlacer()
@@ -602,6 +616,7 @@ func TestArbiterBrickPlacerReplaceDevicesFail(t *testing.T) {
 		brickOwner:      "asdfasdf",
 		setSize:         3,
 		setCount:        1,
+		averageFileSize: 64 * KB,
 	}
 
 	abplacer := NewArbiterBrickPlacer()
@@ -643,6 +658,7 @@ func TestArbiterBrickPlacerReplaceTooFew(t *testing.T) {
 		brickOwner:      "asdfasdf",
 		setSize:         3,
 		setCount:        1,
+		averageFileSize: 64 * KB,
 	}
 
 	abplacer := NewArbiterBrickPlacer()
@@ -698,6 +714,7 @@ func TestArbiterBrickPlacerReplaceTooFewArbiter(t *testing.T) {
 		brickOwner:      "asdfasdf",
 		setSize:         3,
 		setCount:        1,
+		averageFileSize: 64 * KB,
 	}
 
 	abplacer := NewArbiterBrickPlacer()


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?
This PR provides options to change arbiter brick size calculation in heketi. This is needed because as explained below the default in heketi might not work for all use cases. 

Calculation of arbiter brick size is dependent on

* size required for storing metadata for a each file
* maximum number of files that user may need to store on the volume.

We fix the metadata size for each file to 1KiB based on 
* https://gist.github.com/pfactum/e8265ca07f7b19f30bb3
* http://gluster.readthedocs.io/en/latest/Administrator%20Guide/arbiter-volumes-and-quorum/

Hence the only variable that remains is maximum number of files that user may need to store on the volume. This is a little difficult to estimate but can be derived from average file size and volume size. As we already know the volume size, it is easier to just ask for average file size from user.

If we assume average file size is 64KiB then there can be maximum 16384 files in a 1GiB volume and arbiter brick would need 16MiB. This seems like a good default; if the arbiter node has only one 512 GiB SSD, it can still take about 32K bricks. 

At this point, there are three levels where average file size is defined
a. each volume create can come with user.heketi.average-file-size value and it applies only to that volume
b. admin can provide a different average file size in config file and it applies to all volumes which are further created and don't have explicit value for average file size.
c. heketi internally has set average file size as 64 KiB.
