### PR TITLE
apps: prevent delete of volumes that are pending

### DIFF
--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -912,6 +912,11 @@ func (vdel *BlockVolumeDeleteOperation) ResourceUrl() string {
 // marks the db entries as such.
 func (vdel *BlockVolumeDeleteOperation) Build() error {
 	return vdel.db.Update(func(tx *bolt.Tx) error {
+		if vdel.bvol.Pending.Id != "" {
+			logger.LogError("Pending block volume %v can not be deleted",
+				vdel.bvol.Info.Id)
+			return ErrConflict
+		}
 		vdel.op.RecordDeleteBlockVolume(vdel.bvol)
 		if e := vdel.op.Save(tx); e != nil {
 			return e

--- a/apps/glusterfs/operations_test.go
+++ b/apps/glusterfs/operations_test.go
@@ -668,6 +668,122 @@ func TestVolumeDeleteOperationRollback(t *testing.T) {
 	})
 }
 
+func TestVolumeDeleteOperationTwice(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	req := &api.VolumeCreateRequest{}
+	req.Size = 1024
+	req.Durability.Type = api.DurabilityReplicate
+	req.Durability.Replicate.Replica = 3
+
+	// first we need to create a volume to delete
+	vol := NewVolumeEntryFromRequest(req)
+	vc := NewVolumeCreateOperation(vol, app.db)
+
+	e := vc.Build()
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+	e = vc.Exec(app.executor)
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+	e = vc.Finalize()
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+
+	app.db.View(func(tx *bolt.Tx) error {
+		bl, e := BrickList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(bl) == 3, "expected len(bl) == 3, got:", len(bl))
+		po, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(po) == 0, "expected len(po) == 0, got:", len(po))
+		return nil
+	})
+
+	vd := NewVolumeDeleteOperation(vol, app.db)
+	e = vd.Build()
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+
+	app.db.View(func(tx *bolt.Tx) error {
+		po, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(po) == 1, "expected len(po) == 1, got:", len(po))
+		return nil
+	})
+
+	vd2 := NewVolumeDeleteOperation(vol, app.db)
+	e = vd2.Build()
+	tests.Assert(t, e == ErrConflict, "expected e == ErrConflict, got:", e)
+}
+
+func TestVolumeDeleteOperationDuringExpand(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	req := &api.VolumeCreateRequest{}
+	req.Size = 1024
+	req.Durability.Type = api.DurabilityReplicate
+	req.Durability.Replicate.Replica = 3
+
+	// first we need to create a volume to delete
+	vol := NewVolumeEntryFromRequest(req)
+	vc := NewVolumeCreateOperation(vol, app.db)
+
+	e := vc.Build()
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+	e = vc.Exec(app.executor)
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+	e = vc.Finalize()
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+
+	app.db.View(func(tx *bolt.Tx) error {
+		bl, e := BrickList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(bl) == 3, "expected len(bl) == 3, got:", len(bl))
+		po, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(po) == 0, "expected len(po) == 0, got:", len(po))
+		return nil
+	})
+
+	ve := NewVolumeExpandOperation(vol, app.db, 50)
+	e = ve.Build()
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+
+	app.db.View(func(tx *bolt.Tx) error {
+		po, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(po) == 1, "expected len(po) == 1, got:", len(po))
+		return nil
+	})
+
+	vd := NewVolumeDeleteOperation(vol, app.db)
+	e = vd.Build()
+	tests.Assert(t, e == ErrConflict, "expected e == ErrConflict, got:", e)
+}
+
 func TestVolumeExpandOperation(t *testing.T) {
 	tmpfile := tests.Tempfile()
 	defer os.Remove(tmpfile)


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Prevent multiple delete operations on the same volume and prevent
deletes of volumes that are already being worked on by checking
the pending id of the volume and its bricks.
Prevent multiple delete operations on same block volume.

Add a test for 
* deleting the same volume twice
* deleting a volume that is currently being expanded
* deleting the same block volume twice

### Does this PR fix issues?

This fixes part of issue #1189


### Notes for the reviewer

This is part of the fix for #1189 in that it should prevent certain issues inf the first place. However, it does not deal with the failures in the cleanup code.
