### PR TITLE
heketi-cli: fix output of heketi-cli device resync

### DIFF
--- a/client/cli/go/cmds/device.go
+++ b/client/cli/go/cmds/device.go
@@ -336,7 +336,7 @@ var deviceResyncCommand = &cobra.Command{
 		//set url
 		err = heketi.DeviceResync(deviceId)
 		if err == nil {
-			fmt.Fprintf(stdout, "Device %v updated\n", nodeId)
+			fmt.Fprintf(stdout, "Device %v updated\n", deviceId)
 		}
 
 		return nil


### PR DESCRIPTION
Previously, output was "Device  updated".
Now it is of the form  "Device <DEVICE-ID> updated".

Fixes #1240 