### PR TITLE
typo: Administration instead of Adminstration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ volumes.
 ## Topics
 
 * [Heketi API](./api/api.md)
-* [Adminstration](./admin/readme.md)
+* [Administration](./admin/readme.md)
 * [Troubleshooting Guide](./troubleshooting.md)
 * [Contributing to Heketi](./contributing.md)
 


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Typo on documentation.
"Administration" instead of "Adminstration" on topics menu points


