### PR TITLE
client: disable issued at time claim in jwt

### DIFF
--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -22,8 +22,14 @@ import (
 	"github.com/gorilla/context"
 )
 
+// From https://github.com/dgrijalva/jwt-go/pull/139 it is understood
+// that if the machine where jwt token is generated and/or the machine
+// where jwt token is verified have any clock skew then there is a
+// possibility of getting a "Token used before issued" error. Considering
+// that we also check for expiration with delta of 5 minutes, disabling
+// iat claim until the patch is merged in jwt.
 var (
-	required_claims = []string{"iss", "iat", "exp"}
+	required_claims = []string{"iss", "exp"}
 )
 
 type JwtAuth struct {


### PR DESCRIPTION
From https://github.com/dgrijalva/jwt-go/pull/139 it is understood
that if the machine where jwt token is generated and/or the machine
where jwt token is verified have any clock skew then there is a
possibility of getting a "Token used before issued" error. Considering
that we also check for expiration with delta of 5 minutes, disabling
iat claim until the patch is merged in jwt.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>

### What does this PR achieve? Why do we need it?

This PR disables the issued at time claim in jwt. Doing so will stop "token used before issued" errors.

### Does this PR fix issues?
Fixes #646 

### Notes for the reviewer


