### PR TITLE
Fix incorrectly updating the block hosting volume free size on rollback

### DIFF
--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -237,7 +237,7 @@ func (v *BlockVolumeEntry) cleanupBlockVolumeCreate(db wdb.DB,
 	// best effort removal of anything on system
 	v.deleteBlockVolumeExec(db, hvname, executor)
 
-	return v.removeComponents(db)
+	return v.removeComponents(db, true)
 }
 
 func (v *BlockVolumeEntry) Create(db wdb.DB,
@@ -317,7 +317,7 @@ func (v *BlockVolumeEntry) deleteBlockVolumeExec(db wdb.RODB,
 	return nil
 }
 
-func (v *BlockVolumeEntry) removeComponents(db wdb.DB) error {
+func (v *BlockVolumeEntry) removeComponents(db wdb.DB, keepSize bool) error {
 	return db.Update(func(tx *bolt.Tx) error {
 		// Remove volume from cluster
 		cluster, err := NewClusterEntryFromId(tx, v.Info.Cluster)
@@ -343,7 +343,9 @@ func (v *BlockVolumeEntry) removeComponents(db wdb.DB) error {
 			logger.Err(err)
 			// Do not return here.. keep going
 		}
-		blockHostingVolume.ModifyFreeSize(v.Info.Size)
+		if !keepSize {
+			blockHostingVolume.ModifyFreeSize(v.Info.Size)
+		}
 		blockHostingVolume.Save(tx)
 
 		if err != nil {

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -273,7 +273,7 @@ func (v *BlockVolumeEntry) saveCreateBlockVolume(db wdb.DB) error {
 			return err
 		}
 
-		volume.Info.BlockInfo.FreeSize = volume.Info.BlockInfo.FreeSize - v.Info.Size
+		volume.ModifyFreeSize(-v.Info.Size)
 
 		volume.BlockVolumeAdd(v.Info.Id)
 		err = volume.Save(tx)
@@ -343,7 +343,7 @@ func (v *BlockVolumeEntry) removeComponents(db wdb.DB) error {
 			logger.Err(err)
 			// Do not return here.. keep going
 		}
-		blockHostingVolume.Info.BlockInfo.FreeSize = blockHostingVolume.Info.BlockInfo.FreeSize + v.Info.Size
+		blockHostingVolume.ModifyFreeSize(v.Info.Size)
 		blockHostingVolume.Save(tx)
 
 		if err != nil {

--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -959,7 +959,7 @@ func (vdel *BlockVolumeDeleteOperation) Rollback(executor executors.Executor) er
 func (vdel *BlockVolumeDeleteOperation) Finalize() error {
 	return vdel.db.Update(func(tx *bolt.Tx) error {
 		txdb := wdb.WrapTx(tx)
-		if e := vdel.bvol.removeComponents(txdb); e != nil {
+		if e := vdel.bvol.removeComponents(txdb, false); e != nil {
 			logger.LogError("Failed to remove block volume from db")
 			return e
 		}

--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -342,7 +342,7 @@ func (ve *VolumeExpandOperation) Finalize() error {
 		}
 		ve.vol.Info.Size += sizeDelta
 		if ve.vol.Info.Block == true {
-			ve.vol.Info.BlockInfo.FreeSize += sizeDelta
+			ve.vol.ModifyFreeSize(sizeDelta)
 		}
 		ve.op.FinalizeVolume(ve.vol)
 		if e := ve.vol.Save(tx); e != nil {

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -309,6 +309,15 @@ func (v *VolumeEntry) Create(db wdb.DB,
 		executor)
 }
 
+// ModifyFreeSize adjusts the free size of a block hosting volume.
+// When taking space from the volume the value must be negative (on
+// block volume add) and positive when the space is being "freed."
+func (v *VolumeEntry) ModifyFreeSize(delta int) {
+	v.Info.BlockInfo.FreeSize += delta
+	godbc.Check(v.Info.BlockInfo.FreeSize >= 0)
+	godbc.Check(v.Info.BlockInfo.FreeSize <= v.Info.Size)
+}
+
 func (v *VolumeEntry) tryAllocateBricks(
 	db wdb.DB,
 	possibleClusters []string) (brick_entries []*BrickEntry, err error) {


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

This series fixes problems with block hosting volume free size accounting when the block volume create operation fails and the rollback operation step is run.
The first patch creates a helper receiver function for modifying the free size and asserting that the resulting size is within bounds. This reveals an issue with rollback when running the unit tests. The second patch fixes the workflow in an attempt at a minimally invasive manner.

### Does this PR fix issues?

Fixes [RHBZ#1584123](https://bugzilla.redhat.com/show_bug.cgi?id=1584123)

### Notes for the reviewer

Are we ok with using the 'godbc' method of asserting the invariants or should we switch to returning an error and adding addtional error handling to these functions?

