### PR TITLE
apps: enable the node health monitor by default in server binary

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -47,6 +47,12 @@ var (
 	// undefined.
 	// TODO: make a global not needed
 	currentNodeHealthCache *NodeHealthCache
+
+	// global var to enable the use of the health cache + monitor
+	// when the GlusterFS App is created. This is mildly hacky but
+	// avoids having to update config files to enable the feature
+	// while avoiding having to touch all of the unit tests.
+	MonitorGlusterNodes = false
 )
 
 type App struct {
@@ -188,7 +194,7 @@ func NewApp(configIo io.Reader) *App {
 	if app.conf.StartTimeMonitorGlusterNodes > 0 {
 		startDelay = app.conf.StartTimeMonitorGlusterNodes
 	}
-	if app.conf.MonitorGlusterNodes {
+	if MonitorGlusterNodes {
 		app.nhealth = NewNodeHealthCache(timer, startDelay, app.db, app.executor)
 		app.nhealth.Monitor()
 		currentNodeHealthCache = app.nhealth
@@ -255,14 +261,6 @@ func (a *App) setFromEnvironmentalVariable() {
 		a.conf.BlockHostingVolumeSize, err = strconv.Atoi(env)
 		if err != nil {
 			logger.LogError("Error: Atoi in Block Hosting Volume Size: %v", err)
-		}
-	}
-
-	env = os.Getenv("HEKETI_MONITOR_GLUSTER_NODES")
-	if "" != env {
-		a.conf.MonitorGlusterNodes, err = strconv.ParseBool(env)
-		if err != nil {
-			logger.LogError("Error: While parsing HEKETI_MONITOR_GLUSTER_NODES as bool: %v", err)
 		}
 	}
 }

--- a/apps/glusterfs/app_config.go
+++ b/apps/glusterfs/app_config.go
@@ -36,7 +36,6 @@ type GlusterFSConfig struct {
 
 	// server behaviors
 	IgnoreStaleOperations          bool   `json:"ignore_stale_operations"`
-	MonitorGlusterNodes            bool   `json:"monitor_gluster_nodes"`
 	RefreshTimeMonitorGlusterNodes uint32 `json:"refresh_time_monitor_gluster_nodes"`
 	StartTimeMonitorGlusterNodes   uint32 `json:"start_time_monitor_gluster_nodes"`
 }

--- a/etc/heketi.json
+++ b/etc/heketi.json
@@ -55,9 +55,6 @@
     "_db_comment": "Database file name",
     "db": "/var/lib/heketi/heketi.db",
 
-    "_monitor_gluster_nodes": "Periodically check that Gluster nodes are functioning.",
-    "monitor_gluster_nodes": true,
-
      "_refresh_time_monitor_gluster_nodes": "Refresh time in seconds to monitor Gluster nodes",
     "refresh_time_monitor_gluster_nodes": 120,
 

--- a/main.go
+++ b/main.go
@@ -280,6 +280,14 @@ func setupApp(fp *os.File) (a *glusterfs.App) {
 	// Go to the beginning of the file when we pass it
 	// to the application
 	fp.Seek(0, os.SEEK_SET)
+
+	// If one really needs to disable the health monitor for
+	// the server binary we provide only this env var.
+	env := os.Getenv("HEKETI_DISABLE_HEALTH_MONITOR")
+	if env != "true" {
+		glusterfs.MonitorGlusterNodes = true
+	}
+
 	return glusterfs.NewApp(fp)
 }
 


### PR DESCRIPTION
This change removes the ability to enable or disable the node health
monitor from the heketi config file. Instead, we provide a package
level variable that the glusterfs app uses to determine if the
monitor should be used or not. By default this variable is false thus
all unit tests and other non-server code will not run the monitor.

The server binary does set this variable to true by default thus
enabling the monitor for the heketi server. For debugging purposes
this can be disabled (in the server only) by setting
`HEKETI_DISABLE_HEALTH_MONITOR=true` in the environment.
