### PR TITLE
Allow pass the database file name via env var to heketi-start.sh

### DIFF
--- a/extras/kubernetes/heketi-start.sh
+++ b/extras/kubernetes/heketi-start.sh
@@ -1,19 +1,21 @@
 #!/bin/sh
 
+HEKETI_DB_PATH=${HEKETI_DB_PATH:-/var/lib/heketi/heketi.db}
+
 if [ -f /backupdb/heketi.db.gz ] ; then
-    gunzip -c /backupdb/heketi.db.gz > /var/lib/heketi/heketi.db
+    gunzip -c /backupdb/heketi.db.gz > "${HEKETI_DB_PATH}"
     if [ $? -ne 0 ] ; then
         echo "Unable to copy database"
         exit 1
     fi
-    echo "Copied backup db to /var/lib/heketi/heketi.db"
+    echo "Copied backup db to ${HEKETI_DB_PATH}"
 elif [ -f /backupdb/heketi.db ] ; then
-    cp /backupdb/heketi.db /var/lib/heketi/heketi.db
+    cp /backupdb/heketi.db "${HEKETI_DB_PATH}"
     if [ $? -ne 0 ] ; then
         echo "Unable to copy database"
         exit 1
     fi
-    echo "Copied backup db to /var/lib/heketi/heketi.db"
+    echo "Copied backup db to ${HEKETI_DB_PATH}"
 fi
 
 /usr/bin/heketi --config=/etc/heketi/heketi.json


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
You provide ability to change path of db file in the heketi server configuration file (heketi.json)
```
  "glusterfs": {
    "_executor_comment": "Execute plugin. Possible choices: mock, kubernetes, ssh",
    "executor": "kubernetes",

    "_db_comment": "Database file name",
    "db": "/var/lib/heketi/heketi.db",

    "kubeexec": {
      "rebalance_on_expansion": true
},
```
But you don't provide this ability in heketi-start.sh

This small fix gives this ability. In pod spec I can specify environment variable with another path to db file.
For example:
```
HEKETI_DB_PATH=/my/path/to/heketi.db
```
