### PR TITLE
extras: add heketi containers for the CentOS Registry

### DIFF
--- a/extras/docker/centos/.gitignore
+++ b/extras/docker/centos/.gitignore
@@ -1,0 +1,3 @@
+# artifacts copied from elsewere (see prepare-build.sh)
+heketi.json
+heketi-start.sh

--- a/extras/docker/centos/Dockerfile
+++ b/extras/docker/centos/Dockerfile
@@ -1,0 +1,21 @@
+FROM registry.centos.org/centos/centos:latest
+MAINTAINER Heketi Developers <heketi-devel@gluster.org>
+
+LABEL version="0.8"
+LABEL description="Heketi based on the packages from the CentOS Storage SIG"
+
+# install dependencies, build and cleanup
+RUN yum -y install centos-release-gluster && \
+    yum -y install heketi heketi-client && \
+    yum -y clean all
+
+# post install config and volume setup
+ADD heketi.json /etc/heketi/heketi.json
+ADD heketi-start.sh /usr/bin/heketi-start.sh
+
+VOLUME /etc/heketi
+VOLUME /var/lib/heketi
+
+# expose port, set user and set entrypoint with config option
+ENTRYPOINT ["/usr/bin/heketi-start.sh"]
+EXPOSE 8080

--- a/extras/docker/centos/Dockerfile.testing
+++ b/extras/docker/centos/Dockerfile.testing
@@ -1,0 +1,21 @@
+FROM registry.centos.org/centos/centos:latest
+MAINTAINER Heketi Developers <heketi-devel@gluster.org>
+
+LABEL version="0.8"
+LABEL description="Heketi based on the packages from the CentOS Storage SIG in TESTING"
+
+# install dependencies, build and cleanup
+RUN yum -y install centos-release-gluster && \
+    yum -y --enablerepo=centos-gluster*-test install heketi heketi-client && \
+    yum -y --enablerepo=* clean all
+
+# post install config and volume setup
+ADD heketi.json /etc/heketi/heketi.json
+ADD heketi-start.sh /usr/bin/heketi-start.sh
+
+VOLUME /etc/heketi
+VOLUME /var/lib/heketi
+
+# expose port, set user and set entrypoint with config option
+ENTRYPOINT ["/usr/bin/heketi-start.sh"]
+EXPOSE 8080

--- a/extras/docker/centos/README.md
+++ b/extras/docker/centos/README.md
@@ -1,0 +1,28 @@
+# Heketi Container Image based on packages from the CentOS Storage SIG
+
+The CentOS Storage SIG provides a stable version of Heketi as and RPM. This
+container aims to be suitable for productions deployments where CentOS is the
+preferred operating system.
+
+This directory contains two files from creating images:
+
+1. `Dockerfile` for building an image from released packages
+2. `Dockerfile.testing` for building an image from packages in testing
+
+These images are maintained by the Heketi Developers, for questions or problem
+reports they can be reached on
+[heketi-devel@gluster.org](mailto:heketi-devel@gluster.org), on Freenode IRC in
+#heketi or by opening an [issue on
+Gitub](https://github.com/heketi/heketi/issues/new).
+
+
+## Build Process
+
+Images are build by the [CentOS Community Container Pipeline
+Service](https://github.com/CentOS/container-pipeline-service). The
+specification for the job is split over two files:
+
+1. the `cccp.yaml` contains the `job-id` which is used for the image name
+2. a [`gluster.yaml` in the container-index
+   repository](https://github.com/CentOS/container-index/blob/master/index.d/gluster.yaml)
+   that points to this repository and its `Dockerfile`s

--- a/extras/docker/centos/cccp.yaml
+++ b/extras/docker/centos/cccp.yaml
@@ -1,0 +1,11 @@
+# This file is required for the purpose of building a Docker container on CCCP.
+# More information (and a quickstart) found here: https://github.com/CentOS/container-index/pull/265
+
+# This will be part of the name of the container. It should match the job-id in index entry
+job-id: storagesig-heketi
+
+# This flag tells the container pipeline to skip user defined tests on their container
+# test-skip: False
+
+# This is path of the script that initiates the user defined tests. It must be able to return an exit code.
+# test-script: test-script.sh

--- a/extras/docker/centos/prepare-build.sh
+++ b/extras/docker/centos/prepare-build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# Preparation for building container images.
+#
+# - artifacts need to be in this WORKDIR, symlinks won't work
+#
+
+# error out if anything fails
+set -e
+
+# the local directory where the Dockerfile is located
+WORKDIR=$(dirname "${0}")
+
+cp -f "${WORKDIR}"/../fromsource/heketi.json "${WORKDIR}"
+cp -f "${WORKDIR}"/../fromsource/heketi-start.sh "${WORKDIR}"


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Add container images for the CentOS Container Registry that is available at https://registry.centos.org/containers/ . The images are built from RPMs that are available from the CentOS Storage SIG.

Currently two flavours are provided:
1. built from the CentOS Storage SIG stable/released repository
2. built from the CentOS Storage SIG testing repository

The description to build the containers for the CentOS Container Registry is available from [the add-gluster-heketi branch](https://github.com/nixpanic/centos-container-index/commit/5476a48b72a4e192318f5301a6da155ca1b93908) in my fork of the [container-index repository](https://github.com/CentOS/container-index). Once this PR has been merged, a PR for the container-index will be created.