### PR TITLE
executors: prevent (vg|pv)remove commands from prompting

### DIFF
--- a/executors/cmdexec/device.go
+++ b/executors/cmdexec/device.go
@@ -73,8 +73,8 @@ func (s *CmdExecutor) DeviceTeardown(host, device, vgid string) error {
 
 	// Setup commands
 	commands := []string{
-		fmt.Sprintf("vgremove %v", utils.VgIdToName(vgid)),
-		fmt.Sprintf("pvremove '%v'", device),
+		fmt.Sprintf("vgremove -qq %v", utils.VgIdToName(vgid)),
+		fmt.Sprintf("pvremove -qq '%v'", device),
 	}
 
 	// Execute command


### PR DESCRIPTION
If there is an unexpected condition on the vg or pv when
removing a device it is preferable to fail than to allow
the command to prompt for input which will block heketi
"forever" and possibly (due to lvm-level) locking other
commands as well.

Fixes #1244

Signed-off-by: John Mulligan <jmulligan@redhat.com>


### Notes for the reviewer

This ought to have a functional test but due to time limits and the fiddly nature (having to do lvm stuff directly via the test code) I skipped this for now. It may be worthwhile to do a general technical debt issue for adding tests in this general area.

