### PR TITLE
cli: fix copy'n'paste error in usage of heketi-cli device info

### DIFF
--- a/client/cli/go/cmds/device.go
+++ b/client/cli/go/cmds/device.go
@@ -158,7 +158,7 @@ var deviceInfoCommand = &cobra.Command{
 	Use:     "info [device_id]",
 	Short:   "Retrieves information about the device",
 	Long:    "Retrieves information about the device",
-	Example: "  $ heketi-cli node info 886a86a868711bef83001",
+	Example: "  $ heketi-cli device info 886a86a868711bef83001",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		//ensure proper number of args
 		s := cmd.Flags().Args()


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

This PR fixes a copy-and-paste error in the `heketi-cli device info --help` message, where `node` would be printed instead of `device`.
