### PR TITLE
create arbiter bricks sets in reverse order

### DIFF
--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -24,10 +24,16 @@ type BrickSet struct {
 	Bricks  []*BrickEntry
 }
 
+// NewBrickSet creates an empty brick set tracking object with
+// the expected final size of s.
 func NewBrickSet(s int) *BrickSet {
 	return &BrickSet{SetSize: s, Bricks: []*BrickEntry{}}
 }
 
+// NewSparseBrickSet creates a brick set tracking object with
+// the expected final size of s and the brick tracking slice
+// pre-sized to s. This means that the array can be directly
+// indexed but may contain null brick entries.
 func NewSparseBrickSet(s int) *BrickSet {
 	return &BrickSet{
 		SetSize: s,
@@ -67,6 +73,8 @@ func (bs *BrickSet) Contents() []*BrickEntry {
 	return out
 }
 
+// IsSparse returns true if the brick tracking slice contains
+// any nulls, indicating that the BrickSet is not fully populated.
 func (bs *BrickSet) IsSparse() bool {
 	for _, b := range bs.Bricks {
 		if b == nil {
@@ -76,6 +84,8 @@ func (bs *BrickSet) IsSparse() bool {
 	return false
 }
 
+// Full returns true if the brick slice contains the same
+// number of items as the expected set size.
 func (bs *BrickSet) Full() bool {
 	return len(bs.Bricks) == bs.SetSize
 }
@@ -102,10 +112,16 @@ type DeviceSet struct {
 	Devices []*DeviceEntry
 }
 
+// NewDeviceSet creates a device set tracking object with
+// the expected final size of s.
 func NewDeviceSet(s int) *DeviceSet {
 	return &DeviceSet{SetSize: s, Devices: []*DeviceEntry{}}
 }
 
+// NewSparseDeviceSet creates a device set tracking object with
+// the expected final size of s and the device tracking slice
+// pre-sized to s. This means that the array can be directly
+// indexed but may contain null brick entries.
 func NewSparseDeviceSet(s int) *DeviceSet {
 	return &DeviceSet{
 		SetSize: s,
@@ -135,10 +151,14 @@ func (ds *DeviceSet) Insert(index int, d *DeviceEntry) {
 	}
 }
 
+// Full returns true if the device slice contains the same
+// number of items as the expected set size.
 func (ds *DeviceSet) Full() bool {
 	return len(ds.Devices) == ds.SetSize
 }
 
+// IsSparse returns true if the device tracking slice contains
+// any nulls, indicating that the DeviceSet is not fully populated.
 func (ds *DeviceSet) IsSparse() bool {
 	for _, d := range ds.Devices {
 		if d == nil {

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -28,6 +28,13 @@ func NewBrickSet(s int) *BrickSet {
 	return &BrickSet{SetSize: s, Bricks: []*BrickEntry{}}
 }
 
+func NewSparseBrickSet(s int) *BrickSet {
+	return &BrickSet{
+		SetSize: s,
+		Bricks:  make([]*BrickEntry, s),
+	}
+}
+
 func (bs *BrickSet) Add(b *BrickEntry) {
 	godbc.Require(!bs.Full())
 	bs.Bricks = append(bs.Bricks, b)
@@ -48,6 +55,25 @@ func (bs *BrickSet) Insert(index int, b *BrickEntry) {
 			"Brick set may only be extended one (index=%v, len=%v)",
 			index, len(bs.Bricks)))
 	}
+}
+
+func (bs *BrickSet) Contents() []*BrickEntry {
+	out := []*BrickEntry{}
+	for _, b := range bs.Bricks {
+		if b != nil {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+func (bs *BrickSet) IsSparse() bool {
+	for _, b := range bs.Bricks {
+		if b == nil {
+			return true
+		}
+	}
+	return false
 }
 
 func (bs *BrickSet) Full() bool {
@@ -80,6 +106,13 @@ func NewDeviceSet(s int) *DeviceSet {
 	return &DeviceSet{SetSize: s, Devices: []*DeviceEntry{}}
 }
 
+func NewSparseDeviceSet(s int) *DeviceSet {
+	return &DeviceSet{
+		SetSize: s,
+		Devices: make([]*DeviceEntry, s),
+	}
+}
+
 func (ds *DeviceSet) Add(d *DeviceEntry) {
 	godbc.Require(!ds.Full())
 	ds.Devices = append(ds.Devices, d)
@@ -104,6 +137,15 @@ func (ds *DeviceSet) Insert(index int, d *DeviceEntry) {
 
 func (ds *DeviceSet) Full() bool {
 	return len(ds.Devices) == ds.SetSize
+}
+
+func (ds *DeviceSet) IsSparse() bool {
+	for _, d := range ds.Devices {
+		if d == nil {
+			return true
+		}
+	}
+	return false
 }
 
 type BrickAllocation struct {

--- a/apps/glusterfs/placer_arbiter.go
+++ b/apps/glusterfs/placer_arbiter.go
@@ -188,7 +188,7 @@ func (bp *ArbiterBrickPlacer) newSets(
 	// work backwards from the last item in the brick set (typically index 2)
 	// in order to place the most special brick, the arbiter brick, first.
 	// Placing the arbiter brick first means we get a more reliable distribution
-	// of bricks because the nodes will not be "reserved" by the two data
+	// of bricks because the nodes will not be taken by the two data
 	// bricks before we try to place the arbiter brick.
 	for index := ssize - 1; index >= 0; index-- {
 		aopts := newArbiterOpts(opts)

--- a/apps/glusterfs/placer_arbiter_test.go
+++ b/apps/glusterfs/placer_arbiter_test.go
@@ -381,17 +381,17 @@ func TestArbiterBrickPlacerBrickOnArbiterDevice(t *testing.T) {
 func TestArbiterBrickPlacerBrickThreeSets(t *testing.T) {
 	dsrc := NewTestDeviceSource()
 	addDev := dsrc.MultiAdd("10000000")
-	addDev("11111111", "/dev/d1", 10001)
-	addDev("21111111", "/dev/d2", 10002)
-	addDev("31111111", "/dev/d3", 10003)
+	addDev("11111111", "/dev/d1", 20001)
+	addDev("21111111", "/dev/d2", 20002)
+	addDev("31111111", "/dev/d3", 20003)
 	addDev = dsrc.MultiAdd("20000000")
-	addDev("41111111", "/dev/d1", 10001)
-	addDev("51111111", "/dev/d2", 10002)
-	addDev("61111111", "/dev/d3", 10003)
+	addDev("41111111", "/dev/d1", 20001)
+	addDev("51111111", "/dev/d2", 20002)
+	addDev("61111111", "/dev/d3", 20003)
 	addDev = dsrc.MultiAdd("30000000")
-	addDev("71111111", "/dev/d1", 10001)
-	addDev("81111111", "/dev/d2", 10002)
-	addDev("91111111", "/dev/d3", 10003)
+	addDev("71111111", "/dev/d1", 20001)
+	addDev("81111111", "/dev/d2", 20002)
+	addDev("91111111", "/dev/d3", 20003)
 
 	opts := &TestPlacementOpts{
 		brickSize:       800,


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Creating the arbiter bricks in reverse order (starting with the 3rd
brick in the brick set and working back to the 1st) means we create the arbiter brick first
and this prevents the data bricks from "blocking" the arbiter brick
being placed on a particular node. This makes placing the
arbiter bricks more reliable.



### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

See [rhbz #1572561](https://bugzilla.redhat.com/show_bug.cgi?id=1572561)


### Notes for the reviewer

This PR relies on the changes in PR #1171 so that tests can pass. Please review that PR first.
