### PR TITLE
fix device remove (brick replace) for arbiter volumes 

### DIFF
--- a/apps/glusterfs/device_entry_test.go
+++ b/apps/glusterfs/device_entry_test.go
@@ -1066,6 +1066,15 @@ func TestDeviceSetStateFailedWithEmptyPathBricks(t *testing.T) {
 
 // See also RHBZ#1572661
 func TestDeviceRemoveSizeAccounting(t *testing.T) {
+	t.Run("standard", func(t *testing.T) {
+		testDeviceRemoveSizeAccounting(t, false)
+	})
+	t.Run("arbiter", func(t *testing.T) {
+		testDeviceRemoveSizeAccounting(t, true)
+	})
+}
+
+func testDeviceRemoveSizeAccounting(t *testing.T, useArbiter bool) {
 	tmpfile := tests.Tempfile()
 	defer os.Remove(tmpfile)
 
@@ -1084,6 +1093,9 @@ func TestDeviceRemoveSizeAccounting(t *testing.T) {
 	vreq.Size = 100
 	vreq.Durability.Type = api.DurabilityReplicate
 	vreq.Durability.Replicate.Replica = 3
+	if useArbiter {
+		vreq.GlusterVolumeOptions = []string{"user.heketi.arbiter true"}
+	}
 	v := NewVolumeEntryFromRequest(vreq)
 	err = v.Create(app.db, app.executor)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)


### PR DESCRIPTION
Due to the (screwy) behavior of the callers the replace code-path must not add the replacement brick to the list of bricks on the device (however it must deduct the brick size from the device and save it). The brick is added to the device later in a different db transaction (oh yeah, more opportunities for out-of-sync) and adding an existing brick to the brick list will panic.
Thus this change updates the arbiter placer such that functions called during the Replace call will not add the brick to the device's list.