### PR TITLE
apps: fix arbiter placer so that nodes do not get reused in a brick set

### DIFF
--- a/apps/glusterfs/placer_arbiter.go
+++ b/apps/glusterfs/placer_arbiter.go
@@ -254,15 +254,19 @@ func (bp *ArbiterBrickPlacer) tryPlaceBrickOnDevice(
 	index int,
 	device *DeviceEntry) error {
 
-	logger.Debug("Trying to place brick on device %v", device.Info.Id)
+	logger.Debug("Trying to place brick on device %v (node %v)",
+		device.Info.Id, device.NodeId)
 
-	for i, b := range bs.Contents() {
+	for i, b := range bs.Bricks {
 		// do not check the brick in the brick set for the current
 		// index. If this is a new brick set we won't have the index
 		// populated. If this is a replace, we will have the old brick
 		// at the index and we are OK with re-using its node (as the
 		// standard placer does)
-		if i == index {
+		// If b is nil, it means that this is a "sparse" brick set and
+		// we have not tried allocating a brick for that index yet,
+		// so there's nothing to check.
+		if i == index || b == nil {
 			continue
 		}
 		if b.Info.NodeId == device.NodeId {

--- a/apps/glusterfs/placer_arbiter_test.go
+++ b/apps/glusterfs/placer_arbiter_test.go
@@ -407,6 +407,8 @@ func TestArbiterBrickPlacerBrickThreeSets(t *testing.T) {
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, len(ba.BrickSets) == 3,
 		"expected len(ba.BrickSets) == 3, got:", len(ba.BrickSets))
+
+	assertNoRepeatNodesInBrickSet(t, dsrc, ba)
 }
 
 func TestArbiterBrickPlacerBrickThreeSetsOnArbiterDevice(t *testing.T) {
@@ -471,6 +473,7 @@ func TestArbiterBrickPlacerBrickThreeSetsOnArbiterDevice(t *testing.T) {
 			}
 		}
 	}
+	assertNoRepeatNodesInBrickSet(t, dsrc, ba)
 }
 
 func TestArbiterBrickPlacerSimpleReplace(t *testing.T) {
@@ -521,6 +524,9 @@ func TestArbiterBrickPlacerSimpleReplace(t *testing.T) {
 	tests.Assert(t, len(ba2.BrickSets[0].Bricks) == 3,
 		"expected len(ba2.BrickSets[0].Bricks) == 3, got:",
 		len(ba2.BrickSets[0].Bricks))
+
+	assertNoRepeatNodesInBrickSet(t, dsrc, ba)
+	assertNoRepeatNodesInBrickSet(t, dsrc, ba2)
 
 	bs1 := ba.BrickSets[0]
 	bs2 := ba2.BrickSets[0]
@@ -750,4 +756,25 @@ func TestArbiterBrickPlacerReplaceTooFewArbiter(t *testing.T) {
 	tests.Assert(t, len(ba2.BrickSets[0].Bricks) == 3,
 		"expected len(ba2.BrickSets[0].Bricks) == 3, got:",
 		len(ba2.BrickSets[0].Bricks))
+}
+
+func assertNoRepeatNodesInBrickSet(t *testing.T,
+	dsrc DeviceSource, ba *BrickAllocation) {
+
+	// this check is only for arbiter tests so we can assume that there
+	// will be exactly 3 bricks in a brickset on successful placement
+	for _, bs := range ba.BrickSets {
+		d0, err := dsrc.Device(bs.Bricks[0].Info.DeviceId)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		d1, err := dsrc.Device(bs.Bricks[1].Info.DeviceId)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		d2, err := dsrc.Device(bs.Bricks[2].Info.DeviceId)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, d0.NodeId != d1.NodeId,
+			"bricks 0 1 placed on same node:", d0.NodeId)
+		tests.Assert(t, d1.NodeId != d2.NodeId,
+			"bricks 1 2 placed on same node:", d1.NodeId)
+		tests.Assert(t, d2.NodeId != d0.NodeId,
+			"bricks 2 0 placed on same node:", d2.NodeId)
+	}
 }


### PR DESCRIPTION
Due to changes introduced in a previous arbiter fix the function
that returns only "real" bricks from a brick set was not
using the correct indexes for the bricks in the brick set and
thus the check in the code for protecting against re-use of a node
within a single brick set was incorrect.
This fix returns the iteration to the previous approach and
checks for "nil bricks" in the loop itself.
