### PR TITLE
Dockerfile: update the Maintainer

### DIFF
--- a/extras/docker/fromsource/Dockerfile
+++ b/extras/docker/fromsource/Dockerfile
@@ -1,6 +1,6 @@
 # set author and base
 FROM fedora
-MAINTAINER Luis Pabón <lpabon@redhat.com>
+MAINTAINER Heketi Developers <heketi-devel@gluster.org>
 
 LABEL version="1.3.1"
 LABEL description="Development build"


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

The dockerfile lists Luis as the maintainer. But Luis is no longer working on heketi, so update the dockerfile.

