### PR TITLE
apps: enable rebalance on expansion by default

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -82,6 +82,13 @@ func NewApp(configIo io.Reader) *App {
 		return nil
 	}
 
+	// We would like to perform rebalance by default
+	// As it is very difficult to distinguish missing parameter from
+	// set-but-false parameter in json, we are going to ignore json config
+	// We will provide a env method to set it to false again.
+	app.conf.KubeConfig.RebalanceOnExpansion = true
+	app.conf.SshConfig.RebalanceOnExpansion = true
+
 	// Set values mentioned in environmental variable
 	app.setFromEnvironmentalVariable()
 
@@ -261,6 +268,17 @@ func (a *App) setFromEnvironmentalVariable() {
 		a.conf.BlockHostingVolumeSize, err = strconv.Atoi(env)
 		if err != nil {
 			logger.LogError("Error: Atoi in Block Hosting Volume Size: %v", err)
+		}
+	}
+
+	env = os.Getenv("HEKETI_GLUSTERAPP_REBALANCE_ON_EXPANSION")
+	if env != "" {
+		value, err := strconv.ParseBool(env)
+		if err != nil {
+			logger.LogError("Error: While parsing HEKETI_GLUSTERAPP_REBALANCE_ON_EXPANSION as bool: %v", err)
+		} else {
+			a.conf.SshConfig.RebalanceOnExpansion = value
+			a.conf.KubeConfig.RebalanceOnExpansion = value
 		}
 	}
 }


### PR DESCRIPTION

<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?
We would like to perform rebalance by default as it is very difficult to
distinguish missing parameter from set-but-false parameter in json, we
are going to ignore json config. We provide a env method to set it
to false again.

Env is HEKETI_GLUSTERAPP_REBALANCE_ON_EXPANSION

### Notes for the reviewer
I know it makes the parameter in json config file invalid but IMO this is the only way to get rid of this problem. 

