### PR TITLE
utils: improve error reporting if service does not provide a message

### DIFF
--- a/pkg/utils/bodystring.go
+++ b/pkg/utils/bodystring.go
@@ -11,6 +11,7 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -33,5 +34,10 @@ func GetErrorFromResponse(r *http.Response) error {
 	if err != nil {
 		return err
 	}
-	return errors.New(strings.TrimSpace(s))
+
+	s = strings.TrimSpace(s)
+	if len(s) == 0 {
+		return fmt.Errorf("server did not provide a message (status %v: %v)", r.StatusCode, http.StatusText(r.StatusCode))
+	}
+	return errors.New(s)
 }

--- a/pkg/utils/bodystring_test.go
+++ b/pkg/utils/bodystring_test.go
@@ -117,3 +117,17 @@ func TestGetErrorFromResponseErrStringSpace(t *testing.T) {
 	tests.Assert(t, err.Error() == "whoa nellie",
 		`expected err.Error() == "whoa nellie", got:`, err.Error())
 }
+
+func TestGetErrorFromResponseEmptyString(t *testing.T) {
+	bodytext := "\n"
+	resp := &http.Response{
+		Status:        "200 OK",
+		StatusCode:    200,
+		Body:          dummyCloser{bytes.NewBufferString(bodytext)},
+		ContentLength: int64(len(bodytext)),
+	}
+	err := GetErrorFromResponse(resp)
+	tests.Assert(t, err != nil, "expected err != nil, got:", err)
+	tests.Assert(t, err.Error() == "server did not provide a message (status 200: OK)",
+		`expected err.Error() == "server did not provide a message (status 200: OK)", got:`, err.Error())
+}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
On occasion the heketi-cli returned an empty `Error: ` to the caller.
This is obviously suboptimal, as there is no hint to what could have
gone wrong. The Heketi service itself provides error messages for any
issues it hits. If there are no error messages received by the
heketi-cli, the problem is somewhere else.

It seems that a misconfigured router/proxy in Kubernetes or OpenShift
can cause empty error messages. These routers/proxies will provide a
HTTP status code, so let's display that if there is no message.

### Does this PR fix issues?

Bug: https://bugzilla.redhat.com/1432340