### PR TITLE
don't let DeleteBricksWithEmptyPath stumble over broken links in the DB

### DIFF
--- a/apps/glusterfs/cluster_entry.go
+++ b/apps/glusterfs/cluster_entry.go
@@ -218,6 +218,11 @@ func (c *ClusterEntry) DeleteBricksWithEmptyPath(tx *bolt.Tx) error {
 
 	for _, nodeid := range c.Info.Nodes {
 		node, err := NewNodeEntryFromId(tx, nodeid)
+		if err == ErrNotFound {
+			logger.Warning("Ignoring nonexisting node [%v] in "+
+				"cluster [%v].", nodeid, c.Info.Id)
+			continue
+		}
 		if err != nil {
 			return err
 		}

--- a/apps/glusterfs/device_entry.go
+++ b/apps/glusterfs/device_entry.go
@@ -573,6 +573,11 @@ func (d *DeviceEntry) DeleteBricksWithEmptyPath(tx *bolt.Tx) error {
 
 	for _, id := range d.Bricks {
 		brick, err := NewBrickEntryFromId(tx, id)
+		if err == ErrNotFound {
+			logger.Warning("Ignoring nonexistent brick [%v] on "+
+				"disk [%d].", id, d.Info.Id)
+			continue
+		}
 		if err != nil {
 			return err
 		}

--- a/apps/glusterfs/node_entry.go
+++ b/apps/glusterfs/node_entry.go
@@ -462,6 +462,11 @@ func (n *NodeEntry) DeleteBricksWithEmptyPath(tx *bolt.Tx) error {
 
 	for _, deviceid := range n.Devices {
 		device, err := NewDeviceEntryFromId(tx, deviceid)
+		if err == ErrNotFound {
+			logger.Warning("Ignoring nonexisting device [%v] on "+
+				"node [%v].", deviceid, n.Info.Id)
+			continue
+		}
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

If the DB has broken links (list of node-ids in the cluster, list of device-ids in the node, list of brick-ids in the device), DeleteBricksWithEmptyPath will fail. This PR lets DeleteBricksWithEmptyPath ignore these harmless links pointing to nowhere, but logging warning messages about them.



