### PR TITLE
Add an option to destroy data while adding a device to a node

### DIFF
--- a/apps/glusterfs/app_device.go
+++ b/apps/glusterfs/app_device.go
@@ -92,7 +92,7 @@ func (a *App) DeviceAdd(w http.ResponseWriter, r *http.Request) {
 
 		// Setup device on node
 		info, err := a.executor.DeviceSetup(node.ManageHostName(),
-			device.Info.Name, device.Info.Id)
+			device.Info.Name, device.Info.Id, msg.DestroyData)
 		if err != nil {
 			return "", err
 		}

--- a/apps/glusterfs/app_device_test.go
+++ b/apps/glusterfs/app_device_test.go
@@ -445,7 +445,7 @@ func TestDeviceAddCleansUp(t *testing.T) {
 	// Mock the device setup to return an error, which will
 	// cause the cleanup.
 	deviceSetupFn := app.xo.MockDeviceSetup
-	app.xo.MockDeviceSetup = func(host, device, vgid string) (*executors.DeviceInfo, error) {
+	app.xo.MockDeviceSetup = func(host, device, vgid string, destroy bool) (*executors.DeviceInfo, error) {
 		return nil, ErrDbAccess
 	}
 

--- a/client/cli/go/cmds/device.go
+++ b/client/cli/go/cmds/device.go
@@ -38,6 +38,8 @@ func init() {
 		"Name of device to add")
 	deviceAddCommand.Flags().StringVar(&nodeId, "node", "",
 		"Id of the node which has this device")
+	deviceAddCommand.Flags().Bool("destroy-existing-data", false,
+		"[DANGEROUS] Destroy any existing data on the device.")
 	deviceSetTagsCommand.Flags().BoolP("exact", "e", false,
 		"Set the object to this exact set of tags. Overwrites existing tags.")
 	deviceRmTagsCommand.Flags().Bool("all", false,
@@ -72,17 +74,22 @@ var deviceAddCommand = &cobra.Command{
 		if nodeId == "" {
 			return errors.New("Missing node id")
 		}
+		destroyData, err := cmd.Flags().GetBool("destroy-existing-data")
+		if err != nil {
+			return err
+		}
 
 		// Create request blob
 		req := &api.DeviceAddRequest{}
 		req.Name = device
 		req.NodeId = nodeId
+		req.DestroyData = destroyData
 
 		// Create a client
 		heketi := client.NewClient(options.Url, options.User, options.Key)
 
 		// Add node
-		err := heketi.DeviceAdd(req)
+		err = heketi.DeviceAdd(req)
 		if err != nil {
 			return err
 		} else {

--- a/client/cli/go/topology-sample.json
+++ b/client/cli/go/topology-sample.json
@@ -15,14 +15,38 @@
                         "zone": 1
                     },
                     "devices": [
-                        "/dev/sdb",
-                        "/dev/sdc",
-                        "/dev/sdd",
-                        "/dev/sde",
-                        "/dev/sdf",
-                        "/dev/sdg",
-                        "/dev/sdh",
-                        "/dev/sdi"
+                        {
+                            "name": "/dev/sdb",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdc",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdd",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sde",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdf",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdg",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdh",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdi",
+                            "destroydata": false
+                        }
                     ]
                 },
                 {
@@ -38,14 +62,38 @@
                         "zone": 2
                     },
                     "devices": [
-                        "/dev/sdb",
-                        "/dev/sdc",
-                        "/dev/sdd",
-                        "/dev/sde",
-                        "/dev/sdf",
-                        "/dev/sdg",
-                        "/dev/sdh",
-                        "/dev/sdi"
+                        {
+                            "name": "/dev/sdb",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdc",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdd",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sde",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdf",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdg",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdh",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdi",
+                            "destroydata": false
+                        }
                     ]
                 },
                 {
@@ -61,14 +109,38 @@
                         "zone": 1
                     },
                     "devices": [
-                        "/dev/sdb",
-                        "/dev/sdc",
-                        "/dev/sdd",
-                        "/dev/sde",
-                        "/dev/sdf",
-                        "/dev/sdg",
-                        "/dev/sdh",
-                        "/dev/sdi"
+                        {
+                            "name": "/dev/sdb",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdc",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdd",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sde",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdf",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdg",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdh",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdi",
+                            "destroydata": false
+                        }
                     ]
                 },
                 {
@@ -84,14 +156,38 @@
                         "zone": 2
                     },
                     "devices": [
-                        "/dev/sdb",
-                        "/dev/sdc",
-                        "/dev/sdd",
-                        "/dev/sde",
-                        "/dev/sdf",
-                        "/dev/sdg",
-                        "/dev/sdh",
-                        "/dev/sdi"
+                        {
+                            "name": "/dev/sdb",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdc",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdd",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sde",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdf",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdg",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdh",
+                            "destroydata": false
+                        },
+                        {
+                            "name": "/dev/sdi",
+                            "destroydata": false
+                        }
                     ]
                 }
             ]

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -448,6 +448,7 @@ The `devices` endpoint allows management of raw devices in the cluster.
 * **JSON Request**:
     * node: _string_, UUID of node which the devices belong to.
     * name: _string_, Device name
