### PR TITLE
 apps: fix selection of node for issuing gluster replace command 

### DIFF
--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -206,7 +206,7 @@ type replacementItems struct {
 
 func (v *VolumeEntry) prepForBrickReplacement(db wdb.DB,
 	executor executors.Executor,
-	oldBrickId string) (ri replacementItems, err error) {
+	oldBrickId string) (ri replacementItems, node string, err error) {
 
 	var oldBrickEntry *BrickEntry
 	var oldDeviceEntry *DeviceEntry
@@ -233,7 +233,7 @@ func (v *VolumeEntry) prepForBrickReplacement(db wdb.DB,
 		return
 	}
 
-	node := oldBrickNodeEntry.ManageHostName()
+	node = oldBrickNodeEntry.ManageHostName()
 	err = executor.GlusterdCheck(node)
 	if err != nil {
 		node, err = GetVerifiedManageHostname(db, executor, oldBrickNodeEntry.Info.ClusterId)
@@ -311,7 +311,7 @@ func (v *VolumeEntry) replaceBrickInVolume(db wdb.DB, executor executors.Executo
 		return fmt.Errorf("replace brick is not supported for volume durability type %v", v.Info.Durability.Type)
 	}
 
-	ri, err := v.prepForBrickReplacement(
+	ri, node, err := v.prepForBrickReplacement(
 		db, executor, oldBrickId)
 	if err != nil {
 		return err
@@ -374,7 +374,6 @@ func (v *VolumeEntry) replaceBrickInVolume(db wdb.DB, executor executors.Executo
 	newBrick.Path = newBrickEntry.Info.Path
 	newBrick.Host = newBrickNodeEntry.StorageHostName()
 
-	node := oldBrickNodeEntry.ManageHostName()
 	err = executor.VolumeReplaceBrick(node, v.Info.Name, &oldBrick, &newBrick)
 	if err != nil {
 		return err


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

In refactoring the previous replace function the logic around
selecting a node to run commands on was oversimplified in one
area. This change fixes that by plumbing the node selection
through multiple function calls.

### Does this PR fix issues?

Fixes #


### Notes for the reviewer

This PR relies on the changes in PR #1171 so that tests can pass. Please review that PR first.
