### PR TITLE
Add adminstrative modes to Heketi server

### DIFF
--- a/client/api/go-client/admin.go
+++ b/client/api/go-client/admin.go
@@ -1,0 +1,78 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
+//
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/heketi/pkg/utils"
+)
+
+func (c *Client) AdminStatusGet() (*api.AdminStatus, error) {
+	req, err := http.NewRequest("GET", c.host+"/admin", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Set token
+	err = c.setToken(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Send request
+	r, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	var as api.AdminStatus
+	err = utils.GetJsonFromResponse(r, &as)
+	if err != nil {
+		return nil, err
+	}
+	return &as, nil
+}
+
+func (c *Client) AdminStatusSet(request *api.AdminStatus) error {
+	// Marshal request to JSON
+	buffer, err := json.Marshal(request)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", c.host+"/admin", bytes.NewBuffer(buffer))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Set token
+	err = c.setToken(req)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	r, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	if r.StatusCode == http.StatusOK || r.StatusCode == http.StatusNoContent {
+		return nil
+	}
+	return utils.GetErrorFromResponse(r)
+}

--- a/client/api/go-client/client_test.go
+++ b/client/api/go-client/client_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/heketi/heketi/middleware"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
+	"github.com/heketi/heketi/server/admin"
 	"github.com/heketi/tests"
 	"github.com/urfave/negroni"
 )
@@ -59,11 +60,15 @@ func setupHeketiServerAndMiddleware(
 	jwtconfig.Admin.PrivateKey = TEST_ADMIN_KEY
 	jwtconfig.User.PrivateKey = "userkey"
 
+	adminss := admin.New()
+	adminss.SetRoutes(router)
+
 	// Setup middleware
 	n.Use(middleware.NewJwtAuth(jwtconfig))
 	if m != nil {
 		n.Use(m)
 	}
+	n.Use(adminss)
 	n.UseFunc(app.Auth)
 	n.UseHandler(router)
 
@@ -1144,4 +1149,43 @@ func TestRetryAfterThrottle(t *testing.T) {
 	tests.Assert(t, err != nil, "expected err != nil, got", err)
 	tests.Assert(t, err.Error() == "Too Many Requests", "expected err == 'Too Many Requests', got", err)
 	tests.Assert(t, ictr == 1, "expected ictr == 1, got", ictr)
+}
+
+func TestAdminStatus(t *testing.T) {
+	db := tests.Tempfile()
+	defer os.Remove(db)
+
+	// Create the app
+	app := glusterfs.NewTestApp(db)
+	defer app.Close()
+
+	// Setup the server
+	ts := setupHeketiServer(app)
+	defer ts.Close()
+
+	c := NewClient(ts.URL, "admin", TEST_ADMIN_KEY)
+	tests.Assert(t, c != nil, "NewClient failed:", c)
+
+	as, err := c.AdminStatusGet()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, as.State == api.AdminStateNormal,
+		"expected as.State == api.AdminStateNormal, got:", as.State)
+
+	as.State = api.AdminStateLocal
+	err = c.AdminStatusSet(as)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	as, err = c.AdminStatusGet()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, as.State == api.AdminStateLocal,
+		"expected as.State == api.AdminStateNormal, got:", as.State)
+
+	as.State = api.AdminStateNormal
+	err = c.AdminStatusSet(as)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	as, err = c.AdminStatusGet()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, as.State == api.AdminStateNormal,
+		"expected as.State == api.AdminStateNormal, got:", as.State)
 }

--- a/main.go
+++ b/main.go
@@ -395,6 +395,9 @@ func main() {
 	// Setup complete routing
 	router.NewRoute().Handler(n)
 
+	// Reset admin mode on SIGUSR2
+	admin.ResetStateOnSignal(adminss, syscall.SIGUSR2)
+
 	// Shutdown on CTRL-C signal
 	// For a better cleanup, we should shutdown the server and
 	signalch := make(chan os.Signal, 1)

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/heketi/heketi/apps/glusterfs"
 	"github.com/heketi/heketi/middleware"
 	"github.com/heketi/heketi/pkg/metrics"
+	"github.com/heketi/heketi/server/admin"
 	"github.com/heketi/heketi/server/config"
 )
 
@@ -374,6 +375,10 @@ func main() {
 
 		fmt.Println("Authorization loaded")
 	}
