### PR TITLE
apps: avoid throttling test code much

### DIFF
--- a/apps/glusterfs/testapp_mock.go
+++ b/apps/glusterfs/testapp_mock.go
@@ -20,6 +20,7 @@ func NewTestApp(dbfile string) *App {
 		DBfile:                    dbfile,
 		Executor:                  "mock",
 		CreateBlockHostingVolumes: true,
+		MaxInflightOperations:     64, // avoid throttling test code
 	}
 	app := NewApp(appConfig)
 	godbc.Check(app != nil)


### PR DESCRIPTION
Some of the tests make a lot of requests at once and throttling has
a huge impact on it (1min vs 4min). So we avoid doing much
throttling at all in the test code.
