### PR TITLE
apps: update space accounting on device during brick replace

### DIFF
--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -288,6 +288,11 @@ func (v *VolumeEntry) allocBrickReplacement(db wdb.DB,
 		} else if err != nil {
 			return err
 		}
+		// Unfortunately, we need to save the updated device here in order
+		// to preserve the space allocated for the new brick.
+		if err := r.DeviceSets[0].Devices[index].Save(tx); err != nil {
+			return err
+		}
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
After refactoring to implement the placers the device replace code path
we failed to save the updated storage values on the affected device.
This change is bit ugly but it makes sure that the device is saved
until replace moves to a more transactional/operations based model.
The remainder of the change is a unit test for this condition.

