### PR TITLE
Add client side tls configuration

### DIFF
--- a/client/api/go-client/client.go
+++ b/client/api/go-client/client.go
@@ -14,7 +14,11 @@ package client
 
 import (
 	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -26,12 +30,22 @@ const (
 	MAX_CONCURRENT_REQUESTS = 32
 )
 
+type ClientTLSOptions struct {
+	// directly borrow the field names from crypto/tls
+	InsecureSkipVerify bool
+	// one or more cert file paths (best for self-signed certs)
+	VerifyCerts []string
+}
+
 // Client object
 type Client struct {
 	host     string
 	key      string
 	user     string
 	throttle chan bool
+
+	// configuration for TLS support
+	tlsClientConfig *tls.Config
 }
 
 // Creates a new client to access a Heketi server
@@ -48,9 +62,45 @@ func NewClient(host, user, key string) *Client {
 	return c
 }
 
+func NewClientTLS(host, user, key string, tlsOpts *ClientTLSOptions) (*Client, error) {
+	c := NewClient(host, user, key)
+	if err := c.SetTLSOptions(tlsOpts); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
 // Create a client to access a Heketi server without authentication enabled
 func NewClientNoAuth(host string) *Client {
 	return NewClient(host, "", "")
+}
+
+// SetTLSOptions configures an existing heketi client for
+// TLS support based on the ClientTLSOptions.
+func (c *Client) SetTLSOptions(o *ClientTLSOptions) error {
+	if o == nil {
+		c.tlsClientConfig = nil
+		return nil
+	}
+
+	tlsConfig := &tls.Config{}
+	tlsConfig.InsecureSkipVerify = o.InsecureSkipVerify
+	if len(o.VerifyCerts) > 0 {
+		tlsConfig.RootCAs = x509.NewCertPool()
+		for _, path := range o.VerifyCerts {
+			pem, err := ioutil.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("failed to read cert file %v: %v",
+					path, err)
+			}
+			if ok := tlsConfig.RootCAs.AppendCertsFromPEM(pem); !ok {
+				return fmt.Errorf("failed to load PEM encoded cert from %s",
+					path)
+			}
+		}
+	}
+	c.tlsClientConfig = tlsConfig
+	return nil
 }
 
 // Simple Hello test to check if the server is up
@@ -88,6 +138,11 @@ func (c *Client) do(req *http.Request) (*http.Response, error) {
 	}()
 
 	httpClient := &http.Client{}
+	if c.tlsClientConfig != nil {
+		httpClient.Transport = &http.Transport{
+			TLSClientConfig: c.tlsClientConfig,
+		}
+	}
 	httpClient.CheckRedirect = c.checkRedirect
 	return httpClient.Do(req)
 }

--- a/client/api/python/heketi/heketi.py
+++ b/client/api/python/heketi/heketi.py
@@ -31,10 +31,11 @@ TAGS_DELETE = 'delete'
 
 class HeketiClient(object):
 
-    def __init__(self, host, user, key):
+    def __init__(self, host, user, key, verify=True):
         self.host = host
         self.user = user
         self.key = key
+        self.verify = verify
 
     def _set_token_in_header(self, method, uri, headers={}):
         claims = {}
@@ -61,7 +62,7 @@ class HeketiClient(object):
         uri = '/hello'
 
         headers = self._set_token_in_header(method, uri)
-        r = requests.get(self.host + uri, headers=headers)
+        r = requests.get(self.host + uri, headers=headers, verify=self.verify)
         return r.status_code == requests.codes.ok
 
     def _make_request(self, method, uri, data={}, headers={}):
@@ -74,7 +75,8 @@ class HeketiClient(object):
         r = requests.request(method,
                              self.host + uri,
                              headers=headers,
-                             data=json.dumps(data))
+                             data=json.dumps(data),
+                             verify=self.verify)
 
         r.raise_for_status()
 
