### PR TITLE
Fix shellcheck

### DIFF
--- a/client/cli/go/heketi-cli.sh
+++ b/client/cli/go/heketi-cli.sh
@@ -124,7 +124,7 @@ __handle_filename_extension_flag()
 __handle_subdirs_in_dir_flag()
 {
     local dir="$1"
-    pushd "${dir}" >/dev/null 2>&1 && _filedir -d && popd >/dev/null 2>&1
+    pushd "${dir}" >/dev/null 2>&1 && _filedir -d && popd >/dev/null 2>&1 || exit
 }
 
 __handle_flag()

--- a/client/cli/go/heketi-cli.sh
+++ b/client/cli/go/heketi-cli.sh
@@ -52,7 +52,7 @@ __handle_reply()
             else
                 allflags=("${flags[*]} ${two_word_flags[*]}")
             fi
-            COMPREPLY=( $(compgen -W "${allflags[*]}" -- "$cur") )
+            COMPREPLY=( "$(compgen -W "${allflags[*]}" -- "$cur")" )
             if [[ $(type -t compopt) = "builtin" ]]; then
                 [[ "${COMPREPLY[0]}" == *= ]] || compopt +o nospace
             fi
@@ -101,10 +101,10 @@ __handle_reply()
     if [[ ${#must_have_one_flag[@]} -ne 0 ]]; then
         completions+=("${must_have_one_flag[@]}")
     fi
-    COMPREPLY=( $(compgen -W "${completions[*]}" -- "$cur") )
+    COMPREPLY=( "$(compgen -W "${completions[*]}" -- "$cur")" )
 
     if [[ ${#COMPREPLY[@]} -eq 0 && ${#noun_aliases[@]} -gt 0 && ${#must_have_one_noun[@]} -ne 0 ]]; then
-        COMPREPLY=( $(compgen -W "${noun_aliases[*]}" -- "$cur") )
+        COMPREPLY=( "$(compgen -W "${noun_aliases[*]}" -- "$cur")" )
     fi
 
     if [[ ${#COMPREPLY[@]} -eq 0 ]]; then

--- a/test.sh
+++ b/test.sh
@@ -19,7 +19,7 @@ run_test() {
 	sts=$?
 	if [[ ${sts} -ne 0 ]]; then
 		vecho "failed ${cmd} [${sts}]"
-		FAILURES+=(${cmd})
+		FAILURES+=("${cmd}")
 		if [[ "${exitfirst}" = "yes" ]]; then
 			exit 1
 		fi

--- a/tests/300-db-import-export.sh
+++ b/tests/300-db-import-export.sh
@@ -40,7 +40,7 @@ kill_server() {
 show_err() {
         if [[ $? -ne 0 ]]
         then
-                echo -e "\nFAIL: error on line $1"
+                echo -e "\\nFAIL: error on line $1"
         fi
 }
 

--- a/tests/functional/TestKubeSmokeTest/run.sh
+++ b/tests/functional/TestKubeSmokeTest/run.sh
@@ -19,7 +19,7 @@ docker_set_env() {
     ### CENTOS WORKAROUND ###
     ### Suffering from same bug as https://github.com/getcarina/carina/issues/112
     ###
-    if grep -q -s "CentOS\|Fedora" /etc/redhat-release ; then
+    if grep -q -s "CentOS\\|Fedora" /etc/redhat-release ; then
         echo "CentOS/Fedora DOCKER WORKAROUND"
         curl -sL https://download.getcarina.com/dvm/latest/install.sh | sh
         eval "$(minikube docker-env)"
@@ -77,12 +77,12 @@ setup_minikube() {
     fi
 
     if ! md5sum -c md5sums > /dev/null 2>&1 ; then
-        echo -e "\nGet docker-machine"
+        echo -e "\\nGet docker-machine"
         curl -Lo docker-machine https://github.com/docker/machine/releases/download/v0.8.2/docker-machine-Linux-x86_64 || fail "Unable to get docker-machine"
         chmod +x docker-machine
         _sudo mv docker-machine /usr/local/bin
 
-        echo -e "\nGet docker-machine-driver-kvm"
+        echo -e "\\nGet docker-machine-driver-kvm"
         curl -Lo docker-machine-driver-kvm \
             https://github.com/dhiltgen/docker-machine-kvm/releases/download/v0.7.0/docker-machine-driver-kvm || fail "Unable to get docker-machine-driver-kvm"
         chmod +x docker-machine-driver-kvm
@@ -91,20 +91,20 @@ setup_minikube() {
         _sudo usermod -a -G libvirt "$(whoami)"
         #newgrp libvirt
 
-        echo -e "\nGet minikube"
+        echo -e "\\nGet minikube"
         curl -Lo minikube \
             https://storage.googleapis.com/minikube/releases/v0.12.2/minikube-linux-amd64 || fail "Unable to get minikube"
         chmod +x minikube
         _sudo mv minikube /usr/local/bin
 
-        echo -e "\nGet kubectl $KUBEVERSION"
+        echo -e "\\nGet kubectl $KUBEVERSION"
         curl -Lo kubectl \
             http://storage.googleapis.com/kubernetes-release/release/${KUBEVERSION}/bin/linux/amd64/kubectl || fail "Unable to get kubectl"
         chmod +x kubectl
         _sudo mv kubectl /usr/local/bin
     fi
 
-    echo -e "\nOpt-out of errors"
+    echo -e "\\nOpt-out of errors"
     minikube config set WantReportErrorPrompt false
 }
 
@@ -116,7 +116,7 @@ start_minikube() {
 		--kubernetes-version="${KUBEVERSION}" || fail "Unable to start minikube"
 
     # wait until it is ready
-    echo -e "\nWait until kubernetes containers are running and ready"
+    echo -e "\\nWait until kubernetes containers are running and ready"
     while [ 3 -ne "$(kubectl get pods --all-namespaces | grep -c Running)" ] ; do
         echo -n "."
         sleep 1

--- a/tests/functional/TestKubeSmokeTest/testHeketiMock.sh
+++ b/tests/functional/TestKubeSmokeTest/testHeketiMock.sh
@@ -12,45 +12,45 @@ eval "$(minikube docker-env)"
 
 display_information() {
 	# Display information
-	echo -e "\nVersions"
+	echo -e "\\nVersions"
 	kubectl version
 
-	echo -e "\nDocker containers running"
+	echo -e "\\nDocker containers running"
 	docker ps
 
-	echo -e "\nDocker images"
+	echo -e "\\nDocker images"
 	docker images
 
-	echo -e "\nShow nodes"
+	echo -e "\\nShow nodes"
 	kubectl get nodes
 }
 
 setup_heketi() {
 	# Start Heketi
-	echo -e "\nStart Heketi container"
+	echo -e "\\nStart Heketi container"
 	kubectl run heketi --image=heketi/heketi:ci --port=8080 || fail "Unable to start heketi container"
 	sleep 2
 
 	# This blocks until ready
 	kubectl expose deployment heketi --type=NodePort || fail "Unable to expose heketi service"
 
-	echo -e "\nShow Topology"
+	echo -e "\\nShow Topology"
 	HEKETI_CLI_SERVER=$(minikube service heketi --url)
 	export HEKETI_CLI_SERVER
 	heketi-cli topology info
 
-	echo -e "\nLoad mock topology"
+	echo -e "\\nLoad mock topology"
 	heketi-cli topology load --json=mock-topology.json || fail "Unable to load topology"
 
-	echo -e "\nShow Topology"
+	echo -e "\\nShow Topology"
 	HEKETI_CLI_SERVER="$(minikube service heketi --url)"
 	export HEKETI_CLI_SERVER
 	heketi-cli topology info
 
-	echo -e "\nRegister mock endpoints"
+	echo -e "\\nRegister mock endpoints"
 	kubectl create -f mock-endpoints.json || fail "Unable to submit mock-endpoints"
 
-	echo -e "\nRegister storage class"
+	echo -e "\\nRegister storage class"
 	sed -e \
 	"s#%%URL%%#${HEKETI_CLI_SERVER}#" \
 	storageclass.yaml.sed > "${RESOURCES_DIR}/sc.yaml"
@@ -100,7 +100,7 @@ test_delete() {
 display_information
 setup_heketi
 
-echo -e "\n*** Start tests ***"
+echo -e "\\n*** Start tests ***"
 test_create
 test_delete
 

--- a/tests/functional/TestKubeSmokeTest/testHeketiRpc.sh
+++ b/tests/functional/TestKubeSmokeTest/testHeketiRpc.sh
@@ -12,16 +12,16 @@ eval "$(minikube docker-env)"
 
 display_information() {
 	# Display information
-	echo -e "\nVersions"
+	echo -e "\\nVersions"
 	kubectl version
 
-	echo -e "\nDocker containers running"
+	echo -e "\\nDocker containers running"
 	docker ps
 
-	echo -e "\nDocker images"
+	echo -e "\\nDocker images"
 	docker images
 
-	echo -e "\nShow nodes"
+	echo -e "\\nShow nodes"
 	kubectl get nodes
 }
 
@@ -78,7 +78,7 @@ setup_all_pods() {
 	kubectl get nodes --show-labels
 
 	# Start Heketi
-	echo -e "\nStart Heketi container"
+	echo -e "\\nStart Heketi container"
     sed -e "s#heketi/heketi:dev#heketi/heketi:ci#" \
         -e "s#Always#IfNotPresent#" \
         "$RESOURCES_DIR/deploy-heketi-deployment.json" | kubectl create -f -
@@ -96,26 +96,26 @@ setup_all_pods() {
 	echo "Create a service for deploy-heketi"
 	kubectl expose deployment deploy-heketi --port=8080 --type=NodePort || fail "Unable to expose heketi service"
 
-	echo -e "\nShow Topology"
+	echo -e "\\nShow Topology"
 	HEKETI_CLI_SERVER=$(minikube service deploy-heketi --url)
 	export HEKETI_CLI_SERVER
 	heketi-cli topology info
 
-	echo -e "\nStart gluster mock container"
+	echo -e "\\nStart gluster mock container"
 	start_mock_gluster_container 1
 }
 
 test_add_devices() {
-	echo -e "\nGet the Heketi server connection"
+	echo -e "\\nGet the Heketi server connection"
 	heketi-cli cluster create || fail "Unable to create cluster"
 
 	CLUSTERID=$(heketi-cli cluster list | sed -e '$!d')
 
-	echo -e "\nAdd Node"
+	echo -e "\\nAdd Node"
 	heketi-cli node add --zone=1 --cluster="$CLUSTERID" \
 		--management-host-name=minikube --storage-host-name=minikube || fail "Unable to add gluster1"
 
-	echo -e "\nAdd device"
+	echo -e "\\nAdd device"
 	nodeid=$(heketi-cli node list | awk '{print $1}' | awk -F: '{print $2}')
 	heketi-cli device add --name=/dev/fakedevice --node="$nodeid" || fail "Unable to add device"
 
@@ -133,14 +133,14 @@ test_add_devices() {
 		fail "Expected free of 99 instead got $device_free"
 	fi
 
-	echo -e "\nShow Topology"
+	echo -e "\\nShow Topology"
 	heketi-cli topology info
 }
 
 display_information
 setup_all_pods
 
-echo -e "\n*** Start tests ***"
+echo -e "\\n*** Start tests ***"
 test_add_devices
 
 # Ok now start test

--- a/tests/functional/run.sh
+++ b/tests/functional/run.sh
@@ -62,7 +62,7 @@ fetch_golang() {
 vercheck() {
     # return true (0) if version number $2 is greater-or-equal to
     # version number $1
-    r="$(echo -e "$1\n$2" | sort -V | head -n1)"
+    r="$(echo -e "$1\\n$2" | sort -V | head -n1)"
     if [[ "$r" == "$1" ]]; then
         return 0
     fi


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Recent versions of shellcheck (0.4.7, on fedora 27) fail on various scripts. This PR fixes those scripts, so that the `tests/020-test-shellscripts.sh` test passes again.

### Does this PR fix issues?

Fixes #1151

### Notes for the reviewer

Only the last patch to the bash-completion script that catches an error of popd or pushd and exits in that case might be slightly controversial. But I think it's ok.