+    * destroydata: _bool_, (optional) destroy any data on the device
     * tags: _map of strings_, (optional) a mapping of tag-names to tag-values
     * Example:
 

--- a/docs/man/heketi-cli.8
+++ b/docs/man/heketi-cli.8
@@ -126,6 +126,10 @@ Name of device to add
 .TP
 \fB\-\-node\fP=""
 Id of the node which has this device
+.TP
+\fB\-\-destroy-existing-data
+Optional:
+Destroy existing data on the device (DANGEROUS).
 .RE
 .PP
 \fBExample\fP

--- a/executors/cmdexec/device.go
+++ b/executors/cmdexec/device.go
@@ -31,13 +31,17 @@ const (
 // https://access.redhat.com/documentation/en-US/Red_Hat_Storage/3.1/html/Administration_Guide/Brick_Configuration.html
 //
 
-func (s *CmdExecutor) DeviceSetup(host, device, vgid string) (d *executors.DeviceInfo, e error) {
+func (s *CmdExecutor) DeviceSetup(host, device, vgid string, destroy bool) (d *executors.DeviceInfo, e error) {
 
 	// Setup commands
-	commands := []string{
-		fmt.Sprintf("pvcreate --metadatasize=128M --dataalignment=256K '%v'", device),
-		fmt.Sprintf("vgcreate %v %v", utils.VgIdToName(vgid), device),
+	commands := []string{}
+
+	if destroy {
+		logger.Info("Data on device %v (host %v) will be destroyed", device, host)
+		commands = append(commands, fmt.Sprintf("wipefs --all %v", device))
 	}
+	commands = append(commands, fmt.Sprintf("pvcreate --metadatasize=128M --dataalignment=256K '%v'", device))
+	commands = append(commands, fmt.Sprintf("vgcreate %v %v", utils.VgIdToName(vgid), device))
 
 	// Execute command
 	_, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 5)

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -15,7 +15,7 @@ type Executor interface {
 	GlusterdCheck(host string) error
 	PeerProbe(exec_host, newnode string) error
 	PeerDetach(exec_host, detachnode string) error
-	DeviceSetup(host, device, vgid string) (*DeviceInfo, error)
+	DeviceSetup(host, device, vgid string, destroy bool) (*DeviceInfo, error)
 	GetDeviceInfo(host, device, vgid string) (*DeviceInfo, error)
 	DeviceTeardown(host, device, vgid string) error
 	BrickCreate(host string, brick *BrickRequest) (*BrickInfo, error)

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -18,7 +18,7 @@ type MockExecutor struct {
 	MockGlusterdCheck            func(host string) error
 	MockPeerProbe                func(exec_host, newnode string) error
 	MockPeerDetach               func(exec_host, newnode string) error
-	MockDeviceSetup              func(host, device, vgid string) (*executors.DeviceInfo, error)
+	MockDeviceSetup              func(host, device, vgid string, destroy bool) (*executors.DeviceInfo, error)
 	MockDeviceTeardown           func(host, device, vgid string) error
 	MockBrickCreate              func(host string, brick *executors.BrickRequest) (*executors.BrickInfo, error)
 	MockBrickDestroy             func(host string, brick *executors.BrickRequest) (bool, error)
@@ -53,7 +53,7 @@ func NewMockExecutor() (*MockExecutor, error) {
 		return nil
 	}
 
-	m.MockDeviceSetup = func(host, device, vgid string) (*executors.DeviceInfo, error) {
+	m.MockDeviceSetup = func(host, device, vgid string, destroy bool) (*executors.DeviceInfo, error) {
 		d := &executors.DeviceInfo{}
 		d.Size = 500 * 1024 * 1024 // Size in KB
 		d.ExtentSize = 4096
@@ -197,12 +197,12 @@ func (m *MockExecutor) PeerDetach(exec_host, newnode string) error {
 	return m.MockPeerDetach(exec_host, newnode)
 }
 
-func (m *MockExecutor) DeviceSetup(host, device, vgid string) (*executors.DeviceInfo, error) {
-	return m.MockDeviceSetup(host, device, vgid)
+func (m *MockExecutor) DeviceSetup(host, device, vgid string, destroy bool) (*executors.DeviceInfo, error) {
+	return m.MockDeviceSetup(host, device, vgid, destroy)
 }
 
 func (m *MockExecutor) GetDeviceInfo(host, device, vgid string) (*executors.DeviceInfo, error) {
-	return m.MockDeviceSetup(host, device, vgid)
+	return m.MockDeviceSetup(host, device, vgid, false)
 }
 
 func (m *MockExecutor) DeviceTeardown(host, device, vgid string) error {

--- a/extras/kubernetes/topology-sample.json
+++ b/extras/kubernetes/topology-sample.json
@@ -15,9 +15,18 @@
             "zone": 1
           },
           "devices": [
-            "/dev/vdb",
-            "/dev/vdc",
-            "/dev/vdd"
+            {
+              "name": "/dev/vdb",
+              "destroydata": false
+            },
+            {
+              "name": "/dev/vdc",
+              "destroydata": false
+            },
+            {
+              "name": "/dev/vdd",
+              "destroydata": false
+            }
           ]
         },
         {
@@ -33,9 +42,18 @@
             "zone": 1
           },
           "devices": [
-            "/dev/vdb",
-            "/dev/vdc",
-            "/dev/vdd"
+            {
+              "name": "/dev/vdb",
+              "destroydata": false
+            },
+            {
+              "name": "/dev/vdc",
+              "destroydata": false
+            },
+            {
+              "name": "/dev/vdd",
+              "destroydata": false
+            }
           ]
         },
         {
@@ -51,9 +69,18 @@
             "zone": 1
           },
           "devices": [
-            "/dev/vdb",
-            "/dev/vdc",
-            "/dev/vdd"
+            {
+              "name": "/dev/vdb",
+              "destroydata": false
+            },
+            {
+              "name": "/dev/vdc",
+              "destroydata": false
+            },
+            {
+              "name": "/dev/vdd",
+              "destroydata": false
+            }
           ]
         }
       ]

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -165,13 +165,15 @@ func (dev Device) Validate() error {
 
 type DeviceAddRequest struct {
 	Device
-	NodeId string `json:"node"`
+	NodeId      string `json:"node"`
+	DestroyData bool   `json:"destroydata,omitempty"`
 }
 
 func (devAddReq DeviceAddRequest) Validate() error {
 	return validation.ValidateStruct(&devAddReq,
 		validation.Field(&devAddReq.Device, validation.Required),
 		validation.Field(&devAddReq.NodeId, validation.Required, validation.By(ValidateUUID)),
+		validation.Field(&devAddReq.DestroyData, validation.In(true, false)),
 	)
 }
 


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Some users are certain that the data on the disks that they add to a node can be destroyed. It can be useful to force adding a device, even if `pvcreate` detects existing data. This PR adds an option to the "device add" API and implements the functionality to provide this feature.

### Does this PR fix issues?

BUG: https://bugzilla.redhat.com/1433614

### Notes for the reviewer

A short discussion was also held on the heketi-devel list: http://lists.gluster.org/pipermail/heketi-devel/2018-May/000267.html