### PR TITLE
filter pending block hosting from listings of complete volumes

### DIFF
--- a/apps/glusterfs/listing.go
+++ b/apps/glusterfs/listing.go
@@ -76,7 +76,8 @@ func UpdateClusterInfoComplete(tx *bolt.Tx, ci *api.ClusterInfoResponse) error {
 // an error if the db cannot be read.
 func MapPendingVolumes(tx *bolt.Tx) (map[string]string, error) {
 	return mapPendingItems(tx, func(op *PendingOperationEntry, a PendingOperationAction) bool {
-		return (op.Type == OperationCreateVolume && a.Change == OpAddVolume)
+		return ((op.Type == OperationCreateVolume && a.Change == OpAddVolume) ||
+			(op.Type == OperationCreateBlockVolume && a.Change == OpAddVolume))
 	})
 }
 


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Block volume create operations can create volumes (block hosting volumes) when
the block volume is being created. This means when scanning for
pending volumes we must also consider block volume create operations
as well as volume create operations.


### Does this PR fix issues?

Fixes #1188 

