### PR TITLE
update test binaries on make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,10 @@ client: vendor glide.lock
 run: server
 	./$(APP_NAME)
 
-test: vendor glide.lock
+test: server client vendor glide.lock
+	cp heketi tests/functional/TestDbExportImport/heketi-server
+	cp heketi client/api/python/heketi-server
+	cp client/cli/go/heketi-cli tests/functional/TestDbExportImport/heketi-cli
 	$(TESTBIN) $(TESTOPTIONS)
 
 test-functional: vendor glide.lock
@@ -105,6 +108,9 @@ test-functional: vendor glide.lock
 clean:
 	@echo Cleaning Workspace...
 	rm -rf $(APP_NAME)
+	rm -rf tests/functional/TestDbExportImport/heketi-server
+	rm -rf client/api/python/heketi-server
+	rm -rf tests/functional/TestDbExportImport/heketi-cli
 	rm -rf dist coverage packagecover.out
 	@$(MAKE) -C client/cli/go clean
 


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
When heketi and heketi-cli binaries are built they are not copied to locations where test scripts start them. The test scripts have a check with bash "-x" to see if the binary exists and if it does they don't update from the build location.

Considering that the developers might want to have control on what version of binary to use while testing, we don't want to always copy over the binary in the bootstrapping part of the test.

Rather, we overwrite the binary when make is run.

