### PR TITLE
functional tests: discover and fix another level of timeout in test

### DIFF
--- a/tests/functional/run.sh
+++ b/tests/functional/run.sh
@@ -142,9 +142,12 @@ for testDir in "${TESTS[@]}" ; do
 
 		# Run the command with a large timeout.
 		# Just large enough so that it doesn't run forever.
-		timeout 1h run.sh
+		timeout 3h run.sh
 		result=$?
 
+		if [ $result -eq 124 ] ; then
+			println "Test timed out: $testDir"
+		fi
 		if [ $result -ne 0 ] ; then
 			println "FAILED $testDir"
 			println "TEARDOWN $testDir"


### PR DESCRIPTION
Turns out there's more than one level of time out that needs to
be adjusted. Fix it here and print out a specific message if
the test script is timed out.
