### PR TITLE
go client api: support retries when throttled by server

### DIFF
--- a/client/api/go-client/client.go
+++ b/client/api/go-client/client.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	MAX_CONCURRENT_REQUESTS = 32
-	RETRY_COUNT             = 1000
+	RETRY_COUNT             = 6
 
 	// default delay values
 	MIN_DELAY = 10

--- a/client/api/go-client/client.go
+++ b/client/api/go-client/client.go
@@ -18,8 +18,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
-	"fmt"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -248,10 +248,21 @@ func (c *Client) setToken(r *http.Request) error {
 }
 
 //retryOperationDo for retry operation
-func (c *Client) retryOperationDo(req *http.Request, requestBody []byte) (*http.Response, error) {
+func (c *Client) retryOperationDo(req *http.Request) (*http.Response, error) {
+	var (
+		requestBody []byte
+		err         error
+	)
+	if req.Body != nil {
+		requestBody, err = ioutil.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// Send request
 	for i := 0; i <= c.retryCount; i++ {
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(requestBody))
+		req.Body = ioutil.NopCloser(bytes.NewReader(requestBody))
 		r, err := c.do(req)
 		if err != nil {
 			return nil, err

--- a/client/api/go-client/client.go
+++ b/client/api/go-client/client.go
@@ -56,12 +56,13 @@ type Client struct {
 	do func(*http.Request) (*http.Response, error)
 }
 
-//NewClient Creates a new client to access a Heketi server
+// NewClient creates a new client to access a Heketi server
 func NewClient(host, user, key string) *Client {
 	return NewClientWithRetry(host, user, key, RETRY_COUNT)
 }
 
-//NewClientWithRetry Creates a new client to access a Heketi server with retryCount
+// NewClientWithRetry creates a new client to access a Heketi server
+// with a user specified retry count.
 func NewClientWithRetry(host, user, key string, retryCount int) *Client {
 	c := &Client{}
 
@@ -252,7 +253,9 @@ func (c *Client) setToken(r *http.Request) error {
 	return nil
 }
 
-//retryOperationDo for retry operation
+// retryOperationDo performs the http request and internally
+// handles http 429 codes up to the number of retries specified
+// by the Client.
 func (c *Client) retryOperationDo(req *http.Request) (*http.Response, error) {
 	var (
 		requestBody []byte


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

We are working towards adding throttling to the heketi server. However, to better support cli (and api) users in a throttled world we add the ability for the heketi go api client for retry when throttled.

This series takes a patch from pr #1131 and adapts it so that callers of the api, and internal api functions can use the same calls. It adds the abilty to turn off the retries if desired and to control the various retry related values.

### Notes for the reviewer

After having tested some of my hacked up server changes against a k8s cluster that does not have client patches applied I feel that having the client wait too long will give a bad behavior esp. since k8s retries again at a higher level. Instead, the retries are more beneficial to the command line client users who might reasonably want to wait a few minutes for the cli to run but if the server's really overloaded it will eventually give up and report that fact.
So, I've greatly lowered the number of retries the client will perform by default as well as preserved the original http response error state. These patches are currently standalone to point out these changes, let me know if you'd prefer them squashed.

