### PR TITLE
Improve error handling on volume create

### DIFF
--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -311,6 +311,10 @@ func (cds *ClusterDeviceSource) Devices() ([]DeviceAndNode, error) {
 		return nil, err
 	}
 
+	if len(cluster.Info.Nodes) == 0 {
+		return nil, ErrEmptyCluster
+	}
+
 	nodeUp := currentNodeHealthStatus()
 
 	valid := [](DeviceAndNode){}
@@ -351,6 +355,9 @@ func (cds *ClusterDeviceSource) Devices() ([]DeviceAndNode, error) {
 				cds.nodeCache[nodeId] = node
 			}
 		}
+	}
+	if len(valid) == 0 {
+		return nil, ErrNoStorage
 	}
 
 	return valid, nil

--- a/apps/glusterfs/errors.go
+++ b/apps/glusterfs/errors.go
@@ -25,4 +25,8 @@ var (
 	ErrKeyExists        = errors.New("Key already exists in the database")
 	ErrNoReplacement    = errors.New("No Replacement was found for resource requested to be removed")
 	ErrCloneBlockVol    = errors.New("Cloning of block hosting volumes is not supported")
+
+	// well known errors for cluster device source
+	ErrEmptyCluster = errors.New("No nodes in cluster")
+	ErrNoStorage    = errors.New("No online storage devices in cluster")
 )

--- a/apps/glusterfs/operations_test.go
+++ b/apps/glusterfs/operations_test.go
@@ -321,7 +321,8 @@ func TestVolumeCreatePendingNoSpace(t *testing.T) {
 
 	e := vc.Build()
 	// verify that we failed to allocate due to lack of space
-	tests.Assert(t, e == ErrNoSpace, "expected e == ErrNoSpace, got", e)
+	tests.Assert(t, strings.Contains(e.Error(), ErrNoSpace.Error()),
+		"expected strings.Contains(e.Error(), ErrNoSpace.Error()) got", e)
 
 	// verify no volumes, bricks or pending ops in db
 	app.db.View(func(tx *bolt.Tx) error {

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -952,3 +952,69 @@ func (v *VolumeEntry) cloneVolumeRequest(db wdb.RODB, clonename string) (*execut
 
 	return vcr, sshhost, nil
 }
+
+type MultiClusterError struct {
+	prefix string
+	errors map[string]error
+}
+
+// NewMultiClusterError returns a MultiClusterError with the given
+// prefix text. Prefix text will be used in the error string if
+// more than one error is captured.
+func NewMultiClusterError(p string) *MultiClusterError {
+	return &MultiClusterError{
+		prefix: p,
+		errors: map[string]error{},
+	}
+}
+
+// Add an error originating with cluster `c` to the captured
+// errors map.
+func (m *MultiClusterError) Add(c string, e error) {
+	m.errors[c] = e
+}
+
+// Return the length of the captured errors map.
+func (m *MultiClusterError) Len() int {
+	return len(m.errors)
+}
+
+// Shorten returns a simplified version of the errors that
+// the MultiClusterError may have captured. It returns nil if
+// no errors were captured. It returns itself if more than one
+// error was captured. It returns the original error if only
+// one error was captured.
+func (m *MultiClusterError) Shorten() error {
+	switch len(m.errors) {
+	case 0:
+		return nil
+	case 1:
+		for _, err := range m.errors {
+			return err
+		}
+	}
+	return m
+}
+
+// Error returns the error string for the multi cluster error.
+// If only one error was captured, it returns the text of that
+// error alone. If more than one error was captured, it returns
+// formatted text containing all captured errors.
+func (m *MultiClusterError) Error() string {
+	if len(m.errors) == 0 {
+		return "(missing cluster error)"
+	}
+	if len(m.errors) == 1 {
+		for _, v := range m.errors {
+			return v.Error()
+		}
+	}
+	errs := []string{}
+	if m.prefix != "" {
+		errs = append(errs, m.prefix)
+	}
+	for k, v := range m.errors {
+		errs = append(errs, fmt.Sprintf("Cluster %v: %v", k, v.Error()))
+	}
+	return strings.Join(errs, "\n")
+}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

This series improves the handling of error messages on volume create by:
1. Adding specific errors for when the cluster has no nodes or none of the nodes have usable devices
2. Adding the ability to capture and report on each cluster's error by aggregating them in a new MultiClusterError type, as opposed to coercing all errors to "No Space"
3. Adds tests for the above

Example output:
```
heketi-cli volume create --size=4
Error: Failed to allocate new volume: Unable to create volume on any cluster:
Cluster 4081998cadcd0c9093f2c2f0fc813430: No nodes in cluster
Cluster a54cc7f2711c1711b8a6aef195681893: No online storage devices in cluster
```

### Does this PR fix issues?

Fixes #712 


### Notes for the reviewer

Type name and error text wording bike-shedding welcome.
