### PR TITLE
Release 7: fix dockerfile

### DIFF
--- a/extras/docker/fromsource/Dockerfile
+++ b/extras/docker/fromsource/Dockerfile
@@ -1,5 +1,7 @@
 # set author and base
-FROM fedora
+# need to use fedora 27 until glide is fixed in fedora 28
+# (or we get an alternative glide)
+FROM fedora:27
 MAINTAINER Heketi Developers <heketi-devel@gluster.org>
 
 LABEL version="1.3.1"
@@ -13,7 +15,7 @@ ENV HEKETI_BRANCH="release/7"
 
 # install dependencies, build and cleanup
 RUN mkdir $BUILD_HOME $GOPATH && \
-    dnf -y install glide golang git make && \
+    dnf -y install glide golang git make mercurial && \
     dnf -y clean all && \
     mkdir -p $GOPATH/src/github.com/heketi && \
     cd $GOPATH/src/github.com/heketi && \
@@ -25,7 +27,7 @@ RUN mkdir $BUILD_HOME $GOPATH && \
     cp client/cli/go/heketi-cli /usr/bin/heketi-cli && \
     glide cc && \
     cd && rm -rf $BUILD_HOME && \
-    dnf -y remove git glide golang && \
+    dnf -y remove git glide golang mercurial && \
     dnf -y autoremove && \
     dnf -y clean all
 

--- a/extras/docker/fromsource/Dockerfile
+++ b/extras/docker/fromsource/Dockerfile
@@ -1,6 +1,6 @@
 # set author and base
 FROM fedora
-MAINTAINER Luis Pabón <lpabon@redhat.com>
+MAINTAINER Heketi Developers <heketi-devel@gluster.org>
 
 LABEL version="1.3.1"
 LABEL description="Development build"

--- a/extras/docker/fromsource/Dockerfile
+++ b/extras/docker/fromsource/Dockerfile
@@ -1,6 +1,6 @@
 # set author and base
 FROM fedora
-MAINTAINER Michael Adam <obnox@redhat.com>
+MAINTAINER Luis Pabón <lpabon@redhat.com>
 
 LABEL version="1.3.1"
 LABEL description="Development build"


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

This PR improves the dockerfile to name heketi-devel as maintainer, and fix build by installing mercurial.


### Notes for the reviewer

This is against the release/7 branch.

Since the release/7 branch had a patch to change the maintainer (to /me) but now we have a better master patch, I chose to revert the first patch in release/7 and then do clean cherry-picks from master. Alternatively, if preferred, I can squash the revert and the master-cherry-pick for the maintainer.
