### PR TITLE
executors: do not create backups in /etc/lvm/archive by default

### DIFF
--- a/docs/admin/server.md
+++ b/docs/admin/server.md
@@ -25,6 +25,7 @@ The config file has information required to run the Heketi server.  The config f
         * user: _string_, SSH user
         * port: _string_, SSH port number
         * fstab: _string_, Fstab file where to store mount points
+        * backup_lvm_metadata: _bool_, Create archives of the LVM metadata when running vgcreate/lvcreate
         * sudo: _bool_, set to true when SSHing as a non root user
     * kubexec: _map_, Kubernetes configuration
         * host: _string_, Kubernetes API host.  Example `https://myhost:8443`.  Can also be use using environment variable HEKETI_KUBE_APIHOST
@@ -34,6 +35,7 @@ The config file has information required to run the Heketi server.  The config f
         * password: _string_, Password for _user_. Can also be use using environment variable HEKETI_KUBE_PASSWORD.
         * namespace: _string_, Kubernetes namespace or OpenShift project where GlusterFS containers/Pods are running. Can also be use using environment variable HEKETI_KUBE_NAMESPACE.
         * fstab: _string_, Fstab file where to store mount points
+        * backup_lvm_metadata: _bool_, Create archives of the LVM metadata when running vgcreate/lvcreate
 
 ## Advanced Options
 The following configuration options should only be set on advanced configurations under `glusterfs` section:

--- a/etc/heketi.json
+++ b/etc/heketi.json
@@ -48,7 +48,8 @@
       "keyfile": "path/to/private_key",
       "user": "sshuser",
       "port": "Optional: ssh port.  Default is 22",
-      "fstab": "Optional: Specify fstab file on node.  Default is /etc/fstab"
+      "fstab": "Optional: Specify fstab file on node.  Default is /etc/fstab",
+      "backup_lvm_metadata": false
     },
 
     "_kubeexec_comment": "Kubernetes configuration",
@@ -59,7 +60,8 @@
       "user": "kubernetes username",
       "password": "password for kubernetes user",
       "namespace": "OpenShift project or Kubernetes namespace",
-      "fstab": "Optional: Specify fstab file on node.  Default is /etc/fstab"
+      "fstab": "Optional: Specify fstab file on node.  Default is /etc/fstab",
+      "backup_lvm_metadata": false
     },
 
     "_db_comment": "Database file name",

