### PR TITLE
HEKETI_DB_PATH environment variable overrides the heketi.json setting for the daemon

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -245,6 +245,11 @@ func (a *App) setFromEnvironmentalVariable() {
 		a.conf.Executor = env
 	}
 
+	env = os.Getenv("HEKETI_DB_PATH")
+	if env != "" {
+		a.conf.DBfile = env
+	}
+
 	env = os.Getenv("HEKETI_GLUSTERAPP_LOGLEVEL")
 	if env != "" {
 		a.conf.Loglevel = env

--- a/apps/glusterfs/app_test.go
+++ b/apps/glusterfs/app_test.go
@@ -75,12 +75,14 @@ func TestAppAdvsettings(t *testing.T) {
 	defer os.Remove(dbfile)
 	os.Setenv("HEKETI_EXECUTOR", "mock")
 	defer os.Unsetenv("HEKETI_EXECUTOR")
+	os.Setenv("HEKETI_DB_PATH", dbfile)
+	defer os.Unsetenv("HEKETI_DB_PATH")
 
 	data := []byte(`{
 		"glusterfs" : {
 			"executor" : "crazyexec",
 			"allocator" : "simple",
-			"db" : "` + dbfile + `",
+			"db" : "/path/to/nonexistent/heketi.db",
 			"brick_max_size_gb" : 1024,
 			"brick_min_size_gb" : 4,
 			"max_bricks_per_volume" : 33
@@ -96,6 +98,7 @@ func TestAppAdvsettings(t *testing.T) {
 	defer app.Close()
 	tests.Assert(t, app != nil)
 	tests.Assert(t, app.conf.Executor == "mock")
+	tests.Assert(t, app.conf.DBfile == dbfile)
 	tests.Assert(t, BrickMaxNum == 33)
 	tests.Assert(t, BrickMaxSize == 1*TB)
 	tests.Assert(t, BrickMinSize == 4*GB)
@@ -228,12 +231,14 @@ func TestAppBlockSettings(t *testing.T) {
 	defer os.Remove(dbfile)
 	os.Setenv("HEKETI_EXECUTOR", "mock")
 	defer os.Unsetenv("HEKETI_EXECUTOR")
+	os.Setenv("HEKETI_DB_PATH", dbfile)
+	defer os.Unsetenv("HEKETI_DB_PATH")
 
 	data := []byte(`{
 		"glusterfs" : {
 			"executor" : "crazyexec",
 			"allocator" : "simple",
-			"db" : "` + dbfile + `",
+			"db" : "/path/to/nonexistent/heketi.db",
 			"auto_create_block_hosting_volume" : true,
 			"block_hosting_volume_size" : 500
 		}
@@ -248,6 +253,7 @@ func TestAppBlockSettings(t *testing.T) {
 	defer app.Close()
 	tests.Assert(t, app != nil)
 	tests.Assert(t, app.conf.Executor == "mock")
+	tests.Assert(t, app.conf.DBfile == dbfile)
 	tests.Assert(t, CreateBlockHostingVolumes == true)
 	tests.Assert(t, BlockHostingVolumeSize == 500)
 }

--- a/docs/admin/server.md
+++ b/docs/admin/server.md
@@ -19,7 +19,7 @@ The config file has information required to run the Heketi server.  The config f
         * **mock**: Does not send any commands out to servers. Can be used for development and tests
         * **ssh**: Sends commands to real systems over ssh
         * **kubernetes**: Communicate with GlusterFS containers over Kubernetes exec
-    * db: _string_, Location of Heketi database
+    * db: _string_, Location of Heketi database.  Environment variable HEKETI_DB_PATH can also be used to customize database location.
     * sshexec: _map_, SSH configuration
         * keyfile: _string_, File with private ssh key
         * user: _string_, SSH user

--- a/extras/kubernetes/heketi-bootstrap.json
+++ b/extras/kubernetes/heketi-bootstrap.json
@@ -65,6 +65,10 @@
                     "value": "kubernetes"
                   },
                   {
+                    "name": "HEKETI_DB_PATH",
+                    "value": "/var/lib/heketi/heketi.db"
+                  },
+                  {
                     "name": "HEKETI_FSTAB",
                     "value": "/var/lib/heketi/fstab"
                   },

--- a/extras/kubernetes/heketi-deployment.json
+++ b/extras/kubernetes/heketi-deployment.json
@@ -77,6 +77,10 @@
                     "value": "kubernetes"
                   },
                   {
+                    "name": "HEKETI_DB_PATH",
+                    "value": "/var/lib/heketi/heketi.db"
+                  },
+                  {
                     "name": "HEKETI_FSTAB",
                     "value": "/var/lib/heketi/fstab"
                   },

--- a/extras/openshift/templates/deploy-heketi-template.json
+++ b/extras/openshift/templates/deploy-heketi-template.json
@@ -113,6 +113,10 @@
                     "value": "kubernetes"
                   },
                   {
+                    "name": "HEKETI_DB_PATH",
+                    "value": "/var/lib/heketi/heketi.db"
+                  },
+                  {
                     "name": "HEKETI_FSTAB",
                     "value": "/var/lib/heketi/fstab"
                   },

--- a/extras/openshift/templates/heketi-template.json
+++ b/extras/openshift/templates/heketi-template.json
@@ -109,6 +109,10 @@
                     "value": "kubernetes"
                   },
                   {
+                    "name": "HEKETI_DB_PATH",
+                    "value": "/var/lib/heketi/heketi.db"
+                  },
+                  {
                     "name": "HEKETI_FSTAB",
                     "value": "/var/lib/heketi/fstab"
                   },


### PR DESCRIPTION
It is unfortunate that if we choose to use a different place for the DB,
and if we do the backup-to-kube-secret thing, that we then need to
specify it in two places now. This solution fixs this problem.

Related to: https://github.com/heketi/heketi/pull/1155

