### PR TITLE
arbiter: fix volume creation with too big average file size

### DIFF
--- a/apps/glusterfs/placer_arbiter.go
+++ b/apps/glusterfs/placer_arbiter.go
@@ -371,13 +371,25 @@ func (dscan *arbiterDeviceScanner) Scan(index int) <-chan string {
 	return dscan.dataDevs
 }
 
-func discountBrickSize(dataBrickSize, averageFileSize uint64) (uint64, error) {
+func discountBrickSize(dataBrickSize, averageFileSize uint64) (brickSize uint64,
+	err error) {
+
 	if dataBrickSize < averageFileSize {
 		return 0, fmt.Errorf(
 			"Average file size (%v) is greater than Brick size (%v)",
 			averageFileSize, dataBrickSize)
 	}
-	return (dataBrickSize / averageFileSize), nil
+
+	brickSize = dataBrickSize / averageFileSize
+
+	if brickSize < 16*MB {
+		logger.Info("Increasing calculated arbiter brickSize (%vKiB) "+
+			"to 16MiB, the minimum XFS filsystem size with 4KiB "+
+			"blocks.", brickSize)
+		brickSize = 16 * MB
+	}
+
+	return brickSize, nil
 }
 
 func deviceHasArbiterTag(d *DeviceEntry, dsrc DeviceSource, v ...string) bool {

--- a/apps/glusterfs/placer_arbiter_test.go
+++ b/apps/glusterfs/placer_arbiter_test.go
@@ -209,19 +209,19 @@ func TestArbiterBrickPlacer(t *testing.T) {
 		"10000000",
 		"11111111",
 		"/dev/foobar",
-		11000)
+		100*GB)
 	dsrc.QuickAdd(
 		"20000000",
 		"22222222",
 		"/dev/foobar",
-		12000)
+		100*GB)
 	dsrc.QuickAdd(
 		"30000000",
 		"33333333",
 		"/dev/foobar",
-		13000)
+		100*GB)
 	opts := &TestPlacementOpts{
-		brickSize:       800,
+		brickSize:       10 * GB,
 		brickSnapFactor: 0.3,
 		brickOwner:      "asdfasdf",
 		setSize:         3,
@@ -413,24 +413,24 @@ func TestArbiterBrickPlacerBrickThreeSetsOnArbiterDevice(t *testing.T) {
 	dsrc := NewTestDeviceSource()
 	addDev := dsrc.MultiAdd("10000000")
 	// data nodes
-	addDev("11111111", "/dev/d1", 10001)
-	addDev("21111111", "/dev/d2", 10002)
+	addDev("11111111", "/dev/d1", 100*GB)
+	addDev("21111111", "/dev/d2", 100*GB)
 	addDev = dsrc.MultiAdd("20000000")
-	addDev("31111111", "/dev/d1", 10001)
-	addDev("41111111", "/dev/d2", 10002)
+	addDev("31111111", "/dev/d1", 100*GB)
+	addDev("41111111", "/dev/d2", 100*GB)
 	addDev = dsrc.MultiAdd("30000000")
-	addDev("51111111", "/dev/d1", 10001)
-	addDev("61111111", "/dev/d2", 10002)
+	addDev("51111111", "/dev/d1", 100*GB)
+	addDev("61111111", "/dev/d2", 100*GB)
 	addDev = dsrc.MultiAdd("40000000")
-	addDev("71111111", "/dev/d1", 10001)
-	addDev("81111111", "/dev/d2", 10002)
+	addDev("71111111", "/dev/d1", 100*GB)
+	addDev("81111111", "/dev/d2", 100*GB)
 	// arbiter nodes
 	addDev = dsrc.MultiAdd("50000000")
-	addDev("a1111111", "/dev/d1", 10001)
+	addDev("a1111111", "/dev/d1", 100*GB)
 	addDev = dsrc.MultiAdd("60000000")
-	addDev("a2111111", "/dev/d1", 10001)
+	addDev("a2111111", "/dev/d1", 100*GB)
 	addDev = dsrc.MultiAdd("70000000")
-	addDev("a3111111", "/dev/d1", 10001)
+	addDev("a3111111", "/dev/d1", 100*GB)
 	// the above configuration is pretty artificial and reflects
 	// a downside to the current approach. because of the
 	// non-deterministic way the ring provides devices and
@@ -441,7 +441,7 @@ func TestArbiterBrickPlacerBrickThreeSetsOnArbiterDevice(t *testing.T) {
 	// improve this but not now and not for this test. :-\
 
 	opts := &TestPlacementOpts{
-		brickSize:       800,
+		brickSize:       10 * GB,
 		brickSnapFactor: 0.3,
 		brickOwner:      "asdfasdf",
 		setSize:         3,


### PR DESCRIPTION
The arbiter brick size for a brick set is calculated as
(dataBrickSize)/(averageFileSize). If the data brick is
rather small, and the averageFileSize is rather big, this
can get smaller than the minimum filesystem size of 16MiB
that xfs supports. Hence always use at least 16 MiB for
the arbiter brick.

Note this required to change two of the test cases
slightly: The sizes are actually in KB. The tests use
some fantasy numbers like 800 KiB brick sizes that now
contradict for some checks the new mode of having a
minimum arbiter brick size of 16 MiB.

Fixes: #1181