### PR TITLE
Number of hosts should be equal to ha count 

### DIFF
--- a/apps/glusterfs/app_block_volume_test.go
+++ b/apps/glusterfs/app_block_volume_test.go
@@ -277,6 +277,72 @@ func TestBlockVolumeCreate(t *testing.T) {
 	tests.Assert(t, info.Auth == false)
 }
 
+func TestBlockVolumeCreateHACount(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+	router := mux.NewRouter()
+	app.SetRoutes(router)
+
+	// Setup the server
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	// Setup database
+	err := setupSampleDbWithTopology(app,
+		1,    // clusters
+		10,   // nodes_per_cluster
+		10,   // devices_per_node,
+		5*TB, // disksize)
+	)
+	tests.Assert(t, err == nil)
+
+	// BlockVolumeCreate
+	request := []byte(`{
+	"size" : 100,
+	"hacount" : 3
+    }`)
+
+	// Send request
+	r, err := http.Post(ts.URL+"/blockvolumes", "application/json", bytes.NewBuffer(request))
+	tests.Assert(t, err == nil)
+	tests.Assert(t, r.StatusCode == http.StatusAccepted)
+	location, err := r.Location()
+	tests.Assert(t, err == nil)
+
+	// Query queue until finished
+	var info api.BlockVolumeInfoResponse
+	for {
+		r, err = http.Get(location.String())
+		tests.Assert(t, err == nil)
+		tests.Assert(t, r.StatusCode == http.StatusOK)
+		if r.ContentLength <= 0 {
+			time.Sleep(time.Millisecond * 10)
+			continue
+		} else {
+			// Should have node information here
+			tests.Assert(t, r.Header.Get("Content-Type") == "application/json; charset=UTF-8")
+			err = utils.GetJsonFromResponse(r, &info)
+			tests.Assert(t, err == nil)
+			break
+		}
+	}
+	tests.Assert(t, info.Id != "")
+	tests.Assert(t, info.Cluster != "")
+	tests.Assert(t, info.BlockHostingVolume != "")
+	tests.Assert(t, len(info.BlockVolume.Hosts) == 3)
+	tests.Assert(t, info.BlockVolume.Iqn != "")
+	tests.Assert(t, info.BlockVolume.Password == "")
+	tests.Assert(t, info.BlockVolume.Username == "")
+	tests.Assert(t, info.Size == 100)
+	tests.Assert(t, info.Name == "blockvol_"+info.Id)
+	tests.Assert(t, info.Auth == false)
+	tests.Assert(t, info.Hacount == 3)
+}
+
 func TestBlockVolumeInfoIdNotFound(t *testing.T) {
 	tmpfile := tests.Tempfile()
 	defer os.Remove(tmpfile)

--- a/apps/glusterfs/block_volume_entry_create.go
+++ b/apps/glusterfs/block_volume_entry_create.go
@@ -63,7 +63,7 @@ func (v *BlockVolumeEntry) createBlockVolumeRequest(db wdb.RODB,
 		}
 
 		if v.Info.Hacount > 0 && v.Info.Hacount <= len(bhvol.Info.Mount.GlusterFS.Hosts) {
-			for i := 0; i <= v.Info.Hacount && i < len(bhvol.Info.Mount.GlusterFS.Hosts); i++ {
+			for i := 0; i < v.Info.Hacount && i < len(bhvol.Info.Mount.GlusterFS.Hosts); i++ {
 				managehostname, e := GetManageHostnameFromStorageHostname(tx, bhvol.Info.Mount.GlusterFS.Hosts[i])
 				if e != nil {
 					return fmt.Errorf("Could not find managehostname for %v", bhvol.Info.Mount.GlusterFS.Hosts[i])


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
Earlier, due to off by one error, we added one host more than ha count in list of hosts provided to gluster-block cli during blockvolume create.

This PR matches number of hosts to ha count parameter.


