### PR TITLE
Update the free size in block info on expansion

### DIFF
--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -341,6 +341,9 @@ func (ve *VolumeExpandOperation) Finalize() error {
 			}
 		}
 		ve.vol.Info.Size += sizeDelta
+		if ve.vol.Info.Block == true {
+			ve.vol.Info.BlockInfo.FreeSize += sizeDelta
+		}
 		ve.op.FinalizeVolume(ve.vol)
 		if e := ve.vol.Save(tx); e != nil {
 			return e


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
Update the free size in block info on expansion. If a volume is expanded and has a block flag set to true, then we should also update the free size attribute of the volume in blockinfo.

### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #1229 


### Notes for the reviewer


