### PR TITLE
apps: shuffle block-volume ha nodes to avoid relying on same nodes 

### DIFF
--- a/pkg/utils/shuffle.go
+++ b/pkg/utils/shuffle.go
@@ -1,0 +1,44 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package utils
+
+import (
+	"math/rand"
+	"time"
+)
+
+// Shuffle pseudo-randomizes the order of elements.
+// This shuffle is based on that from Go 1.10. As heketi currently
+// supports older versions of Go we need our own shuffle. Once,
+// only Go 1.10 or higher is supported this can be dropped.
+func Shuffle(r *rand.Rand, n int, swap func(i, j int)) {
+	if n < 0 {
+		panic("invalid argument to Shuffle")
+	}
+
+	// Fisher-Yates shuffle. Shamelessly stolen from Golang 1.10
+	// math/rand package. See go docs for details.
+	i := n - 1
+	for ; i > 1<<31-1-1; i-- {
+		j := int(r.Int63n(int64(i + 1)))
+		swap(i, j)
+	}
+	for ; i > 0; i-- {
+		j := int(r.Int31n(int32(i + 1)))
+		swap(i, j)
+	}
+}
+
+// SeededShuffle pseudo-randomizes the order of elements
+// using a private PRNG instance seeded from the clock.
+func SeededShuffle(n int, swap func(i, j int)) {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	Shuffle(r, n, swap)
+}

--- a/pkg/utils/shuffle_test.go
+++ b/pkg/utils/shuffle_test.go
@@ -1,0 +1,63 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package utils
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/heketi/tests"
+)
+
+func TestShuffle(t *testing.T) {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	a := []string{
+		"bobcat",
+		"lion",
+		"puma",
+		"cheetah",
+		"lynx",
+	}
+	a2 := make([]string, len(a))
+	copy(a2, a)
+	Shuffle(r, len(a2), func(i, j int) {
+		a2[i], a2[j] = a2[j], a2[i]
+	})
+	same := true
+	for i := 0; i < len(a); i++ {
+		same = same && (a[i] == a2[i])
+	}
+	tests.Assert(t, !same, a, a2)
+}
+
+func TestSeededShuffle(t *testing.T) {
+	a := []string{
+		"bobcat",
+		"lion",
+		"puma",
+		"cheetah",
+		"lynx",
+	}
+	a2 := make([]string, len(a))
+	dedup := map[string]int{}
+	copy(a2, a)
+	SeededShuffle(len(a2), func(i, j int) {
+		a2[i], a2[j] = a2[j], a2[i]
+	})
+	same := true
+	for i := 0; i < len(a); i++ {
+		dedup[a2[i]] += 1
+		same = same && (a[i] == a2[i])
+	}
+	tests.Assert(t, !same, a, a2)
+	tests.Assert(t, len(dedup) == len(a),
+		"expected len(dedup) == len(a), got:", dedup, a)
+}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

When the number of nodes available is greater than the HA count
we want to select a subset of these nodes for use with gluster
block ha support. Previous changes to the code try to select
the ha-count number of healthy nodes from this set but if the
healthy node set was unchanging it would always pick the exact
same nodes.

This change add utility code for shuffling (based on Go 1.10), shuffles the list of nodes that is tested for
liveness so different block volumes are distributed across
different nodes, and adds a test for this behavior.


### Does this PR fix issues?

Fixes (latter half of) rhbz#1595531


### Notes for the reviewer

This change depends on PR #1280 and should not be merged before it.