@@ -91,7 +93,8 @@ class HeketiClient(object):
             headers = self._set_token_in_header('GET', queue_uri)
             q = requests.get(self.host + queue_uri,
                              headers=headers,
-                             allow_redirects=False)
+                             allow_redirects=False,
+                             verify=self.verify)
 
             # Raise an exception when the request fails
             q.raise_for_status()

--- a/client/cli/go/cmds/block_volume.go
+++ b/client/cli/go/cmds/block_volume.go
@@ -16,7 +16,6 @@ import (
 	//	"os"
 	"strings"
 
-	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/spf13/cobra"
 )
@@ -103,7 +102,10 @@ var blockVolumeCreateCommand = &cobra.Command{
 			return errors.New("Invalid HA count")
 		}
 
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		blockvolume, err := heketi.BlockVolumeCreate(req)
 		if err != nil {
@@ -141,10 +143,13 @@ var blockVolumeDeleteCommand = &cobra.Command{
 		volumeId := cmd.Flags().Arg(0)
 
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		//set url
-		err := heketi.BlockVolumeDelete(volumeId)
+		err = heketi.BlockVolumeDelete(volumeId)
 		if err == nil {
 			fmt.Fprintf(stdout, "Volume %v deleted\n", volumeId)
 		}
@@ -169,7 +174,10 @@ var blockVolumeInfoCommand = &cobra.Command{
 		volumeId := cmd.Flags().Arg(0)
 
 		// Create a client to talk to Heketi
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		// Create cluster
 		info, err := heketi.BlockVolumeInfo(volumeId)
@@ -198,7 +206,10 @@ var blockVolumeListCommand = &cobra.Command{
 	Example: "  $ heketi-cli blockvolume list",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		// List volumes
 		list, err := heketi.BlockVolumeList()

--- a/client/cli/go/cmds/cluster.go
+++ b/client/cli/go/cmds/cluster.go
@@ -16,7 +16,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/heketi/heketi/client/api/go-client"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/spf13/cobra"
 )
@@ -90,7 +89,10 @@ var clusterCreateCommand = &cobra.Command{
 		req.Block = cl_block
 
 		// Create a client to talk to Heketi
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 		// Create cluster
 		cluster, err := heketi.ClusterCreate(req)
 		if err != nil {
@@ -134,7 +136,10 @@ var clusterSetFlagsCommand = &cobra.Command{
 
 		clusterId := cmd.Flags().Arg(0)
 
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		info, err := heketi.ClusterInfo(clusterId)
 		if err != nil {
@@ -187,10 +192,13 @@ var clusterDeleteCommand = &cobra.Command{
 		clusterId := cmd.Flags().Arg(0)
 
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		//set url
-		err := heketi.ClusterDelete(clusterId)
+		err = heketi.ClusterDelete(clusterId)
 		if err == nil {
 			fmt.Fprintf(stdout, "Cluster %v deleted\n", clusterId)
 		}
@@ -214,7 +222,10 @@ var clusterInfoCommand = &cobra.Command{
 		clusterId := cmd.Flags().Arg(0)
 
 		// Create a client to talk to Heketi
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		info, err := heketi.ClusterInfo(clusterId)
 		if err != nil {
@@ -247,7 +258,10 @@ var clusterListCommand = &cobra.Command{
 	Example: "  $ heketi-cli cluster list",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		// List clusters
 		list, err := heketi.ClusterList()

--- a/client/cli/go/cmds/db.go
+++ b/client/cli/go/cmds/db.go
@@ -12,7 +12,6 @@ package cmds
 import (
 	"fmt"
 
-	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +33,10 @@ var dumpDbCommand = &cobra.Command{
 	Long:    "dumps the database in json format",
 	Example: "  $ heketi-cli db dump",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		dump, err := heketi.DbDump()
 		if err != nil {

--- a/client/cli/go/cmds/device.go
+++ b/client/cli/go/cmds/device.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/heketi/heketi/client/api/go-client"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/spf13/cobra"
 )
@@ -86,7 +85,10 @@ var deviceAddCommand = &cobra.Command{
 		req.DestroyData = destroyData
 
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		// Add node
 		err = heketi.DeviceAdd(req)
@@ -117,10 +119,13 @@ var deviceDeleteCommand = &cobra.Command{
 		deviceId := cmd.Flags().Arg(0)
 
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		//set url
-		err := heketi.DeviceDelete(deviceId)
+		err = heketi.DeviceDelete(deviceId)
 		if err == nil {
 			fmt.Fprintf(stdout, "Device %v deleted\n", deviceId)
 		}
@@ -146,13 +151,16 @@ var deviceRemoveCommand = &cobra.Command{
 		deviceId := cmd.Flags().Arg(0)
 
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		//set url
 		req := &api.StateRequest{
 			State: "failed",
 		}
-		err := heketi.DeviceState(deviceId, req)
+		err = heketi.DeviceState(deviceId, req)
 		if err == nil {
 			fmt.Fprintf(stdout, "Device %v is now removed\n", deviceId)
 		}
@@ -177,7 +185,10 @@ var deviceInfoCommand = &cobra.Command{
 		deviceId := cmd.Flags().Arg(0)
 
 		// Create a client to talk to Heketi
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		// Create cluster
 		info, err := heketi.DeviceInfo(deviceId)
@@ -248,13 +259,16 @@ var deviceEnableCommand = &cobra.Command{
 		deviceId := cmd.Flags().Arg(0)
 
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		//set url
 		req := &api.StateRequest{
 			State: "online",
 		}
-		err := heketi.DeviceState(deviceId, req)
+		err = heketi.DeviceState(deviceId, req)
 		if err == nil {
 			fmt.Fprintf(stdout, "Device %v is now online\n", deviceId)
 		}
@@ -280,13 +294,16 @@ var deviceDisableCommand = &cobra.Command{
 		deviceId := cmd.Flags().Arg(0)
 
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		//set url
 		req := &api.StateRequest{
 			State: "offline",
 		}
-		err := heketi.DeviceState(deviceId, req)
+		err = heketi.DeviceState(deviceId, req)
 		if err == nil {
 			fmt.Fprintf(stdout, "Device %v is now offline\n", deviceId)
 		}
@@ -311,10 +328,13 @@ var deviceResyncCommand = &cobra.Command{
 		deviceId := cmd.Flags().Arg(0)
 
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		//set url
-		err := heketi.DeviceResync(deviceId)
+		err = heketi.DeviceResync(deviceId)
 		if err == nil {
 			fmt.Fprintf(stdout, "Device %v updated\n", nodeId)
 		}
@@ -330,7 +350,10 @@ var deviceSetTagsCommand = &cobra.Command{
 	Example: "  $ heketi-cli device settags 886a86a868711bef83001 foo:bar",
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 		return setTagsCommand(cmd, heketi.DeviceSetTags)
 	},
 }
@@ -343,7 +366,10 @@ var deviceRmTagsCommand = &cobra.Command{
 	Example: "  $ heketi-cli device rmtags 886a86a868711bef83001 foo",
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 		return rmTagsCommand(cmd, heketi.DeviceSetTags)
 	},
 }

--- a/client/cli/go/cmds/heketi_storage.go
+++ b/client/cli/go/cmds/heketi_storage.go
@@ -307,7 +307,10 @@ var setupHeketiStorageCommand = &cobra.Command{
 		list.Items = make([]interface{}, 0)
 
 		// Create client
-		c := client.NewClient(options.Url, options.User, options.Key)
+		c, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		// Create volume
 		volume, err := createHeketiStorageVolume(c, durability, heketiStorageReplicaCount)

--- a/client/cli/go/cmds/loglevel.go
+++ b/client/cli/go/cmds/loglevel.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/heketi/heketi/client/api/go-client"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
@@ -38,7 +37,10 @@ var logLevelGetCommand = &cobra.Command{
 	Long:    "Get Heketi server Log Level",
 	Example: `  $ heketi-cli loglevel get`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 		llinfo, err := heketi.LogLevelGet()
 		if err == nil {
 			fmt.Fprintf(stdout, "%s\n", llinfo.LogLevel["glusterfs"])
@@ -59,8 +61,11 @@ var logLevelSetCommand = &cobra.Command{
 		if len(args) > 1 {
 			return fmt.Errorf("too many arguments")
 		}
-		heketi := client.NewClient(options.Url, options.User, options.Key)
-		err := heketi.LogLevelSet(&api.LogLevelInfo{
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
+		err = heketi.LogLevelSet(&api.LogLevelInfo{
 			LogLevel: map[string]string{"glusterfs": args[0]},
 		})
 		if err == nil {

--- a/client/cli/go/cmds/node.go
+++ b/client/cli/go/cmds/node.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/heketi/heketi/client/api/go-client"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/spf13/cobra"
 )
@@ -92,7 +91,10 @@ var nodeAddCommand = &cobra.Command{
 		req.Zone = zone
 
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		// Add node
 		node, err := heketi.NodeAdd(req)
@@ -142,10 +144,13 @@ var nodeDeleteCommand = &cobra.Command{
 		nodeId := cmd.Flags().Arg(0)
 
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		//set url
-		err := heketi.NodeDelete(nodeId)
+		err = heketi.NodeDelete(nodeId)
 		if err == nil {
 			fmt.Fprintf(stdout, "Node %v deleted\n", nodeId)
 		}
@@ -171,13 +176,16 @@ var nodeEnableCommand = &cobra.Command{
 		nodeId := cmd.Flags().Arg(0)
 
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		//set url
 		req := &api.StateRequest{
 			State: "online",
 		}
-		err := heketi.NodeState(nodeId, req)
+		err = heketi.NodeState(nodeId, req)
 		if err == nil {
 			fmt.Fprintf(stdout, "Node %v is now online\n", nodeId)
 		}
@@ -203,13 +211,16 @@ var nodeDisableCommand = &cobra.Command{
 		nodeId := cmd.Flags().Arg(0)
 
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		//set url
 		req := &api.StateRequest{
 			State: "offline",
 		}
-		err := heketi.NodeState(nodeId, req)
+		err = heketi.NodeState(nodeId, req)
 		if err == nil {
 			fmt.Fprintf(stdout, "Node %v is now offline\n", nodeId)
 		}
@@ -225,7 +236,10 @@ var nodeListCommand = &cobra.Command{
 	Example: "  $ heketi-cli node list",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		clusters, err := heketi.ClusterList()
 		if err != nil {
@@ -265,7 +279,10 @@ var nodeInfoCommand = &cobra.Command{
 		nodeId := cmd.Flags().Arg(0)
 
 		// Create a client to talk to Heketi
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		// Create cluster
 		info, err := heketi.NodeInfo(nodeId)
@@ -341,13 +358,16 @@ var nodeRemoveCommand = &cobra.Command{
 		nodeId := cmd.Flags().Arg(0)
 
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		//set url
 		req := &api.StateRequest{
 			State: "failed",
 		}
-		err := heketi.NodeState(nodeId, req)
+		err = heketi.NodeState(nodeId, req)
 		if err == nil {
 			fmt.Fprintf(stdout, "Node %v is now removed\n", nodeId)
 		}
@@ -363,7 +383,10 @@ var nodeSetTagsCommand = &cobra.Command{
 	Example: "  $ heketi-cli node settags 886a86a868711bef83001 foo:bar",
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 		return setTagsCommand(cmd, heketi.NodeSetTags)
 	},
 }
@@ -376,7 +399,10 @@ var nodeRmTagsCommand = &cobra.Command{
 	Example: "  $ heketi-cli node rmtags 886a86a868711bef83001 foo",
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 		return rmTagsCommand(cmd, heketi.NodeSetTags)
 	},
 }

--- a/client/cli/go/cmds/root.go
+++ b/client/cli/go/cmds/root.go
@@ -33,6 +33,8 @@ const (
 type Options struct {
 	Url, Key, User string
 	Json           bool
+	InsecureTLS    bool
+	TLSCerts       []string
 }
 
 var RootCmd = &cobra.Command{
@@ -64,6 +66,13 @@ func init() {
 		"\n\tPrint response as JSON")
 	RootCmd.Flags().BoolVarP(&version, "version", "v", false,
 		"\n\tPrint version")
+	RootCmd.PersistentFlags().BoolVarP(&options.InsecureTLS,
+		"insecure-tls", "I", false,
+		"\n\tIf using TLS (HTTPS) do not verify server certificates (insecure)")
+	RootCmd.PersistentFlags().StringSliceVarP(&options.TLSCerts,
+		"tls-cert", "C", []string{},
+		"\n\tIf using TLS (HTTPS), specify a certificate file that can be used to verify"+
+			"\n\tthe TLS connection (can be repeated)")
 	RootCmd.SilenceUsage = true
 }
 

--- a/client/cli/go/cmds/topology.go
+++ b/client/cli/go/cmds/topology.go
@@ -16,7 +16,6 @@ import (
 	"os"
 	"strings"
 
-	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/spf13/cobra"
 )
@@ -154,7 +153,10 @@ var topologyLoadCommand = &cobra.Command{
 		}
 
 		// Create client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		// Load current topolgy
 		heketiTopology, err := heketi.TopologyInfo()
@@ -277,7 +279,10 @@ var topologyInfoCommand = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		// Create a client to talk to Heketi
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		// Create Topology
 		topoinfo, err := heketi.TopologyInfo()

--- a/client/cli/go/cmds/utils.go
+++ b/client/cli/go/cmds/utils.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
@@ -98,4 +99,15 @@ func rmTagsCommand(cmd *cobra.Command,
 	}
 
 	return submitTags(id, req)
+}
+
+func newHeketiClient() (*client.Client, error) {
+	return client.NewClientTLS(
+		options.Url,
+		options.User,
+		options.Key,
+		&client.ClientTLSOptions{
+			InsecureSkipVerify: options.InsecureTLS,
+			VerifyCerts:        options.TLSCerts,
+		})
 }

--- a/client/cli/go/cmds/volume.go
+++ b/client/cli/go/cmds/volume.go
@@ -16,7 +16,6 @@ import (
 	"os"
 	"strings"
 
-	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/kubernetes"
 	"github.com/spf13/cobra"
@@ -186,7 +185,10 @@ var volumeCreateCommand = &cobra.Command{
 		}
 
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		// Add volume
 		volume, err := heketi.VolumeCreate(req)
@@ -252,10 +254,13 @@ var volumeDeleteCommand = &cobra.Command{
 		volumeId := cmd.Flags().Arg(0)
 
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		//set url
-		err := heketi.VolumeDelete(volumeId)
+		err = heketi.VolumeDelete(volumeId)
 		if err == nil {
 			fmt.Fprintf(stdout, "Volume %v deleted\n", volumeId)
 		}
@@ -286,7 +291,10 @@ var volumeExpandCommand = &cobra.Command{
 		req.Size = expandSize
 
 		// Create client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		// Expand volume
 		volume, err := heketi.VolumeExpand(id, req)
@@ -323,7 +331,10 @@ var volumeInfoCommand = &cobra.Command{
 		volumeId := cmd.Flags().Arg(0)
 
 		// Create a client to talk to Heketi
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		// Create cluster
 		info, err := heketi.VolumeInfo(volumeId)
@@ -352,7 +363,10 @@ var volumeListCommand = &cobra.Command{
 	Example: "  $ heketi-cli volume list",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Create a client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		// List volumes
 		list, err := heketi.VolumeList()
@@ -410,8 +424,10 @@ var volumeCloneCommand = &cobra.Command{
 			req.Name = volname
 		}
 
-		// Create client
-		heketi := client.NewClient(options.Url, options.User, options.Key)
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
 
 		// Clone the volume
 		volume, err := heketi.VolumeClone(volumeId, req)

--- a/tests/functional/TestEnabledTLS/client_tls_test/client_tls_test.go
+++ b/tests/functional/TestEnabledTLS/client_tls_test/client_tls_test.go
@@ -1,0 +1,118 @@
+// +build functional
+
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
+//
+
+package client_tls_test
+
+import (
+	"testing"
+
+	client "github.com/heketi/heketi/client/api/go-client"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+
+	"github.com/heketi/tests"
+)
+
+var (
+	URL      = "https://localhost:8080"
+	User     = "abc"
+	Key      = "xyz"
+	CertPath = "../heketi.crt"
+)
+
+func TestCreateClusterTLSCert(t *testing.T) {
+	heketiServer := NewServerCtlFromEnv("..")
+	err := heketiServer.Start()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	defer heketiServer.Stop()
+
+	heketi, err := client.NewClientTLS(URL, User, Key, &client.ClientTLSOptions{
+		VerifyCerts: []string{CertPath},
+	})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, heketi != nil, "expected heketi != nil, got:", heketi)
+
+	testClientActions(t, heketi)
+}
+
+func TestCreateClusterTLSNoVerify(t *testing.T) {
+	heketiServer := NewServerCtlFromEnv("..")
+	err := heketiServer.Start()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	defer heketiServer.Stop()
+
+	heketi, err := client.NewClientTLS(URL, User, Key, &client.ClientTLSOptions{
+		InsecureSkipVerify: true,
+	})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, heketi != nil, "expected heketi != nil, got:", heketi)
+
+	testClientActions(t, heketi)
+}
+
+// This test checks that the client fails when the server is using
+// a self signed cert and none of the options needed for it
+// are provided.
+func TestClientFailUnknownAuthority(t *testing.T) {
+	heketiServer := NewServerCtlFromEnv("..")
+	err := heketiServer.Start()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	defer heketiServer.Stop()
+
+	heketi, err := client.NewClientTLS(URL, User, Key, &client.ClientTLSOptions{})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, heketi != nil, "expected heketi != nil, got:", heketi)
+
+	clusterReq := &api.ClusterCreateRequest{
+		ClusterFlags: api.ClusterFlags{
+			Block: true,
+			File:  true,
+		},
+	}
+	_, err = heketi.ClusterCreate(clusterReq)
+	tests.Assert(t, err != nil, "expected err != nil, got:", err)
+}
+
+func testClientActions(t *testing.T, heketi *client.Client) {
+	clusterReq := &api.ClusterCreateRequest{
+		ClusterFlags: api.ClusterFlags{
+			Block: true,
+			File:  true,
+		},
+	}
+	cluster, err := heketi.ClusterCreate(clusterReq)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, cluster.Id != "", `expected cluster.Id != "", got ""`)
+
+	nodeReq := &api.NodeAddRequest{}
+	nodeReq.ClusterId = cluster.Id
+	nodeReq.Hostnames.Manage = []string{"foo"}
+	nodeReq.Hostnames.Storage = []string{"foo"}
+	nodeReq.Zone = 1
+	node, err := heketi.NodeAdd(nodeReq)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, node.Id != "", `expected node.Id != "", got ""`)
+
+	clusters, err := heketi.ClusterList()
+	tests.Assert(t, err == nil, err)
+	tests.Assert(t, len(clusters.Clusters) == 1,
+		"expected len(clusters.Clusters) == 1, got:", len(clusters.Clusters))
+
+	clusterInfo, err := heketi.ClusterInfo(clusters.Clusters[0])
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(clusterInfo.Nodes) == 1,
+		"expected len(clusterInfo.Nodes) == 1, got:", len(clusterInfo.Nodes))
+	tests.Assert(t, clusterInfo.Nodes[0] == node.Id,
+		"expected clusterInfo.Nodes[0] == node.Id, got:",
+		clusterInfo.Nodes[0] == node.Id)
+}

--- a/tests/functional/TestEnabledTLS/client_tls_test/serverctl_test.go
+++ b/tests/functional/TestEnabledTLS/client_tls_test/serverctl_test.go
@@ -1,0 +1,103 @@
+// +build functional
+
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
+//
+
+package client_tls_test
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path"
+	"syscall"
+	"time"
+)
+
+type ServerCtl struct {
+	serverDir string
+	heketiBin string
+	logPath   string
+	dbPath    string
+	keepDB    bool
+	// the real stuff
+	cmd       *exec.Cmd
+	cmdExited bool
+	cmdErr    error
+	logF      *os.File
+}
+
+func getEnvValue(k, val string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return val
+}
+
+func NewServerCtlFromEnv(dir string) *ServerCtl {
+	return &ServerCtl{
+		serverDir: getEnvValue("HEKETI_SERVER_DIR", dir),
+		heketiBin: getEnvValue("HEKETI_SERVER", "./heketi-server"),
+		logPath:   getEnvValue("HEKETI_LOG", "./heketi.log"),
+		dbPath:    getEnvValue("HEKETI_DB_PATH", "./heketi.db"),
+	}
+}
+
+func (s *ServerCtl) Start() error {
+	if !s.keepDB {
+		// do not preserve the heketi db between server instances
+		os.Remove(path.Join(s.serverDir, s.dbPath))
+	}
+	f, err := os.OpenFile(s.logPath, os.O_TRUNC|os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return err
+	}
+	s.logF = f
+	s.cmd = exec.Command(s.heketiBin, "--config=heketi.json")
+	s.cmd.Dir = s.serverDir
+	s.cmd.Stdout = f
+	s.cmd.Stderr = f
+	if err := s.cmd.Start(); err != nil {
+		return err
+	}
+	go func() {
+		s.cmdErr = s.cmd.Wait()
+		s.cmdExited = true
+	}()
+	time.Sleep(300 * time.Millisecond)
+	if !s.IsAlive() {
+		return errors.New("server exited early")
+	}
+	// dump some logs if heketi fails to start?
+	return nil
+}
+
+func (s *ServerCtl) IsAlive() bool {
+	if err := s.cmd.Process.Signal(syscall.Signal(0)); err != nil {
+		return false
+	}
+	return true
+}
+
+func (s *ServerCtl) Stop() error {
+	if err := s.cmd.Process.Signal(os.Interrupt); err != nil {
+		return err
+	}
+	time.Sleep(100 * time.Millisecond)
+	if !s.cmdExited {
+		if err := s.cmd.Process.Kill(); err != nil {
+			return err
+		}
+	}
+	s.logF.Close()
+	return nil
+}

--- a/tests/functional/TestEnabledTLS/run.sh
+++ b/tests/functional/TestEnabledTLS/run.sh
@@ -37,6 +37,7 @@ if ! command -v virtualenv &>/dev/null; then
 fi
 
 rm -rf .env
+export PYTHONPATH="$PYTHONPATH:$HEKETI_DIR/client/api/python"
 virtualenv .env
 . .env/bin/activate
 pip install -r "$HEKETI_DIR/client/api/python/requirements.txt"


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

With pr #1108 now merged Heketi server can now be enabled for TLS/HTTPS. However, if the client APIs need to access an HTTPS secured heketi they may run into issues if the server is using self-signed or non well known CAs. To ease this situation the following changes add the ability to enable or disable verification OR provide cert files to the python client, the go client, and the heketi cli.

### Notes for the reviewer

Please feel free to bikeshed the cli option names and the user facing variable names if they don't seem clear.


