### PR TITLE
Provide config to control options applied to Block Hosting Volume

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -274,6 +274,11 @@ func (a *App) setFromEnvironmentalVariable() {
 		}
 	}
 
+	env = os.Getenv("HEKETI_BLOCK_HOSTING_VOLUME_OPTIONS")
+	if "" != env {
+		a.conf.BlockHostingVolumeOptions = env
+	}
+
 	env = os.Getenv("HEKETI_GLUSTERAPP_REBALANCE_ON_EXPANSION")
 	if env != "" {
 		value, err := strconv.ParseBool(env)
@@ -326,6 +331,11 @@ func (a *App) setBlockSettings() {
 		// Should be in GB as this is input for block hosting volume create
 		BlockHostingVolumeSize = a.conf.BlockHostingVolumeSize
 	}
+	if a.conf.BlockHostingVolumeOptions != "" {
+		logger.Info("Block: New Block Hosting Volume Options: %v", a.conf.BlockHostingVolumeOptions)
+		BlockHostingVolumeOptions = a.conf.BlockHostingVolumeOptions
+	}
+
 }
 
 // Register Routes

--- a/apps/glusterfs/app_config.go
+++ b/apps/glusterfs/app_config.go
@@ -33,8 +33,9 @@ type GlusterFSConfig struct {
 	AverageFileSize uint64 `json:"average_file_size_kb"`
 
 	//block settings
-	CreateBlockHostingVolumes bool `json:"auto_create_block_hosting_volume"`
-	BlockHostingVolumeSize    int  `json:"block_hosting_volume_size"`
+	CreateBlockHostingVolumes bool   `json:"auto_create_block_hosting_volume"`
+	BlockHostingVolumeSize    int    `json:"block_hosting_volume_size"`
+	BlockHostingVolumeOptions string `json:"block_hosting_volume_options"`
 
 	// server behaviors
 	IgnoreStaleOperations          bool   `json:"ignore_stale_operations"`

--- a/apps/glusterfs/block_settings.go
+++ b/apps/glusterfs/block_settings.go
@@ -13,5 +13,6 @@ var (
 	// Default block settings
 	CreateBlockHostingVolumes = false
 	// Default 1 TB
-	BlockHostingVolumeSize = 1024
+	BlockHostingVolumeSize    = 1024
+	BlockHostingVolumeOptions = "group gluster-block"
 )

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -42,7 +42,6 @@ func NewVolumeEntryForBlockHosting(clusters []string) (*VolumeEntry, error) {
 	msg.Size = BlockHostingVolumeSize
 	msg.Durability.Replicate.Replica = 3
 	msg.Block = true
-	msg.GlusterVolumeOptions = []string{"group gluster-block"}
 
 	vol := NewVolumeEntryFromRequest(&msg)
 

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -142,8 +142,9 @@ func NewVolumeEntryFromRequest(req *api.VolumeCreateRequest) *VolumeEntry {
 		vol.Info.BlockInfo.FreeSize = req.Size
 		// prepend the gluster-block group option,
 		// so that the user-specified options can take precedence
+		blockoptions := strings.Split(BlockHostingVolumeOptions, ",")
 		vol.GlusterVolumeOptions = append(
-			[]string{"group gluster-block"},
+			blockoptions,
 			vol.GlusterVolumeOptions...)
 	}
 

--- a/etc/heketi.json
+++ b/etc/heketi.json
@@ -84,6 +84,9 @@
     "auto_create_block_hosting_volume": true,
 
     "_block_hosting_volume_size": "New block hosting volume will be created in size mentioned, This is considered only if auto-create is enabled.",
-    "block_hosting_volume_size": 500
+    "block_hosting_volume_size": 500,
+
+    "_block_hosting_volume_options": "New block hosting volume will be created with the following set of options. Removing the group gluster-block option is NOT recommended. Additional options can be added next to it separated by a comma.",
+    "block_hosting_volume_options": "group gluster-block"
   }
 }


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Earlier, block hosting volume created in heketi had only "group gluster-block" option set. This PR provides option to edit the set of options that are applied on block hosting volumes. Also, a flag is provided to disable setting of such an option for volumes if required.

As an use-case, one can edit   
block_hosting_volume_options in heketi.json  
or  
HEKETI_BLOCK_HOSTING_VOLUME_OPTIONS env var  
to have "group gluster-block,user.heketi.arbiter true" to have arbiter volumes as block hosting volumes.


### Does this PR fix issues?

Fixes #1224 


### Notes for the reviewer


