### PR TITLE
executor: use long options on lvcreate

### DIFF
--- a/executors/cmdexec/brick.go
+++ b/executors/cmdexec/brick.go
@@ -44,7 +44,7 @@ func (s *CmdExecutor) BrickCreate(host string,
 		fmt.Sprintf("mkdir -p %v", mountPath),
 
 		// Setup the LV
-		fmt.Sprintf("lvcreate --poolmetadatasize %vK -c 256K -L %vK -T %v/%v -V %vK -n %v",
+		fmt.Sprintf("lvcreate --poolmetadatasize %vK --chunksize 256K --size %vK --thin %v/%v --virtualsize %vK --name %v",
 			// MetadataSize
 			brick.PoolMetadataSize,
 

--- a/executors/cmdexec/brick_test.go
+++ b/executors/cmdexec/brick_test.go
@@ -54,7 +54,7 @@ func TestSshExecBrickCreate(t *testing.T) {
 			case 1:
 				tests.Assert(t,
 					cmd == "lvcreate --poolmetadatasize 5K "+
-						"-c 256K -L 100K -T vg_xvgid/tp_id -V 10K -n brick_id", cmd)
+						"--chunksize 256K --size 100K --thin vg_xvgid/tp_id --virtualsize 10K --name brick_id", cmd)
 
 			case 2:
 				tests.Assert(t,
@@ -127,7 +127,7 @@ func TestSshExecBrickCreateWithGid(t *testing.T) {
 			case 1:
 				tests.Assert(t,
 					cmd == "lvcreate --poolmetadatasize 5K "+
-						"-c 256K -L 100K -T vg_xvgid/tp_id -V 10K -n brick_id", cmd)
+						"--chunksize 256K --size 100K --thin vg_xvgid/tp_id --virtualsize 10K --name brick_id", cmd)
 
 			case 2:
 				tests.Assert(t,
@@ -211,7 +211,7 @@ func TestSshExecBrickCreateSudo(t *testing.T) {
 			case 1:
 				tests.Assert(t,
 					cmd == "lvcreate --poolmetadatasize 5K "+
-						"-c 256K -L 100K -T vg_xvgid/tp_id -V 10K -n brick_id", cmd)
+						"--chunksize 256K --size 100K --thin vg_xvgid/tp_id --virtualsize 10K --name brick_id", cmd)
 
 			case 2:
 				tests.Assert(t,


### PR DESCRIPTION
This greately enhances readability.

Signed-off-by: Michael Adam <obnox@redhat.com>

