### PR TITLE
apps: treat an empty string log level name as a no-op

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -227,6 +227,9 @@ func SetLogLevel(level string) error {
 		logger.SetLevel(utils.LEVEL_INFO)
 	case "debug":
 		logger.SetLevel(utils.LEVEL_DEBUG)
+	case "":
+		// treat empty string as a no-op & don't complain
+		// about it
 	default:
 		return fmt.Errorf("invalid log level: %s", level)
 	}


### PR DESCRIPTION
Some heketi config files lack a specific log level and thus
the configuration value is defaulted to the empty string.
If this is passed to the glusterfs app SetLogLevel it produces
an ugly message on start up. Simply treat the empty string
as a no-op.

Signed-off-by: John Mulligan <jmulligan@redhat.com>