### PR TITLE
glusterfs: improve the logging in error path of DeleteBricksWithEmptyPath

### DIFF
--- a/apps/glusterfs/cluster_entry.go
+++ b/apps/glusterfs/cluster_entry.go
@@ -216,6 +216,9 @@ func addBlockFileFlagsInClusterEntry(tx *bolt.Tx) error {
 
 func (c *ClusterEntry) DeleteBricksWithEmptyPath(tx *bolt.Tx) error {
 
+	logger.Debug("Deleting bricks with empty path in cluster [%v].",
+		c.Info.Id)
+
 	for _, nodeid := range c.Info.Nodes {
 		node, err := NewNodeEntryFromId(tx, nodeid)
 		if err == ErrNotFound {

--- a/apps/glusterfs/db_operations.go
+++ b/apps/glusterfs/db_operations.go
@@ -405,7 +405,6 @@ func DeleteBricksWithEmptyPath(db *bolt.DB, all bool, clusterIDs []string, nodeI
 				if err != nil {
 					return err
 				}
-				logger.Debug("deleting bricks with empty path in cluster %v", clusterEntry.Info.Id)
 				err = clusterEntry.DeleteBricksWithEmptyPath(tx)
 				if err != nil {
 					return err

--- a/apps/glusterfs/device_entry.go
+++ b/apps/glusterfs/device_entry.go
@@ -574,6 +574,9 @@ func (d *DeviceEntry) DeleteBricksWithEmptyPath(tx *bolt.Tx) error {
 	godbc.Require(tx != nil)
 	var bricksToDelete []*BrickEntry
 
+	logger.Debug("Deleting bricks with empty path on device [%v].",
+		d.Info.Id)
+
 	for _, id := range d.Bricks {
 		brick, err := NewBrickEntryFromId(tx, id)
 		if err == ErrNotFound {
@@ -582,6 +585,8 @@ func (d *DeviceEntry) DeleteBricksWithEmptyPath(tx *bolt.Tx) error {
 			continue
 		}
 		if err != nil {
+			logger.LogError("Unable to fetch brick [%v] from db: %v",
+				id, err)
 			return err
 		}
 		if brick.Info.Path == "" {
@@ -589,6 +594,8 @@ func (d *DeviceEntry) DeleteBricksWithEmptyPath(tx *bolt.Tx) error {
 		}
 	}
 	for _, brick := range bricksToDelete {
+		logger.Debug("Deleting brick [%v] which has empty path.",
+			brick.Info.Id)
 		err := brick.Delete(tx)
 		if err != nil {
 			return logger.LogError("Unable to remove brick %v: %v", brick.Info.Id, err)

--- a/apps/glusterfs/node_entry.go
+++ b/apps/glusterfs/node_entry.go
@@ -460,6 +460,9 @@ func NodeList(tx *bolt.Tx) ([]string, error) {
 
 func (n *NodeEntry) DeleteBricksWithEmptyPath(tx *bolt.Tx) error {
 
+	logger.Debug("Deleting bricks with empty path on node [%v].",
+		n.Info.Id)
+
 	for _, deviceid := range n.Devices {
 		device, err := NewDeviceEntryFromId(tx, deviceid)
 		if err == ErrNotFound {


### PR DESCRIPTION
This makes it easier to understand from the logs what's going on, in case of troubleshooting.