--- a/executors/cmdexec/brick.go
+++ b/executors/cmdexec/brick.go
@@ -44,7 +44,10 @@ func (s *CmdExecutor) BrickCreate(host string,
 		fmt.Sprintf("mkdir -p %v", mountPath),
 
 		// Setup the LV
-		fmt.Sprintf("lvcreate --poolmetadatasize %vK --chunksize 256K --size %vK --thin %v/%v --virtualsize %vK --name %v",
+		fmt.Sprintf("lvcreate --autobackup=%v --poolmetadatasize %vK --chunksize 256K --size %vK --thin %v/%v --virtualsize %vK --name %v",
+			// backup LVM metadata
+			utils.BoolToYN(s.BackupLVM),
+
 			// MetadataSize
 			brick.PoolMetadataSize,
 
@@ -147,7 +150,7 @@ func (s *CmdExecutor) BrickDestroy(host string,
 
 	// Remove the LV (by device name)
 	commands = []string{
-		fmt.Sprintf("lvremove -f %v", dev),
+		fmt.Sprintf("lvremove --autobackup=%v -f %v", utils.BoolToYN(s.BackupLVM), dev),
 	}
 	_, err = s.RemoteExecutor.RemoteCommandExecute(host, commands, 5)
 	if err != nil {
@@ -175,7 +178,7 @@ func (s *CmdExecutor) BrickDestroy(host string,
 	// If there is no brick left in the thin-pool, it can be removed
 	if thin_count == 0 {
 		commands = []string{
-			fmt.Sprintf("lvremove -f %v", tp),
+			fmt.Sprintf("lvremove --autobackup=%v -f %v", utils.BoolToYN(s.BackupLVM), tp),
 		}
 		_, err = s.RemoteExecutor.RemoteCommandExecute(host, commands, 5)
 		if err != nil {

--- a/executors/cmdexec/cmdexec.go
+++ b/executors/cmdexec/cmdexec.go
@@ -31,6 +31,7 @@ type CmdExecutor struct {
 
 	RemoteExecutor RemoteCommandTransport
 	Fstab          string
+	BackupLVM      bool
 }
 
 func (s *CmdExecutor) AccessConnection(host string) {

--- a/executors/cmdexec/device.go
+++ b/executors/cmdexec/device.go
@@ -41,7 +41,7 @@ func (s *CmdExecutor) DeviceSetup(host, device, vgid string, destroy bool) (d *e
 		commands = append(commands, fmt.Sprintf("wipefs --all %v", device))
 	}
 	commands = append(commands, fmt.Sprintf("pvcreate --metadatasize=128M --dataalignment=256K '%v'", device))
-	commands = append(commands, fmt.Sprintf("vgcreate %v %v", utils.VgIdToName(vgid), device))
+	commands = append(commands, fmt.Sprintf("vgcreate --autobackup=%v %v %v", utils.BoolToYN(s.BackupLVM), utils.VgIdToName(vgid), device))
 
 	// Execute command
 	_, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 5)

--- a/executors/kubeexec/kubeexec.go
+++ b/executors/kubeexec/kubeexec.go
@@ -116,6 +116,8 @@ func NewKubeExecutor(config *KubeConfig) (*KubeExecutor, error) {
 		k.Fstab = config.Fstab
 	}
 
+	k.BackupLVM = config.BackupLVM
+
 	// Get namespace
 	var err error
 	if k.config.Namespace == "" {

--- a/executors/sshexec/sshexec.go
+++ b/executors/sshexec/sshexec.go
@@ -112,6 +112,8 @@ func NewSshExecutor(config *SshConfig) (*SshExecutor, error) {
 		s.Fstab = config.Fstab
 	}
 
+	s.BackupLVM = config.BackupLVM
+
 	// Save the configuration
 	s.config = config
 

--- a/pkg/utils/conv.go
+++ b/pkg/utils/conv.go
@@ -7,12 +7,12 @@
 // cases as published by the Free Software Foundation.
 //
 
-package cmdexec
+package utils
 
-type CmdConfig struct {
-	Fstab                string `json:"fstab"`
-	Sudo                 bool   `json:"sudo"`
-	SnapShotLimit        int    `json:"snapshot_limit"`
-	RebalanceOnExpansion bool   `json:"rebalance_on_expansion"`
-	BackupLVM            bool   `json:"backup_lvm_metadata"`
+// BoolToYN returns a "y" (yes) or "n" (no) for the passed bool.
+func BoolToYN(b bool) string {
+	if b {
+		return "y"
+	}
+	return "n"
 }

--- a/pkg/utils/conv_test.go
+++ b/pkg/utils/conv_test.go
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/heketi/tests"
+)
+
+func TestBoolToYNTrue(t *testing.T) {
+	result := BoolToYN(true)
+	tests.Assert(t, result == "y", "calling BoolToYN(true), expected", "y", "got", result)
+}
+
+func TestBoolToYNFalse(t *testing.T) {
+	result := BoolToYN(false)
+	tests.Assert(t, result == "n", "calling BoolToYN(false), expected", "n", "got", result)
+}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

With the automation that Heketi provides and the redundancy that Gluster
offers there is no need for the LVM-metadata backups under
/etc/lvm/archive. It is not expected that users have a need for these
archives, and they can take up a considerable amount space on the /
filesystem in active environments.

The heketi.json used by the service daemon can be configured to create
the LVM-metadata archives by setting "backup_lvm_metadata" to true. This
option defaults to false if not set.

### Does this PR fix issues?

BUG: https://bugzilla.redhat.com/1561680