### PR TITLE
glusterfs: add an empty line between functions in db_operations.go

### DIFF
--- a/apps/glusterfs/db_operations.go
+++ b/apps/glusterfs/db_operations.go
@@ -375,6 +375,7 @@ func DbCreate(jsonfile string, dbfile string) error {
 
 	return nil
 }
+
 func DeleteBricksWithEmptyPath(db *bolt.DB, all bool, clusterIDs []string, nodeIDs []string, deviceIDs []string) error {
 
 	for _, id := range clusterIDs {


### PR DESCRIPTION
Just a cosmetic patch