### PR TITLE
apps: shuffle block-volume ha nodes to avoid relying on same nodes

### DIFF
--- a/apps/glusterfs/app_block_volume_test.go
+++ b/apps/glusterfs/app_block_volume_test.go
@@ -14,9 +14,11 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -278,6 +280,31 @@ func TestBlockVolumeCreate(t *testing.T) {
 	tests.Assert(t, info.Auth == false)
 }
 
+func blockVolumeTestResult(t *testing.T, r *http.Response) api.BlockVolumeInfoResponse {
+	var info api.BlockVolumeInfoResponse
+	tests.Assert(t, r.StatusCode == http.StatusAccepted)
+	location, err := r.Location()
+	tests.Assert(t, err == nil)
+
+	// Query queue until finished
+	for {
+		r, err = http.Get(location.String())
+		tests.Assert(t, err == nil)
+		tests.Assert(t, r.StatusCode == http.StatusOK)
+		if r.ContentLength <= 0 {
+			time.Sleep(time.Millisecond * 10)
+			continue
+		} else {
+			// Should have node information here
+			tests.Assert(t, r.Header.Get("Content-Type") == "application/json; charset=UTF-8")
+			err = utils.GetJsonFromResponse(r, &info)
+			tests.Assert(t, err == nil)
+			break
+		}
+	}
+	return info
+}
+
 func TestBlockVolumeCreateHACount(t *testing.T) {
 	tmpfile := tests.Tempfile()
 	defer os.Remove(tmpfile)
@@ -310,27 +337,8 @@ func TestBlockVolumeCreateHACount(t *testing.T) {
 	// Send request
 	r, err := http.Post(ts.URL+"/blockvolumes", "application/json", bytes.NewBuffer(request))
 	tests.Assert(t, err == nil)
-	tests.Assert(t, r.StatusCode == http.StatusAccepted)
-	location, err := r.Location()
-	tests.Assert(t, err == nil)
+	info := blockVolumeTestResult(t, r)
 
-	// Query queue until finished
-	var info api.BlockVolumeInfoResponse
-	for {
-		r, err = http.Get(location.String())
-		tests.Assert(t, err == nil)
-		tests.Assert(t, r.StatusCode == http.StatusOK)
-		if r.ContentLength <= 0 {
-			time.Sleep(time.Millisecond * 10)
-			continue
-		} else {
-			// Should have node information here
-			tests.Assert(t, r.Header.Get("Content-Type") == "application/json; charset=UTF-8")
-			err = utils.GetJsonFromResponse(r, &info)
-			tests.Assert(t, err == nil)
-			break
-		}
-	}
 	tests.Assert(t, info.Id != "")
 	tests.Assert(t, info.Cluster != "")
 	tests.Assert(t, info.BlockHostingVolume != "")
@@ -402,27 +410,8 @@ func TestBlockVolumeCreateHACountHostUnavailableSuccess(t *testing.T) {
 	// Send request
 	r, err := http.Post(ts.URL+"/blockvolumes", "application/json", bytes.NewBuffer(request))
 	tests.Assert(t, err == nil)
-	tests.Assert(t, r.StatusCode == http.StatusAccepted)
-	location, err := r.Location()
-	tests.Assert(t, err == nil)
 
-	// Query queue until finished
-	var info api.BlockVolumeInfoResponse
-	for {
-		r, err = http.Get(location.String())
-		tests.Assert(t, err == nil)
-		tests.Assert(t, r.StatusCode == http.StatusOK)
-		if r.ContentLength <= 0 {
-			time.Sleep(time.Millisecond * 10)
-			continue
-		} else {
-			// Should have node information here
-			tests.Assert(t, r.Header.Get("Content-Type") == "application/json; charset=UTF-8")
-			err = utils.GetJsonFromResponse(r, &info)
-			tests.Assert(t, err == nil)
-			break
-		}
-	}
+	info := blockVolumeTestResult(t, r)
 	tests.Assert(t, info.Id != "")
 	tests.Assert(t, info.Cluster != "")
 	tests.Assert(t, info.BlockHostingVolume != "")
@@ -490,6 +479,55 @@ func TestBlockVolumeCreateHACountHostUnavailableFail(t *testing.T) {
 	}
 	tests.Assert(t, len(hostAvailable) == 4)
 	tests.Assert(t, countTrue(hostAvailable) == 2)
+}
+
+func TestBlockVolumeCreateHAShuffled(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+	router := mux.NewRouter()
+	app.SetRoutes(router)
+
+	// Setup the server
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	// Setup database
+	err := setupSampleDbWithTopology(app,
+		1,    // clusters
+		10,   // nodes_per_cluster
+		10,   // devices_per_node,
+		5*TB, // disksize)
+	)
+	tests.Assert(t, err == nil)
+
+	// BlockVolumeCreate
+	request := []byte(`{"size": 100, "hacount": 3}`)
+
+	// reset a static seed to make test deterministic
+	rand.Seed(42)
+	var prevHosts []string
+	changed := false
+	for i := 0; i < 5; i++ {
+		r, err := http.Post(ts.URL+"/blockvolumes", "application/json", bytes.NewBuffer(request))
+		tests.Assert(t, err == nil)
+		info := blockVolumeTestResult(t, r)
+
+		// check that the hosts counts are as expected and match the ha counts
+		// verify that we do not get the same hosts every time this function is
+		// called.
+		tests.Assert(t, len(info.BlockVolume.Hosts) == 3)
+		tests.Assert(t, info.Hacount == 3)
+		if prevHosts != nil && !reflect.DeepEqual(prevHosts, info.BlockVolume.Hosts) {
+			changed = true
+			break
+		}
+		prevHosts = info.BlockVolume.Hosts
+	}
+	tests.Assert(t, changed)
 }
 
 func TestBlockVolumeInfoIdNotFound(t *testing.T) {

--- a/apps/glusterfs/block_volume_entry_create.go
+++ b/apps/glusterfs/block_volume_entry_create.go
@@ -11,6 +11,7 @@ package glusterfs
 
 import (
 	"fmt"
+	"math/rand"
 
 	"github.com/boltdb/bolt"
 	"github.com/heketi/heketi/executors"
@@ -64,7 +65,7 @@ func (v *BlockVolumeEntry) createBlockVolumeRequest(db wdb.RODB,
 
 		if v.Info.Hacount > 0 && v.Info.Hacount <= len(bhvol.Info.Mount.GlusterFS.Hosts) {
 			v.Info.BlockVolume.Hosts = nil
-			for i := 0; i < len(bhvol.Info.Mount.GlusterFS.Hosts); i++ {
+			for _, i := range rand.Perm(len(bhvol.Info.Mount.GlusterFS.Hosts)) {
 				managehostname, e := GetManageHostnameFromStorageHostname(tx, bhvol.Info.Mount.GlusterFS.Hosts[i])
 				if e != nil {
 					return fmt.Errorf("Could not find managehostname for %v", bhvol.Info.Mount.GlusterFS.Hosts[i])

--- a/main.go
+++ b/main.go
@@ -10,11 +10,16 @@
 package main
 
 import (
+	crand "crypto/rand"
 	"fmt"
+	"math"
+	"math/big"
+	"math/rand"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
@@ -281,6 +286,17 @@ func setupApp(config *config.Config) (a *glusterfs.App) {
 	return glusterfs.NewApp(config.GlusterFS)
 }
 
+func randSeed() {
+	var max big.Int
+	max.Add(big.NewInt(math.MaxInt64), big.NewInt(1))
+	n, err := crand.Int(crand.Reader, &max)
+	if err != nil {
+		rand.Seed(time.Now().UTC().UnixNano())
+	} else {
+		rand.Seed(n.Int64())
+	}
+}
+
 func main() {
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
@@ -291,6 +307,9 @@ func main() {
 	if configfile == "" {
 		return
 	}
+
+	// Seed PRNG
+	randSeed()
 
 	// Read configuration
 	options, err := config.ReadConfig(configfile)


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
When the number of nodes available is greater than the HA count
we want to select a subset of these nodes for use with gluster
block ha support. Previous changes to the code try to select
the ha-count number of healthy nodes from this set but if the
healthy node set was unchanging it would always pick the exact
same nodes.

This change shuffles the list of nodes that is tested for
liveness so different block volumes are distributed across
different nodes, and adds a test for this behavior.

Also in introduces proper seeding for the PRNG.

### Does this PR fix issues?

Fixes (latter half of) rhbz#1595531

### Notes for the reviewer

Supersedes PR #1281
