### PR TITLE
apps: add per-brick log, if brick destroy fails

### DIFF
--- a/apps/glusterfs/brick_create.go
+++ b/apps/glusterfs/brick_create.go
@@ -56,14 +56,16 @@ func DestroyBricks(db wdb.RODB, executor executors.Executor, brick_entries []*Br
 		go func(b *BrickEntry, r map[string]bool, m *sync.Mutex) {
 			defer sg.Done()
 			spaceReclaimed, err := b.Destroy(db, executor)
-			if err == nil {
+			if err != nil {
 				logger.LogError("error destroying brick %v: %v",
 					b.Info.Id, err)
+			} else {
 				// mark space from device as freed
 				m.Lock()
 				r[b.Info.DeviceId] = spaceReclaimed
 				m.Unlock()
 			}
+
 			sg.Err(err)
 		}(brick, reclaimed, &mutex)
 	}


### PR DESCRIPTION


Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>

<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?
This fixes the logging ,if brick destroy fails

### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes: 7da13ee7a43337c8724e3429f69d4192339e5a4a


### Notes for the reviewer


