### PR TITLE
build: add a check for mercurial/hg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ ifeq ($(GOARCH),$(GOHOSTARCH))
 endif
 endif
 GLIDEPATH := $(shell command -v glide 2> /dev/null)
+HGPATH := $(shell command -v hg 2> /dev/null)
 DIR=.
 
 ifeq (master,$(BRANCH))
@@ -69,6 +70,11 @@ ifndef GLIDEPATH
 	$(info by running: curl https://glide.sh/get | sh.)
 	$(info )
 	$(error glide is required to continue)
+endif
+ifndef HGPATH
+	$(info Please install mercurial/hg.)
+	$(info glide needs to fetch pkgs from a mercurial repository.)
+	$(error mercurial/hg is required to continue)
 endif
 	echo "Installing vendor directory"
 	glide install -v


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Glide needs to fetch a repository from bitbucket.org, which is a Mercurial hosting site. The `hg` executable needs to be available to download the requires pkgs.

If `hg` is not available running `make vendor` fails with the following error:

     [WARN] Unable to checkout bitbucket.org/ww/goautoneg
     [ERROR] Update failed for bitbucket.org/ww/goautoneg: hg is not installed
     [ERROR] Failed to install: hg is not installed
     make: *** [Makefile:74: vendor] Error 1
