### PR TITLE
Add method to receive (detailed) volume status through HTTP

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -469,6 +469,12 @@ func (a *App) SetRoutes(router *mux.Router) error {
 			Pattern:     "/volumes/{id:[A-Fa-f0-9]+}",
 			HandlerFunc: a.VolumeInfo},
 		rest.Route{
+			Name:        "VolumeStatus",
+			Method:      "GET",
+			Pattern:     "/volumes/{id:[A-Fa-f0-9]+}/status",
+			HandlerFunc: a.VolumeDetailedStatus,
+		},
+		rest.Route{
 			Name:        "VolumeExpand",
 			Method:      "POST",
 			Pattern:     "/volumes/{id:[A-Fa-f0-9]+}/expand",

--- a/apps/glusterfs/app_config.go
+++ b/apps/glusterfs/app_config.go
@@ -45,4 +45,7 @@ type GlusterFSConfig struct {
 
 	// operation retry amounts
 	RetryLimits RetryLimitConfig `json:"operation_retry_limits"`
+
+	// "volume status" is a very heavy operation
+	VolumeStatusEnabled bool `json:"volume_status_enabled"`
 }

--- a/client/api/go-client/volume.go
+++ b/client/api/go-client/volume.go
@@ -197,6 +197,39 @@ func (c *Client) VolumeInfo(id string) (*api.VolumeInfoResponse, error) {
 	return &volume, nil
 }
 
+func (c *Client) VolumeStatus(id string) (*api.VolumeDetailedStatusResponse, error) {
+	// Create request
+	req, err := http.NewRequest("GET", c.host+"/volumes/"+id+"/status", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set token
+	err = c.setToken(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get info
+	r, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		return nil, utils.GetErrorFromResponse(r)
+	}
+
+	// Read JSON response
+	var status api.VolumeDetailedStatusResponse
+	err = utils.GetJsonFromResponse(r, &status)
+	if err != nil {
+		return nil, err
+	}
+
+	return &status, nil
+}
+
 func (c *Client) VolumeDelete(id string) error {
 
 	// Create a request

--- a/client/cli/go/cmds/utils.go
+++ b/client/cli/go/cmds/utils.go
@@ -111,3 +111,26 @@ func newHeketiClient() (*client.Client, error) {
 			VerifyCerts:        options.TLSCerts,
 		})
 }
+
+const (
+	_         = iota
+	KB uint64 = 1 << (10 * iota)
+	MB
+	GB
+	TB
+)
+
+func humanReadableSize(byteSize uint64) string {
+	switch {
+	case byteSize < KB:
+		return fmt.Sprintf("%d", byteSize)
+	case byteSize < MB:
+		return fmt.Sprintf("%.1fKiB", float64(byteSize)/float64(KB))
+	case byteSize < GB:
+		return fmt.Sprintf("%.1fMiB", float64(byteSize)/float64(MB))
+	case byteSize < TB:
+		return fmt.Sprintf("%.1fGiB", float64(byteSize)/float64(GB))
+	default:
+		return fmt.Sprintf("%.1fTiB", float64(byteSize)/float64(TB))
+	}
+}

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -23,6 +23,7 @@
     * [Volumes](#volumes)
         * [Create a Volume](#create-a-volume)
         * [Volume Information](#volume-information)
+        * [Volume Status](#volume-status)
         * [Expand a Volume](#expand-a-volume)
         * [Delete Volume](#delete-volume)
         * [List Volumes](#list-volumes)
@@ -671,6 +672,104 @@ So, it is not possible create a volume of size less than 1GiB.
             "device": "49a9bd2e40df882180479024ac4c24c8"
         }
     ]
+}
+```
+
+### Volume Status
+* **Method:** _GET_
+* **Endpoint**:`/volumes/{id}/status`
+* **Response HTTP Status Code**: 200
+* **JSON Request**: None
+* **JSON Response**:
+    * name: _string_, Name of volume
+    * nodes: _array of maps_, Status of volume on each cluster node
+        * hostname: _string_, Hostname of cluster node
+        * path: _string_, Mountpoint of volume
+        * status: _int_, Status of the volume. Value 1 means that it is online
+        * port: _int_, Currently used port
+        * ports: _array of maps_, Ports which may be used
+            * tcp: _int_, TCP port
+            * rdma: _string_, RDMA port. Has value `N/A` if not available
+        * pid: _int_, Gluster daemon PID
+        * size_total: _int_, Size of volume in bytes
+        * size_free: _int_, Free space on volume in bytes
+        * device: _string_, Block device path
+        * block_size: _int_, Size of filesystem block in bytes
+        * mount_options: _string_, Mount options of volume
+        * fs_name: _string_, Filesystem type
+        * inode_size: _string_, Explains size of filesystem inode. May equal to `fs_name`
+        * inodes_total: _int_, Total count of inodes
+        * inodes_free: _int_, Count of free inodes
+    * Example:
+
+```json
+{
+  "name": "vol_07578d152371d67db1f267cf05d144ec",
+  "nodes": [
+    {
+      "hostname": "192.168.88.223",
+      "path": "/var/lib/heketi/mounts/vg_a724d796e9650f54402651c485452cce/brick_6ceecf6aa603d5c562a4ea0fed7bb890/brick",
+      "peerid": "d00af9f7-888c-4be2-bfea-57f95f413a10",
+      "status": 1,
+      "port": 49153,
+      "ports": {
+        "tcp": 49153,
+        "rdma": "N/A"
+      },
+      "pid": 17567,
+      "size_total": 5358223360,
+      "size_free": 5324062720,
+      "device": "/dev/mapper/vg_a724d796e9650f54402651c485452cce-brick_6ceecf6aa603d5c562a4ea0fed7bb890",
+      "block_size": 4096,
+      "mount_options": "rw,seclabel,noatime,nouuid,attr2,inode64,logbsize=256k,sunit=512,swidth=512,noquota",
+      "fs_name": "xfs",
+      "inode_size": "xfs",
+      "inodes_total": 2621440,
+      "inodes_free": 2621417
+    },
+    {
+      "hostname": "192.168.88.221",
+      "path": "/var/lib/heketi/mounts/vg_c6dba216bbc2c57fa06cf3e8c8b7452c/brick_061097492a46cc4a79a59756ecb80583/brick",
+      "peerid": "6aa57558-cda5-45ed-8eb3-4b79d18d07f3",
+      "status": 1,
+      "port": 49153,
+      "ports": {
+        "tcp": 49153,
+        "rdma": "N/A"
+      },
+      "pid": 12145,
+      "size_total": 5358223360,
+      "size_free": 5324062720,
+      "device": "/dev/mapper/vg_c6dba216bbc2c57fa06cf3e8c8b7452c-brick_061097492a46cc4a79a59756ecb80583",
+      "block_size": 4096,
+      "mount_options": "rw,seclabel,noatime,nouuid,attr2,inode64,logbsize=256k,sunit=512,swidth=512,noquota",
+      "fs_name": "xfs",
+      "inode_size": "xfs",
+      "inodes_total": 2621440,
+      "inodes_free": 2621417
+    },
+    {
+      "hostname": "192.168.88.222",
+      "path": "/var/lib/heketi/mounts/vg_d01d91984f58d57bdd32f2564aeae550/brick_b96a961291ac70f83239b3fa5f990cab/brick",
+      "peerid": "4734834b-fad6-4eda-abfa-6d03cc543aa2",
+      "status": 1,
+      "port": 49153,
+      "ports": {
+        "tcp": 49153,
+        "rdma": "N/A"
+      },
+      "pid": 17606,
+      "size_total": 5358223360,
+      "size_free": 5324062720,
+      "device": "/dev/mapper/vg_d01d91984f58d57bdd32f2564aeae550-brick_b96a961291ac70f83239b3fa5f990cab",
+      "block_size": 4096,
+      "mount_options": "rw,seclabel,noatime,nouuid,attr2,inode64,logbsize=256k,sunit=512,swidth=512,noquota",
+      "fs_name": "xfs",
+      "inode_size": "xfs",
+      "inodes_total": 2621440,
+      "inodes_free": 2621417
+    }
+  ]
 }
 ```
 

--- a/docs/man/heketi-cli.8
+++ b/docs/man/heketi-cli.8
@@ -644,6 +644,19 @@ $ heketi-cli volume info 886a86a868711bef83001
 .fi
 .RE
 .RE
+.RE
+.PP
+\fBheketi\-cli volume status  <VOLUME-ID>\fP
+.RS
+Retrieves information volume status from all cluster nodes
+.PP
+\fBExample\fP
+.RS
+.nf
+$ heketi-cli volume status 886a86a868711bef83001
+.fi
+.RE
+.RE
 .PP
 \fBheketi\-cli volume list\fP
 .RS

--- a/etc/heketi.json
+++ b/etc/heketi.json
@@ -87,6 +87,9 @@
     "block_hosting_volume_size": 500,
 
     "_block_hosting_volume_options": "New block hosting volume will be created with the following set of options. Removing the group gluster-block option is NOT recommended. Additional options can be added next to it separated by a comma.",
-    "block_hosting_volume_options": "group gluster-block"
+    "block_hosting_volume_options": "group gluster-block",
+
+    "_volume_status_enabled": "Enable volume status fetching via HTTP.",
+    "volume_status_enabled": false
   }
 }

--- a/executors/cmdexec/volume.go
+++ b/executors/cmdexec/volume.go
@@ -280,6 +280,40 @@ func (s *CmdExecutor) VolumeInfo(host string, volume string) (*executors.Volume,
 	return &volumeInfo.VolInfo.Volumes.VolumeList[0], nil
 }
 
+func (s *CmdExecutor) VolumeStatusDetailed(host string, volume string) (*executors.VolumeDetail, error) {
+	godbc.Require(volume != "")
+	godbc.Require(host != "")
+
+	type CliOutput struct {
+		OpRet     int                 `xml:"opRet"`
+		OpErrno   int                 `xml:"opErrno"`
+		OpErrStr  string              `xml:"opErrstr"`
+		VolStatus executors.VolStatus `xml:"volStatus"`
+	}
+
+	command := []string{
+		fmt.Sprintf("gluster --mode=script volume status %v detail --xml", volume),
+	}
+
+	//Get the xml output of volume info
+	output, err := s.RemoteExecutor.RemoteCommandExecute(host, command, 10)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to get detailed volume status of volume name: %v", volume)
+	}
+	var volumeDetails CliOutput
+	err = xml.Unmarshal([]byte(output[0]), &volumeDetails)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to determine detailed volume status of volume name: %v", volume)
+	}
+	logger.Debug("%+v\n", volumeDetails)
+
+	if volumeDetails.OpRet != 0 {
+		return nil, fmt.Errorf("Failed to get status of volume %v: %v", volume, volumeDetails.OpErrStr)
+	}
+
+	return &volumeDetails.VolStatus.Volumes.VolumeDetailList[0], nil
+}
+
 func (s *CmdExecutor) VolumeReplaceBrick(host string, volume string, oldBrick *executors.BrickInfo, newBrick *executors.BrickInfo) error {
 	godbc.Require(volume != "")
 	godbc.Require(host != "")

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -26,6 +26,7 @@ type Executor interface {
 	VolumeExpand(host string, volume *VolumeRequest) (*Volume, error)
 	VolumeReplaceBrick(host string, volume string, oldBrick *BrickInfo, newBrick *BrickInfo) error
 	VolumeInfo(host string, volume string) (*Volume, error)
+	VolumeStatusDetailed(host string, volume string) (*VolumeDetail, error)
 	VolumeClone(host string, vsr *VolumeCloneRequest) (*Volume, error)
 	VolumeSnapshot(host string, vsr *VolumeSnapshotRequest) (*Snapshot, error)
 	SnapshotCloneVolume(host string, scr *SnapshotCloneRequest) (*Volume, error)
@@ -249,4 +250,47 @@ type VolumeDoesNotExistErr struct {
 
 func (dne *VolumeDoesNotExistErr) Error() string {
 	return "Volume Does Not Exist: " + dne.Name
+}
+
+type NodePorts struct {
+	XMLName xml.Name `xml:"ports"`
+	TCP     int      `xml:"tcp"`
+	RDMA    string   `xml:"rdma"`
+}
+
+type Node struct {
+	XMLName      xml.Name  `xml:"node"`
+	HostName     string    `xml:"hostname"`
+	Path         string    `xml:"path"`
+	PeerID       string    `xml:"peerid"`
+	Status       int       `xml:"status"`
+	Port         int       `xml:"port"`
+	Ports        NodePorts `xml:"ports"`
+	PID          int       `xml:"pid"`
+	SizeTotal    uint64    `xml:"sizeTotal"`
+	SizeFree     uint64    `xml:"sizeFree"`
+	Device       string    `xml:"device"`
+	BlockSize    uint      `xml:"blockSize"`
+	MountOptions string    `xml:"mntOptions"`
+	FSName       string    `xml:"fsName"`
+	InodeSize    string    `xml:"inodeSize"`
+	InodesTotal  uint64    `xml:"inodesTotal"`
+	InodesFree   uint64    `xml:"inodesFree"`
+}
+
+type VolumeDetail struct {
+	XMLName    xml.Name `xml:"volume"`
+	VolumeName string   `xml:"volName"`
+	NodeCount  int      `xml:"nodeCount"`
+	Nodes      []Node   `xml:"node"`
+}
+
+type VolumeDetailList struct {
+	XMLName          xml.Name       `xml:"volumes"`
+	VolumeDetailList []VolumeDetail `xml:"volume"`
+}
+
+type VolStatus struct {
+	XMLName xml.Name `xml:"volStatus"`
+	Volumes VolumeDetailList
 }

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -29,6 +29,7 @@ type MockExecutor struct {
 	MockVolumeDestroyCheck       func(host, volume string) error
 	MockVolumeReplaceBrick       func(host string, volume string, oldBrick *executors.BrickInfo, newBrick *executors.BrickInfo) error
 	MockVolumeInfo               func(host string, volume string) (*executors.Volume, error)
+	MockVolumeStatusDetailed     func(host string, volume string) (*executors.VolumeDetail, error)
 	MockVolumeClone              func(host string, volume *executors.VolumeCloneRequest) (*executors.Volume, error)
 	MockVolumeSnapshot           func(host string, volume *executors.VolumeSnapshotRequest) (*executors.Snapshot, error)
 	MockSnapshotCloneVolume      func(host string, volume *executors.SnapshotCloneRequest) (*executors.Volume, error)
@@ -123,6 +124,21 @@ func NewMockExecutor() (*MockExecutor, error) {
 			Bricks: Bricks,
 		}
 		return vinfo, nil
+	}
+
+	m.MockVolumeStatusDetailed = func(host string, volume string) (*executors.VolumeDetail, error) {
+		nodes := []executors.Node{
+			{
+				HostName: host,
+				Path:     host + ":/mockpath",
+			},
+		}
+		volumeDetail := &executors.VolumeDetail{
+			VolumeName: volume,
+			NodeCount:  len(nodes),
+			Nodes:      nodes,
+		}
+		return volumeDetail, nil
 	}
 
 	m.MockVolumeSnapshot = func(host string, vsr *executors.VolumeSnapshotRequest) (*executors.Snapshot, error) {
@@ -251,6 +267,10 @@ func (m *MockExecutor) VolumeReplaceBrick(host string, volume string, oldBrick *
 
 func (m *MockExecutor) VolumeInfo(host string, volume string) (*executors.Volume, error) {
 	return m.MockVolumeInfo(host, volume)
+}
+
+func (m *MockExecutor) VolumeStatusDetailed(host string, volume string) (*executors.VolumeDetail, error) {
+	return m.MockVolumeStatusDetailed(host, volume)
 }
 
 func (m *MockExecutor) VolumeClone(host string, vcr *executors.VolumeCloneRequest) (*executors.Volume, error) {

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -217,6 +217,28 @@ type NodeInfoResponse struct {
 	DevicesInfo []DeviceInfoResponse `json:"devices"`
 }
 
+type NodeDetailedStatusResponse struct {
+	HostName string `json:"hostname"`
+	Path     string `json:"path"`
+	PeerID   string `json:"peerid"`
+	Status   int    `json:"status"`
+	Port     int    `json:"port"`
+	Ports    struct {
+		TCP  int    `json:"tcp"`
+		RDMA string `json:"rdma"`
+	} `json:"ports"`
+	PID          int    `json:"pid"`
+	SizeTotal    uint64 `json:"size_total"`
+	SizeFree     uint64 `json:"size_free"`
+	Device       string `json:"device"`
+	BlockSize    uint   `json:"block_size"`
+	MountOptions string `json:"mount_options"`
+	FSName       string `json:"fs_name"`
+	InodeSize    string `json:"inode_size"`
+	InodesTotal  uint64 `json:"inodes_total"`
+	InodesFree   uint64 `json:"inodes_free"`
+}
+
 // Cluster
 
 type ClusterFlags struct {
@@ -323,6 +345,11 @@ type VolumeInfo struct {
 type VolumeInfoResponse struct {
 	VolumeInfo
 	Bricks []BrickInfo `json:"bricks"`
+}
+
+type VolumeDetailedStatusResponse struct {
+	Name  string                       `json:"name"`
+	Nodes []NodeDetailedStatusResponse `json:"nodes"`
 }
 
 type VolumeListResponse struct {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?
It allows to fetch useful information about volume using HTTP request: 
* Filesystem type 
* Mount options
* Volume size and usage
* Inodes (total/usage)
* and more...

Here is output of command `gluster volume status {volume} details`
```
Status of volume: vol_e4fdf8a3eb3f3f57eb002ca6fc1ea636
------------------------------------------------------------------------------
Brick                : Brick 192.168.88.223:/var/lib/heketi/mounts/vg_a724d796e9650f54402651c485452cce/brick_e9b32169c1beaf643ab569f3e1283a62/brick
TCP Port             : 49157               
RDMA Port            : 0                   
Online               : Y                   
Pid                  : 10208               
File System          : xfs                 
Device               : /dev/mapper/vg_a724d796e9650f54402651c485452cce-brick_e9b32169c1beaf643ab569f3e1283a62
Mount Options        : rw,seclabel,noatime,nouuid,attr2,inode64,logbsize=256k,sunit=512,swidth=512,noquota
Inode Size           : 512                 
Disk Space Free      : 6.0GB               
Total Disk Space     : 6.0GB               
Inode Count          : 3145728             
Free Inodes          : 3145697             
------------------------------------------------------------------------------
Brick                : Brick 192.168.88.221:/var/lib/heketi/mounts/vg_c6dba216bbc2c57fa06cf3e8c8b7452c/brick_e98aefcee69f97943208d72058582984/brick
TCP Port             : 49157               
RDMA Port            : 0                   
Online               : Y                   
Pid                  : 8015                
File System          : xfs                 
Device               : /dev/mapper/vg_c6dba216bbc2c57fa06cf3e8c8b7452c-brick_e98aefcee69f97943208d72058582984
Mount Options        : rw,seclabel,noatime,nouuid,attr2,inode64,logbsize=256k,sunit=512,swidth=512,noquota
Inode Size           : 512                 
Disk Space Free      : 6.0GB               
Total Disk Space     : 6.0GB               
Inode Count          : 3145728             
Free Inodes          : 3145697             
------------------------------------------------------------------------------
Brick                : Brick 192.168.88.222:/var/lib/heketi/mounts/vg_d01d91984f58d57bdd32f2564aeae550/brick_8c5106b430e173f881b670fd27bcdbc6/brick
TCP Port             : 49157               
RDMA Port            : 0                   
Online               : Y                   
Pid                  : 10167               
File System          : xfs                 
Device               : /dev/mapper/vg_d01d91984f58d57bdd32f2564aeae550-brick_8c5106b430e173f881b670fd27bcdbc6
Mount Options        : rw,seclabel,noatime,nouuid,attr2,inode64,logbsize=256k,sunit=512,swidth=512,noquota
Inode Size           : 512                 
Disk Space Free      : 6.0GB               
Total Disk Space     : 6.0GB               
Inode Count          : 3145728             
Free Inodes          : 3145697             
 
```


