### PR TITLE
Improve create rollback behavior when cleanup fails

### DIFF
--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -777,7 +777,15 @@ func (v *VolumeEntry) runOnHost(db wdb.RODB,
 		return err
 	}
 
+	nodeUp := currentNodeHealthStatus()
 	for nodeId, host := range hosts {
+		if up, found := nodeUp[nodeId]; found && !up {
+			// if the node is in the cache and we know it was not
+			// recently healthy, skip it
+			logger.Debug("skipping node. %v (%v) is presumed unhealthy",
+				nodeId, host)
+			continue
+		}
 		logger.Debug("running function on node %v (%v)", nodeId, host)
 		tryNext, err := cb(host)
 		if !tryNext {


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

When the underlying gluster system is able to create a volume but not start it heketi can get into a weird state. This seems to have been made worse by the recent volume create retry code being able to "spam" many volume create commands in a shorter time period.
This change aims to make rollback more accurately reflect the state of the system and fail in the face of a condition that it can not clean up.

### Notes for the reviewer


