### PR TITLE
Fix heketi startup with orphaned cluster->volume and volume-> brick links

### DIFF
--- a/apps/glusterfs/brick_entry.go
+++ b/apps/glusterfs/brick_entry.go
@@ -274,6 +274,12 @@ func addVolumeIdInBrickEntry(tx *bolt.Tx) error {
 		}
 		for _, brick := range volumeEntry.Bricks {
 			brickEntry, err := NewBrickEntryFromId(tx, brick)
+			if err == ErrNotFound {
+				logger.Warning("Volume [%v] links to "+
+					"nonexistent brick [%v]. Ignoring.",
+					volume, brick)
+				continue
+			}
 			if err != nil {
 				return err
 			}

--- a/apps/glusterfs/brick_entry.go
+++ b/apps/glusterfs/brick_entry.go
@@ -263,34 +263,28 @@ func BrickEntryUpgrade(tx *bolt.Tx) error {
 }
 
 func addVolumeIdInBrickEntry(tx *bolt.Tx) error {
-	clusters, err := ClusterList(tx)
+	volumes, err := VolumeList(tx)
 	if err != nil {
 		return err
 	}
-	for _, cluster := range clusters {
-		clusterEntry, err := NewClusterEntryFromId(tx, cluster)
+	for _, volume := range volumes {
+		volumeEntry, err := NewVolumeEntryFromId(tx, volume)
 		if err != nil {
 			return err
 		}
-		for _, volume := range clusterEntry.Info.Volumes {
-			volumeEntry, err := NewVolumeEntryFromId(tx, volume)
+		for _, brick := range volumeEntry.Bricks {
+			brickEntry, err := NewBrickEntryFromId(tx, brick)
 			if err != nil {
 				return err
 			}
-			for _, brick := range volumeEntry.Bricks {
-				brickEntry, err := NewBrickEntryFromId(tx, brick)
+			if brickEntry.Info.VolumeId == "" {
+				brickEntry.Info.VolumeId = volume
+				err = brickEntry.Save(tx)
 				if err != nil {
 					return err
 				}
-				if brickEntry.Info.VolumeId == "" {
-					brickEntry.Info.VolumeId = volume
-					err = brickEntry.Save(tx)
-					if err != nil {
-						return err
-					}
-				} else {
-					break
-				}
+			} else {
+				break
 			}
 		}
 	}


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

Currenly, when a cluster lists a volumeid, that does not exist in the db, and when a volume lists a brick id that does not exist in the db, heketi will refuse to start with the upgrade failing. This is unnecessary since those orphan backlinks are actually harmless.  This PR improves the upgrade code to  not fail over these.

