### PR TITLE
executors: delete path needs to check raw errors from lvm commands

### DIFF
--- a/executors/cmdexec/brick.go
+++ b/executors/cmdexec/brick.go
@@ -151,9 +151,7 @@ func (s *CmdExecutor) countThinLVsInPool(host, tp string) (int, error) {
 	}
 	output, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 5)
 	if err != nil {
-		logger.Err(err)
-		return 0, fmt.Errorf("Unable to determine number of logical volumes in "+
-			"thin pool %v on host %v", tp, host)
+		return 0, err
 	}
 	thin_count, err := strconv.Atoi(strings.TrimSpace(output[0]))
 	if err != nil {
@@ -240,7 +238,10 @@ func (s *CmdExecutor) BrickDestroy(host string,
 			// if the thin pool is gone it can't host lvs
 			thin_count = 0
 		} else {
-			return spaceReclaimed, err
+			logger.Err(err)
+			return spaceReclaimed, fmt.Errorf(
+				"Unable to determine number of logical volumes in "+
+					"thin pool %v on host %v", tp, host)
 		}
 	}
 


### PR DESCRIPTION
When this function was refactored in preparation for robust delete
behavior the "friendly" error message was moved into the utility
function used for counting the number of lvs in a thin pool.
However, the errors from this function need to be checked to see
if lvm errors out because the thin pool is missing vs. another
reason. Changing the raw lvm error to a friendly error in this
case is wrong. Move the friendly error back to the upper function
call.

Fixes issue #1242