+
+	adminss := admin.New()
+	n.Use(adminss)
+	adminss.SetRoutes(heketiRouter)
 
 	if options.BackupDbToKubeSecret {
 		// Check if running in a Kubernetes environment

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -579,3 +579,22 @@ type OperationsInfo struct {
 	Stale uint64 `json:"stale"`
 	New   uint64 `json:"new"`
 }
+
+type AdminState string
+
+const (
+	AdminStateNormal   AdminState = "normal"
+	AdminStateReadOnly AdminState = "read-only"
+	AdminStateLocal    AdminState = "local-client"
+)
+
+type AdminStatus struct {
+	State AdminState `json:"state"`
+}
+
+func (as AdminStatus) Validate() error {
+	return validation.ValidateStruct(&as,
+		validation.Field(&as.State,
+			validation.Required,
+			validation.In(AdminStateNormal, AdminStateReadOnly, AdminStateLocal)))
+}

--- a/server/admin/http.go
+++ b/server/admin/http.go
@@ -1,0 +1,101 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/heketi/pkg/utils"
+)
+
+var (
+	// there's got to be a better way than this, but I couldn't find
+	// one in a reasonable number of searches
+	localhost4 = "127.0.0.1"
+	localhost6 = "::1"
+)
+
+func (s *ServerState) AllowRequest(r *http.Request) bool {
+	switch s.Get() {
+	case api.AdminStateReadOnly:
+		return r.Method == http.MethodGet || r.Method == http.MethodHead
+	case api.AdminStateLocal:
+		if r.Method == http.MethodGet || r.Method == http.MethodHead {
+			return true
+		}
+		clientIP, _, _ := net.SplitHostPort(r.RemoteAddr)
+		return clientIP == localhost4 || clientIP == localhost6
+	default:
+		return true
+	}
+}
+
+func (s *ServerState) ServeHTTP(
+	w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+
+	if !s.AllowRequest(r) {
+		http.Error(w,
+			"Service disabled for maintenance",
+			http.StatusServiceUnavailable)
+		return
+	}
+	next(w, r)
+}
+
+func (s *ServerState) SetRoutes(router *mux.Router) error {
+	router.
+		Methods("GET").
+		Path("/admin").
+		Name("GetAdminState").
+		Handler(http.HandlerFunc(s.GetAdminState))
+	router.
+		Methods("POST").
+		Path("/admin").
+		Name("SetAdminState").
+		Handler(http.HandlerFunc(s.SetAdminState))
+	return nil
+}
+
+func (s *ServerState) GetAdminState(w http.ResponseWriter, r *http.Request) {
+	data := api.AdminStatus{
+		State: s.Get(),
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		panic(err)
+	}
+}
+
+func (s *ServerState) SetAdminState(w http.ResponseWriter, r *http.Request) {
+	msg := api.AdminStatus{}
+	err := utils.GetJsonFromRequest(r, &msg)
+	if err != nil {
+		http.Error(w,
+			fmt.Sprintf("request unable to be parsed: %s", err.Error()),
+			http.StatusBadRequest)
+		return
+	}
+
+	if err := msg.Validate(); err != nil {
+		http.Error(w, "validation failed: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	s.Set(msg.State)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/server/admin/reset.go
+++ b/server/admin/reset.go
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package admin
+
+import (
+	"os"
+	"os/signal"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+)
+
+func ResetStateOnSignal(s *ServerState, sig ...os.Signal) {
+	signalch := make(chan os.Signal, 1)
+	signal.Notify(signalch, sig...)
+
+	go func() {
+		for {
+			select {
+			case <-signalch:
+				s.Set(api.AdminStateNormal)
+			}
+		}
+	}()
+}

--- a/server/admin/state.go
+++ b/server/admin/state.go
@@ -1,0 +1,39 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package admin
+
+import (
+	"sync"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+)
+
+type ServerState struct {
+	state api.AdminState
+	lock  sync.RWMutex
+}
+
+func New() *ServerState {
+	return &ServerState{
+		state: api.AdminStateNormal,
+	}
+}
+
+func (s *ServerState) Set(newState api.AdminState) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.state = newState
+}
+
+func (s *ServerState) Get() api.AdminState {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.state
+}

--- a/tests/functional/TestSmokeTest/tests/admin_modes_test.go
+++ b/tests/functional/TestSmokeTest/tests/admin_modes_test.go
@@ -1,0 +1,141 @@
+// +build functional
+
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package functional
+
+import (
+	"os"
+	"strconv"
+	"syscall"
+	"testing"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/tests"
+)
+
+func TestAdminModes(t *testing.T) {
+	setupCluster(t, 4, 8)
+	defer teardownCluster(t)
+	t.Run("testAdminStatusGet", testAdminStatusGet)
+	teardownVolumes(t)
+	t.Run("testAdminStatusLocal", testAdminStatusLocal)
+	teardownVolumes(t)
+	t.Run("testAdminStatusNormal", testAdminStatusNormal)
+	teardownVolumes(t)
+	t.Run("testAdminStatusReadOnly", testAdminStatusReadOnly)
+	t.Run("testAdminStatusReset", testAdminStatusReset)
+}
+
+func checkAdminState(t *testing.T, s api.AdminState) {
+	as, err := heketi.AdminStatusGet()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, as.State == s,
+		"expected as.State == s, got:", as.State, s)
+}
+
+func testAdminStatusGet(t *testing.T) {
+	checkAdminState(t, api.AdminStateNormal)
+}
+
+func testAdminStatusLocal(t *testing.T) {
+	err := heketi.AdminStatusSet(&api.AdminStatus{
+		State: api.AdminStateLocal,
+	})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	checkAdminState(t, api.AdminStateLocal)
+
+	// now we should still be able to create a volume as
+	// the test runs on the same host as heketi
+	volReq := &api.VolumeCreateRequest{}
+	volReq.Size = 1
+	volReq.Durability.Type = api.DurabilityReplicate
+	volReq.Durability.Replicate.Replica = 3
+	_, err = heketi.VolumeCreate(volReq)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+}
+
+func testAdminStatusNormal(t *testing.T) {
+	testAdminStatusLocal(t)
+	// re-executing the local status test will leave this
+	// in local-only mode. But because we are a local client
+	// we should be able to set server back to normal
+
+	err := heketi.AdminStatusSet(&api.AdminStatus{
+		State: api.AdminStateNormal,
+	})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	checkAdminState(t, api.AdminStateNormal)
+
+	// now we should still be able to create a volume as
+	// the test runs on the same host as heketi
+	volReq := &api.VolumeCreateRequest{}
+	volReq.Size = 1
+	volReq.Durability.Type = api.DurabilityReplicate
+	volReq.Durability.Replicate.Replica = 3
+	_, err = heketi.VolumeCreate(volReq)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+}
+
+func testAdminStatusReadOnly(t *testing.T) {
+	err := heketi.AdminStatusSet(&api.AdminStatus{
+		State: api.AdminStateReadOnly,
+	})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	checkAdminState(t, api.AdminStateReadOnly)
+
+	// now we can no longer make changes to the system
+	volReq := &api.VolumeCreateRequest{}
+	volReq.Size = 1
+	volReq.Durability.Type = api.DurabilityReplicate
+	volReq.Durability.Replicate.Replica = 3
+	_, err = heketi.VolumeCreate(volReq)
+	tests.Assert(t, err != nil, "expected err != nil, got:", err)
+
+	// we can not even change the admin mode
+	err = heketi.AdminStatusSet(&api.AdminStatus{
+		State: api.AdminStateNormal,
+	})
+	tests.Assert(t, err != nil, "expected err != nil, got:", err)
+}
+
+func testAdminStatusReset(t *testing.T) {
+	as, err := heketi.AdminStatusGet()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	if as.State != api.AdminStateReadOnly {
+		testAdminStatusReadOnly(t)
+	}
+
+	checkAdminState(t, api.AdminStateReadOnly)
+	syscall.Kill(heketiPid(), syscall.SIGUSR2)
+	checkAdminState(t, api.AdminStateNormal)
+
+	// now we should be able to create a volume again
+	volReq := &api.VolumeCreateRequest{}
+	volReq.Size = 1
+	volReq.Durability.Type = api.DurabilityReplicate
+	volReq.Durability.Replicate.Replica = 3
+	_, err = heketi.VolumeCreate(volReq)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+}
+
+// heketiPid returns the pid of the current heketi process.
+// If the pid can not be determined the function will panic.
+func heketiPid() int {
+	hpid := os.Getenv("HEKETI_PID")
+	if hpid == "" {
+		panic("no heketi pid supplied")
+	}
+	i, err := strconv.Atoi(hpid)
+	if err != nil {
+		panic(err)
+	}
+	return i
+}

--- a/tests/functional/lib.sh
+++ b/tests/functional/lib.sh
@@ -81,6 +81,7 @@ teardown_vagrant() {
 
 run_go_tests() {
     cd tests || fail "Unable to 'cd tests'."
+    export HEKETI_PID
     time go test -timeout=2h -tags functional -v
     gotest_result=$?
     echo "~~~ go test exited with ${gotest_result}"


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

This series creates apis, middleware and utilities to track and control a heketi
server's administrative state. Currently all the state does
is control what clients are allowed to made modifying requests (POSTS, DELETES, etc):
* normal: all clients
* read-only: no clients
* local-only: only localhost may make changes

The idea is to allow an admin to put heketi into read-only mode in order for it to finish outstanding requests but accept no more. The local-only state is a hybrid state where only changes from localhost will be accepted so as to drain any outstanding external client requests but to allow for local administrative actions like a node replacement.

As a special case a local process can send SIGUSR2 to the server to reset the administrative state to normal. This is done to support testing (TDB) as well as an "escape hatch" in case the user sets the server to read-only and decides that was not what was wanted.


### Does this PR fix issues?

Fixes #1225


### Notes for the reviewer

Currently only the server core and the API are supported. I have not done cli yet and would like feedback on the general approach first. When it comes time to do the cli I'm actually thinking that the "status" version will hit this api as well as a few others to aggregate some general information about the state of the server.
