### PR TITLE
Update volume hosts info during node removal

### DIFF
--- a/apps/glusterfs/volume_entry_create.go
+++ b/apps/glusterfs/volume_entry_create.go
@@ -55,7 +55,10 @@ func (v *VolumeEntry) updateMountInfo(db wdb.RODB) error {
 			if err != nil {
 				return err
 			}
-			hosts = append(hosts, node.StorageHostName())
+			if node.isOnline() {
+				hosts = append(hosts, node.StorageHostName())
+			}
+
 		}
 		return err
 	}); err != nil {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?

during the node removal in heketi, we replace the brick from removal node to another node, during this process we need to update the volume info such as Hosts (which may contain the removal node hostname). and we need to update the backup-volfile-servers and volume mountpoint  (this also may contain the removal hostname)

if it's a block hosting volume, we need to fetch all the block volumes belongs to it, and update the hosts in those volumes, so that next block volume creation fetches the new hosts.

consider only online nodes for a volume mountpoint update 
if the node statue is online, then consider this node for updating the mount point and backup-volfile-servers of a volume.


### Does this PR fix issues?


<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #1274
Fixes #1273 


### Notes for the reviewer


