### PR TITLE
manpage: expand example section and add arbiter volume create example

### DIFF
--- a/docs/man/heketi-cli.8
+++ b/docs/man/heketi-cli.8
@@ -677,12 +677,34 @@ Can also be set using the environment variable HEKETI\_CLI\_USER.
 \fB\-v\fP, \fB\-\-version\fP[=false]
 Print version.
 .PP
-.SH EXAMPLE
+.SH EXAMPLES
 .PP
+.SS List Volumes
+.PP
+Specify the Heketi server to contact using an environment variable
+and list the volumes.
 .RS
 .nf
 $ export HEKETI\_CLI\_SERVER=http://localhost:8080
 $ heketi\-cli volume list
+.fi
+.RE
+.PP
+.SS Create a Volume
+.PP
+Create a 4 GiB volume.
+.RS
+.nf
+$ heketi\-cli volume create --size 4
+.fi
+.RE
+.PP
+.SS Create an Arbiter Volume
+.PP
+Create a 4 GiB volume that uses the arbiter feature.
+.RS
+.nf
+$ heketi\-cli volume create --size 4 --gluster-volume-options='user.heketi.arbiter true'
 .fi
 .RE
 .SH COPYRIGHT


### PR DESCRIPTION
To avoid looking weird when the arbiter example is added the whole
example section is expanded a little bit. Then an example of
creating an arbiter volume is added.


### Does this PR fix issues?

Fixes [rhbz #1569486](https://bugzilla.redhat.com/show_bug.cgi?id=1569486)