### PR TITLE
Add support for resumable delete volume

### DIFF
--- a/apps/glusterfs/brick_create.go
+++ b/apps/glusterfs/brick_create.go
@@ -57,6 +57,8 @@ func DestroyBricks(db wdb.RODB, executor executors.Executor, brick_entries []*Br
 			defer sg.Done()
 			spaceReclaimed, err := b.Destroy(db, executor)
 			if err == nil {
+				logger.LogError("error destroying brick %v: %v",
+					b.Info.Id, err)
 				// mark space from device as freed
 				m.Lock()
 				r[b.Info.DeviceId] = spaceReclaimed

--- a/apps/glusterfs/brick_entry.go
+++ b/apps/glusterfs/brick_entry.go
@@ -164,6 +164,8 @@ func (b *BrickEntry) brickRequest(path string) *executors.BrickRequest {
 	req.TpSize = b.TpSize
 	req.VgId = b.Info.DeviceId
 	req.PoolMetadataSize = b.PoolMetadataSize
+	req.TpName = b.TpName()
+	req.LvName = b.LvName()
 	// path varies depending on what it is called from
 	req.Path = path
 	return req

--- a/apps/glusterfs/brick_entry.go
+++ b/apps/glusterfs/brick_entry.go
@@ -28,6 +28,12 @@ type BrickEntry struct {
 	PoolMetadataSize uint64
 	gidRequested     int64
 	Pending          PendingItem
+
+	// the following is used when tracking the
+	// bricks in cloned volumes. They follow a different
+	// scheme than the bricks created directly by Heketi.
+	LvmThinPool string
+	LvmLv       string
 }
 
 func BrickList(tx *bolt.Tx) ([]string, error) {
@@ -320,4 +326,22 @@ func (b *BrickEntry) RemoveFromDevice(tx *bolt.Tx) error {
 	}
 
 	return nil
+}
+
+// TpName returns the expected name of the lvm thin pool that
+// stores this brick.
+func (b *BrickEntry) TpName() string {
+	if b.LvmThinPool != "" {
+		return b.LvmThinPool
+	}
+	return utils.BrickIdToThinPoolName(b.Info.Id)
+}
+
+// LvName returns the expected name of the lvm lv that stores
+// this brick.
+func (b *BrickEntry) LvName() string {
+	if b.LvmLv != "" {
+		return b.LvmLv
+	}
+	return utils.BrickIdToName(b.Info.Id)
 }

--- a/apps/glusterfs/brick_entry.go
+++ b/apps/glusterfs/brick_entry.go
@@ -62,6 +62,7 @@ func NewBrickEntry(size, tpsize, poolMetadataSize uint64,
 	entry.Info.NodeId = nodeid
 	entry.Info.DeviceId = deviceid
 	entry.Info.VolumeId = volumeid
+	entry.LvmThinPool = utils.BrickIdToThinPoolName(entry.Info.Id)
 	entry.UpdatePath()
 
 	godbc.Ensure(entry.Info.Id != "")
@@ -96,6 +97,12 @@ func CloneBrickEntryFromId(tx *bolt.Tx, id string) (*BrickEntry, error) {
 	}
 
 	entry.Info.Id = utils.GenUUID()
+	// bricks always share a thin pool with the original brick
+	if entry.LvmThinPool == "" {
+		entry.LvmThinPool = utils.BrickIdToThinPoolName(entry.Info.Id)
+	}
+	// brick clones have their own lv name (not yet known)
+	entry.LvmLv = ""
 
 	return entry, nil
 }

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -932,6 +932,7 @@ func updateCloneBrickPaths(bricks []*BrickEntry,
 		logger.Debug("Updating brick %v with new path %v (had %v)",
 			brick.Id(), clonePath, origPath)
 		brick.Info.Path = clonePath
+		brick.LvmLv = utils.VolumeIdToCloneLv(clone.ID)
 	}
 	return nil
 }

--- a/executors/cmdexec/brick.go
+++ b/executors/cmdexec/brick.go
@@ -191,6 +191,14 @@ func (s *CmdExecutor) BrickDestroy(host string,
 	_, umountErr = s.RemoteExecutor.RemoteCommandExecute(host, commands, 5)
 	if umountErr != nil {
 		logger.Err(umountErr)
+		// check if the brick was previously unmounted
+		out, e := s.RemoteExecutor.RemoteCommandExecute(
+			host, []string{"mount"}, 5)
+		if e == nil && len(out) == 1 && !strings.Contains(out[0], brick.Path) {
+			logger.Warning("brick path [%v] not mounted, assuming deleted",
+				brick.Path)
+			umountErr = nil
+		}
 	}
 
 	// remove brick from fstab before we start deleting LVM items.

--- a/executors/cmdexec/brick_test.go
+++ b/executors/cmdexec/brick_test.go
@@ -27,6 +27,8 @@ func doTestSshExecBrickCreate(t *testing.T, f *CommandFaker, s *FakeExecutor) {
 		Size:             10,
 		PoolMetadataSize: 5,
 		Path:             utils.BrickPath("xvgid", "id"),
+		TpName:           "tp_id",
+		LvName:           "brick_id",
 	}
 
 	// Mock ssh function
@@ -110,6 +112,8 @@ func TestSshExecBrickCreateWithGid(t *testing.T) {
 		PoolMetadataSize: 5,
 		Gid:              1234,
 		Path:             utils.BrickPath("xvgid", "id"),
+		TpName:           "tp_id",
+		LvName:           "brick_id",
 	}
 
 	// Mock ssh function
@@ -193,6 +197,8 @@ func TestSshExecBrickCreateSudo(t *testing.T) {
 		Size:             10,
 		PoolMetadataSize: 5,
 		Path:             utils.BrickPath("xvgid", "id"),
+		TpName:           "tp_id",
+		LvName:           "brick_id",
 	}
 
 	// Mock ssh function
@@ -277,6 +283,8 @@ func TestSshExecBrickDestroy(t *testing.T) {
 		Size:             10,
 		PoolMetadataSize: 5,
 		Path:             strings.TrimSuffix(utils.BrickPath("xvgid", "id"), "/brick"),
+		TpName:           "tp_id",
+		LvName:           "brick_id",
 	}
 
 	// Mock ssh function
@@ -320,7 +328,7 @@ func TestSshExecBrickDestroy(t *testing.T) {
 			case strings.Contains(cmd, "lvremove"):
 				tests.Assert(t,
 					cmd == "lvremove --autobackup="+utils.BoolToYN(s.BackupLVM)+" -f vg_xvgid/tp_id" ||
-						cmd == "lvremove --autobackup="+utils.BoolToYN(s.BackupLVM)+" -f /dev/vg_xvgid/brick_id", cmd)
+						cmd == "lvremove --autobackup="+utils.BoolToYN(s.BackupLVM)+" -f vg_xvgid/brick_id", cmd)
 
 			case strings.Contains(cmd, "rmdir"):
 				tests.Assert(t,

--- a/executors/cmdexec/volume.go
+++ b/executors/cmdexec/volume.go
@@ -161,12 +161,7 @@ func (s *CmdExecutor) VolumeDestroyCheck(host, volume string) error {
 	godbc.Require(volume != "")
 
 	// Determine if the volume is able to be deleted
-	err := s.checkForSnapshots(host, volume)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return s.checkForSnapshots(host, volume)
 }
 
 func (s *CmdExecutor) createVolumeOptionsCommand(volume *executors.VolumeRequest) []string {

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -237,3 +237,11 @@ type BlockVolumeInfo struct {
 	Username          string
 	Password          string
 }
+
+type VolumeDoesNotExistErr struct {
+	Name string
+}
+
+func (dne *VolumeDoesNotExistErr) Error() string {
+	return "Volume Does Not Exist: " + dne.Name
+}

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -63,6 +63,9 @@ type BrickRequest struct {
 	Gid              int64
 	// Path is the brick mountpoint (named Path for symmetry with BrickInfo)
 	Path string
+	// lvm names
+	TpName string
+	LvName string
 }
 
 // Returns information about the location of the brick

--- a/pkg/utils/paths.go
+++ b/pkg/utils/paths.go
@@ -12,6 +12,7 @@ package utils
 import (
 	"errors"
 	"path"
+	"strings"
 )
 
 const (
@@ -89,4 +90,10 @@ func BrickDevNode(vgId, brickId string) string {
 	return path.Join(
 		deviceMapperRoot,
 		VgIdToName(vgId)+"-"+BrickIdToName(brickId))
+}
+
+// VolumeIdToCloneLv converts a gluster volume UUID into the
+// lv name used by the gluster snapshot/clone process.
+func VolumeIdToCloneLv(gvolId string) string {
+	return strings.Replace(gvolId, "-", "", -1) + "_0"
 }

--- a/tests/functional/TestSmokeTest/tests/delete_test.go
+++ b/tests/functional/TestSmokeTest/tests/delete_test.go
@@ -1,0 +1,132 @@
+// +build functional
+
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package functional
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/heketi/pkg/utils/ssh"
+	"github.com/heketi/tests"
+)
+
+func TestPartialDeletes(t *testing.T) {
+	setupCluster(t, 4, 8)
+	defer teardownCluster(t)
+	t.Run("testDeleteNormal", testDeleteNormal)
+	t.Run("testDeletedOnGluster", testDeletedOnGluster)
+	t.Run("testDeletedUnmountedBrick", testDeletedUnmountedBrick)
+	t.Run("testDeletedBrickPv", testDeletedBrickPv)
+}
+
+func testPrepareVolume(t *testing.T) *api.VolumeInfoResponse {
+	volReq := &api.VolumeCreateRequest{}
+	volReq.Size = 10
+	volReq.Durability.Type = api.DurabilityReplicate
+	volReq.Durability.Replicate.Replica = 3
+
+	vcr, err := heketi.VolumeCreate(volReq)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	return vcr
+}
+
+func testDeleteNormal(t *testing.T) {
+	vcr := testPrepareVolume(t)
+
+	err := heketi.VolumeDelete(vcr.Id)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+}
+
+func testDeletedOnGluster(t *testing.T) {
+	vcr := testPrepareVolume(t)
+
+	s := ssh.NewSshExecWithKeyFile(
+		logger, "vagrant", "../config/insecure_private_key")
+	cmds := []string{
+		fmt.Sprintf("gluster --mode=script volume stop %v", vcr.Name),
+		fmt.Sprintf("gluster --mode=script volume delete %v", vcr.Name),
+	}
+	_, err := s.ConnectAndExec(storage0ssh, cmds, 10, true)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	err = heketi.VolumeDelete(vcr.Id)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+}
+
+func testDeletedUnmountedBrick(t *testing.T) {
+	vcr := testPrepareVolume(t)
+
+	s := ssh.NewSshExecWithKeyFile(
+		logger, "vagrant", "../config/insecure_private_key")
+	cmds := []string{
+		fmt.Sprintf("gluster --mode=script volume info %v", vcr.Name),
+		fmt.Sprintf("gluster --mode=script volume stop %v", vcr.Name),
+		fmt.Sprintf("gluster --mode=script volume delete %v", vcr.Name),
+	}
+	o, err := s.ConnectAndExec(storage0ssh, cmds, 10, true)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(o) >= 1)
+	var host, brickPath string
+	for _, line := range strings.Split(o[0], "\n") {
+		if len(line) >= 8 && line[:8] == "Brick1: " {
+			parts := strings.SplitN(line[8:], ":", 2)
+			host, brickPath = parts[0], parts[1]
+			break
+		}
+	}
+	tests.Assert(t, len(host) > 0, "expected len(host) > 0, got:", host)
+	tests.Assert(t, len(brickPath) > 0, "expected len(brickPath) > 0, got:", host)
+	cmds = []string{
+		fmt.Sprintf("umount %v", strings.TrimSuffix(brickPath, "/brick")),
+	}
+	_, err = s.ConnectAndExec(host+":"+portNum, cmds, 10, true)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	err = heketi.VolumeDelete(vcr.Id)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+}
+
+func testDeletedBrickPv(t *testing.T) {
+	vcr := testPrepareVolume(t)
+
+	s := ssh.NewSshExecWithKeyFile(
+		logger, "vagrant", "../config/insecure_private_key")
+	cmds := []string{
+		fmt.Sprintf("gluster --mode=script volume info %v", vcr.Name),
+		fmt.Sprintf("gluster --mode=script volume stop %v", vcr.Name),
+		fmt.Sprintf("gluster --mode=script volume delete %v", vcr.Name),
+	}
+	o, err := s.ConnectAndExec(storage0ssh, cmds, 10, true)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(o) >= 1)
+	var host, brickPath string
+	for _, line := range strings.Split(o[0], "\n") {
+		if len(line) >= 8 && line[:8] == "Brick1: " {
+			parts := strings.SplitN(line[8:], ":", 2)
+			host, brickPath = parts[0], parts[1]
+			break
+		}
+	}
+	tests.Assert(t, len(host) > 0, "expected len(host) > 0, got:", host)
+	tests.Assert(t, len(brickPath) > 0, "expected len(brickPath) > 0, got:", host)
+	cmds = []string{
+		fmt.Sprintf("umount %v", strings.TrimSuffix(brickPath, "/brick")),
+		"lvs --noheadings --sep / -o vg_name,lv_name | grep vg_ | xargs -L1 echo lvremove -f",
+	}
+	_, err = s.ConnectAndExec(host+":"+portNum, cmds, 10, true)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	err = heketi.VolumeDelete(vcr.Id)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

This PR implements the ability to resume deleting partially deleted volumes. It currently involves refactoring various parts of the delete volume path. It also adds support for explicitly tracking the the LV and thinpool name for bricks. Functional tests for normal volumes are included.

### Does this PR fix issues?

Fixes #1220


### Notes for the reviewer

I still need to add tests for deleting cloned volumes. This is already a big PR so I may do that in a followup pr depending on timing/your opinions.