### PR TITLE
 api: support colon chars in device paths

### DIFF
--- a/client/api/go-client/client_test.go
+++ b/client/api/go-client/client_test.go
@@ -608,7 +608,7 @@ func TestClientVolume(t *testing.T) {
 				defer sg.Done()
 
 				deviceReq := &api.DeviceAddRequest{}
-				deviceReq.Name = "/sd" + utils.GenUUID()
+				deviceReq.Name = "/dev/by-magic/id:" + utils.GenUUID()
 				deviceReq.NodeId = node.Id
 
 				// Create device

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -28,7 +28,7 @@ import (
 var (
 	// Restricting the deviceName to much smaller subset of Unix Path
 	// as unix path takes almost everything except NULL
-	deviceNameRe = regexp.MustCompile("^/[a-zA-Z0-9_./-]+$")
+	deviceNameRe = regexp.MustCompile("^/[a-zA-Z0-9_.:/-]+$")
 
 	// Volume name constraints decided by looking at
 	// "cli_validate_volname" function in cli-cmd-parser.c of gluster code


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Adjust regex to allow device paths with colons. Colons may appear
in paths such as "/dev/disk/by-path/pci-0000:00:10.0-scsi-0:0:1:0"
and thus are valid use cases.

### Does this PR fix issues?

Fixes #1246
