### PR TITLE
device resync should update total, used and free

### DIFF
--- a/apps/glusterfs/app_device.go
+++ b/apps/glusterfs/app_device.go
@@ -98,7 +98,7 @@ func (a *App) DeviceAdd(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Create an entry for the device and set the size
-		device.StorageSet(info.Size)
+		device.StorageSet(info.TotalSize, info.FreeSize, info.UsedSize)
 		device.SetExtentSize(info.ExtentSize)
 
 		// Setup garbage collector on error

--- a/apps/glusterfs/app_device.go
+++ b/apps/glusterfs/app_device.go
@@ -346,8 +346,9 @@ func (a *App) DeviceResync(w http.ResponseWriter, r *http.Request) {
 	deviceId := vars["id"]
 
 	var (
-		device *DeviceEntry
-		node   *NodeEntry
+		device        *DeviceEntry
+		node          *NodeEntry
+		brickSizesSum uint64
 	)
 
 	// Get device info from DB
@@ -360,6 +361,13 @@ func (a *App) DeviceResync(w http.ResponseWriter, r *http.Request) {
 		node, err = NewNodeEntryFromId(tx, device.NodeId)
 		if err != nil {
 			return err
+		}
+		for _, brick := range device.Bricks {
+			brickEntry, err := NewBrickEntryFromId(tx, brick)
+			if err != nil {
+				return err
+			}
+			brickSizesSum += brickEntry.Info.Size
 		}
 		return nil
 	})
@@ -383,20 +391,6 @@ func (a *App) DeviceResync(w http.ResponseWriter, r *http.Request) {
 			return "", err
 		}
 
-		// Note that method GetDeviceInfo returns the free disk space available for allocation.
-		// The free disk space is equal to the total disk space only if we haven't already
-		// allocated space, because every allocation decreases the free disk space returned
-		// by method GetDeviceInfo. In order to calculate a new total space we need to sum
-		// the free disk space and the space used by heketi.
-		if device.Info.Storage.Total == info.Size+device.Info.Storage.Used {
-			logger.Info("Device %v is up to date", device.Info.Id)
-			return "", nil
-		}
-
-		logger.Debug("Free space of '%v' (%v) has changed %v -> %v", device.Info.Name, device.Info.Id,
-			device.Info.Storage.Free, info.Size)
-
-		// Update device
 		err = a.db.Update(func(tx *bolt.Tx) error {
 
 			// Reload device in current transaction
@@ -406,14 +400,15 @@ func (a *App) DeviceResync(w http.ResponseWriter, r *http.Request) {
 				return err
 			}
 
-			newFreeSize := info.Size
-			newTotalSize := newFreeSize + device.Info.Storage.Used
+			if brickSizesSum != info.UsedSize {
+				logger.Info("Sum of sizes of all bricks on the device:%v differs from used size from LVM:%v", brickSizesSum, info.UsedSize)
+				logger.Info("Database needs cleaning")
+			}
 
-			logger.Info("Updating device %v, total: %v -> %v, free: %v -> %v", device.Info.Name,
-				device.Info.Storage.Total, newTotalSize, device.Info.Storage.Free, newFreeSize)
+			logger.Info("Updating device %v, total: %v -> %v, free: %v -> %v, used: %v -> %v", device.Info.Name,
+				device.Info.Storage.Total, info.TotalSize, device.Info.Storage.Free, info.FreeSize, device.Info.Storage.Used, info.UsedSize)
 
-			device.Info.Storage.Total = newTotalSize
-			device.Info.Storage.Free = newFreeSize
+			device.StorageSet(info.TotalSize, info.FreeSize, info.UsedSize)
 
 			// Save updated device
 			err = device.Save(tx)

--- a/apps/glusterfs/app_device_test.go
+++ b/apps/glusterfs/app_device_test.go
@@ -789,13 +789,12 @@ func TestDeviceSync(t *testing.T) {
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 
-	var total, used, newFree uint64
-	total = 200 * 1024 * 1024
-	used = 100 * 1024 * 1024
-	newFree = 500 * 1024 * 1024 // see mockexec
-
 	nodeId := utils.GenUUID()
 	deviceId := utils.GenUUID()
+
+	var total uint64 = 600 * 1024 * 1024
+	var used uint64 = 250 * 1024 * 1024
+	var free uint64 = 350 * 1024 * 1024
 
 	// Init test database
 	err := app.db.Update(func(tx *bolt.Tx) error {
@@ -809,8 +808,8 @@ func TestDeviceSync(t *testing.T) {
 		device.Info.Id = deviceId
 		device.Info.Name = "/dev/abc"
 		device.NodeId = nodeId
-		device.StorageSet(total)
-		device.StorageAllocate(used)
+		device.StorageSet(total, total, 0)
+		device.StorageAllocate(100)
 
 		if err := device.Save(tx); err != nil {
 			return err
@@ -833,6 +832,14 @@ func TestDeviceSync(t *testing.T) {
 	})
 	tests.Assert(t, err == nil)
 
+	app.xo.MockGetDeviceInfo = func(host, device, vgid string) (*executors.DeviceInfo, error) {
+		d := &executors.DeviceInfo{}
+		d.TotalSize = total
+		d.FreeSize = free
+		d.UsedSize = used
+		d.ExtentSize = 4096
+		return d, nil
+	}
 	r, err := http.Get(ts.URL + "/devices/" + deviceId + "/resync")
 	tests.Assert(t, err == nil)
 	tests.Assert(t, r.StatusCode == http.StatusAccepted)
@@ -856,12 +863,13 @@ func TestDeviceSync(t *testing.T) {
 	err = app.db.View(func(tx *bolt.Tx) error {
 		device, err := NewDeviceEntryFromId(tx, deviceId)
 		tests.Assert(t, err == nil)
-		tests.Assert(t, device.Info.Storage.Total == newFree+used)
-		tests.Assert(t, device.Info.Storage.Free == newFree)
+		tests.Assert(t, device.Info.Storage.Total == total, "expected:", total, "got:", device.Info.Storage.Total)
+		tests.Assert(t, device.Info.Storage.Free == free)
 		tests.Assert(t, device.Info.Storage.Used == used)
 		return nil
 	})
 	tests.Assert(t, err == nil)
+
 }
 
 func TestDeviceSyncIdNotFound(t *testing.T) {

--- a/apps/glusterfs/app_device_test.go
+++ b/apps/glusterfs/app_device_test.go
@@ -540,7 +540,7 @@ func TestDeviceInfo(t *testing.T) {
 	device.Info.Id = "abc"
 	device.Info.Name = "/dev/fake1"
 	device.NodeId = "def"
-	device.StorageSet(10000)
+	device.StorageSet(10000, 10000, 0)
 	device.StorageAllocate(1000)
 
 	// Save device in the db
@@ -585,7 +585,7 @@ func TestDeviceDeleteErrors(t *testing.T) {
 	device.Info.Id = "abc"
 	device.Info.Name = "/dev/fake1"
 	device.NodeId = "def"
-	device.StorageSet(10000)
+	device.StorageSet(10000, 10000, 0)
 	device.StorageAllocate(1000)
 
 	// Save device in the db
@@ -906,7 +906,7 @@ func TestDeviceSetTags(t *testing.T) {
 	device.Info.Id = deviceId
 	device.Info.Name = "/dev/fake1"
 	device.NodeId = "def"
-	device.StorageSet(10000)
+	device.StorageSet(10000, 10000, 0)
 	device.StorageAllocate(1000)
 	err := app.db.Update(func(tx *bolt.Tx) error {
 		return device.Save(tx)

--- a/apps/glusterfs/dbexamples.go
+++ b/apps/glusterfs/dbexamples.go
@@ -51,7 +51,7 @@ func buildCluster(app *App) {
 				}
 				dev_req.Name = fmt.Sprintf("/dev/id%v", j)
 				d := NewDeviceEntryFromRequest(dev_req)
-				d.StorageSet(1 << 30)
+				d.StorageSet(1<<30, 1<<30, 0)
 				n.DeviceAdd(d.Id())
 				if err := d.Save(tx); err != nil {
 					return err

--- a/apps/glusterfs/device_entry.go
+++ b/apps/glusterfs/device_entry.go
@@ -329,9 +329,12 @@ func (d *DeviceEntry) BrickDelete(id string) {
 	d.Bricks = utils.SortedStringsDelete(d.Bricks, id)
 }
 
-func (d *DeviceEntry) StorageSet(amount uint64) {
-	d.Info.Storage.Free = amount
-	d.Info.Storage.Total = amount
+func (d *DeviceEntry) StorageSet(total uint64, free uint64, used uint64) {
+	godbc.Check(total == free+used)
+
+	d.Info.Storage.Total = total
+	d.Info.Storage.Free = free
+	d.Info.Storage.Used = used
 }
 
 func (d *DeviceEntry) StorageAllocate(amount uint64) {

--- a/apps/glusterfs/device_entry_test.go
+++ b/apps/glusterfs/device_entry_test.go
@@ -30,7 +30,7 @@ func createSampleDeviceEntry(nodeid string, disksize uint64) *DeviceEntry {
 	req.Name = "/dev/" + utils.GenUUID()[:8]
 
 	d := NewDeviceEntryFromRequest(req)
-	d.StorageSet(disksize)
+	d.StorageSet(disksize, disksize, 0)
 
 	return d
 }
@@ -589,12 +589,12 @@ func TestDeviceEntryStorage(t *testing.T) {
 	tests.Assert(t, d.Info.Storage.Total == 0)
 	tests.Assert(t, d.Info.Storage.Used == 0)
 
-	d.StorageSet(1000)
+	d.StorageSet(1000, 1000, 0)
 	tests.Assert(t, d.Info.Storage.Free == 1000)
 	tests.Assert(t, d.Info.Storage.Total == 1000)
 	tests.Assert(t, d.Info.Storage.Used == 0)
 
-	d.StorageSet(2000)
+	d.StorageSet(2000, 2000, 0)
 	tests.Assert(t, d.Info.Storage.Free == 2000)
 	tests.Assert(t, d.Info.Storage.Total == 2000)
 	tests.Assert(t, d.Info.Storage.Used == 0)

--- a/executors/cmdexec/device.go
+++ b/executors/cmdexec/device.go
@@ -142,8 +142,22 @@ func (s *CmdExecutor) getVgSizeFromNode(
 		return err
 	}
 
-	d.Size = free_extents * extent_size
+	allocated_extents, err :=
+		strconv.ParseUint(vginfo[VGDISPLAY_ALLOCATED_NUMBER_EXTENTS], 10, 64)
+	if err != nil {
+		return err
+	}
+
+	total_extents, err :=
+		strconv.ParseUint(vginfo[VGDISPLAY_TOTAL_NUMBER_EXTENTS], 10, 64)
+	if err != nil {
+		return err
+	}
+
+	d.TotalSize = total_extents * extent_size
+	d.FreeSize = free_extents * extent_size
+	d.UsedSize = allocated_extents * extent_size
 	d.ExtentSize = extent_size
-	logger.Debug("Size of %v in %v is %v", device, host, d.Size)
+	logger.Debug("%v in %v has TotalSize:%v, FreeSize:%v, UsedSize:%v", device, host, d.TotalSize, d.FreeSize, d.UsedSize)
 	return nil
 }

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -49,7 +49,9 @@ const (
 // Returns the size of the device
 type DeviceInfo struct {
 	// Size in KB
-	Size       uint64
+	TotalSize  uint64
+	FreeSize   uint64
+	UsedSize   uint64
 	ExtentSize uint64
 }
 

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -20,6 +20,7 @@ type MockExecutor struct {
 	MockPeerDetach               func(exec_host, newnode string) error
 	MockDeviceSetup              func(host, device, vgid string, destroy bool) (*executors.DeviceInfo, error)
 	MockDeviceTeardown           func(host, device, vgid string) error
+	MockGetDeviceInfo            func(host, device, vgid string) (*executors.DeviceInfo, error)
 	MockBrickCreate              func(host string, brick *executors.BrickRequest) (*executors.BrickInfo, error)
 	MockBrickDestroy             func(host string, brick *executors.BrickRequest) (bool, error)
 	MockVolumeCreate             func(host string, volume *executors.VolumeRequest) (*executors.Volume, error)
@@ -64,6 +65,15 @@ func NewMockExecutor() (*MockExecutor, error) {
 
 	m.MockDeviceTeardown = func(host, device, vgid string) error {
 		return nil
+	}
+
+	m.MockGetDeviceInfo = func(host, device, vgid string) (*executors.DeviceInfo, error) {
+		d := &executors.DeviceInfo{}
+		d.TotalSize = 500 * 1024 * 1024
+		d.FreeSize = 500 * 1024 * 1024
+		d.UsedSize = 0
+		d.ExtentSize = 4096
+		return d, nil
 	}
 
 	m.MockBrickCreate = func(host string, brick *executors.BrickRequest) (*executors.BrickInfo, error) {
@@ -204,7 +214,7 @@ func (m *MockExecutor) DeviceSetup(host, device, vgid string, destroy bool) (*ex
 }
 
 func (m *MockExecutor) GetDeviceInfo(host, device, vgid string) (*executors.DeviceInfo, error) {
-	return m.MockDeviceSetup(host, device, vgid, false)
+	return m.MockGetDeviceInfo(host, device, vgid)
 }
 
 func (m *MockExecutor) DeviceTeardown(host, device, vgid string) error {

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -55,7 +55,9 @@ func NewMockExecutor() (*MockExecutor, error) {
 
 	m.MockDeviceSetup = func(host, device, vgid string, destroy bool) (*executors.DeviceInfo, error) {
 		d := &executors.DeviceInfo{}
-		d.Size = 500 * 1024 * 1024 // Size in KB
+		d.TotalSize = 500 * 1024 * 1024 // Size in KB
+		d.FreeSize = 500 * 1024 * 1024  // Size in KB
+		d.UsedSize = 0                  // Size in KB
 		d.ExtentSize = 4096
 		return d, nil
 	}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
Device resync feature currently only fetches the free space and calculates the total and used based on that and data in heketi db. If the device has been resized or if heketi has gone out of sync from back end it is better to update all three attributes.


