### PR TITLE
apps:glusterfs: reserve 1% of raw capacity in FreeSpace tracking

### DIFF
--- a/apps/glusterfs/app_block_volume_test.go
+++ b/apps/glusterfs/app_block_volume_test.go
@@ -213,7 +213,7 @@ func TestBlockVolumeLargerThanBlockHostingVolume(t *testing.T) {
 	body, err := ioutil.ReadAll(io.LimitReader(r.Body, r.ContentLength))
 	tests.Assert(t, err == nil)
 	r.Body.Close()
-	tests.Assert(t, strings.Contains(string(body), "Failed to allocate new block volume: The size configured for automatic creation of block hosting volumes (1024) is too small to host the requested block volume of size 1600. Please create a sufficiently large block hosting volume manually."), "got", string(body))
+	tests.Assert(t, strings.Contains(string(body), "Failed to allocate new block volume: The size configured for automatic creation of block hosting volumes (1100) is too small to host the requested block volume of size 1600. Please create a sufficiently large block hosting volume manually."), "got", string(body))
 }
 
 func TestBlockVolumeCreate(t *testing.T) {

--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -341,7 +341,7 @@ func (ve *VolumeExpandOperation) Finalize() error {
 		}
 		ve.vol.Info.Size += sizeDelta
 		if ve.vol.Info.Block == true {
-			ve.vol.ModifyFreeSize(sizeDelta)
+			ve.vol.AddRawCapacity(sizeDelta)
 		}
 		ve.op.FinalizeVolume(ve.vol)
 		if e := ve.vol.Save(tx); e != nil {
@@ -703,7 +703,7 @@ func (bvc *BlockVolumeCreateOperation) Build() error {
 		if len(volumes) > 0 {
 			bvc.bvol.Info.BlockHostingVolume = volumes[0].Info.Id
 			bvc.bvol.Info.Cluster = volumes[0].Info.Cluster
-		} else if bvc.bvol.Info.Size > BlockHostingVolumeSize {
+		} else if bvc.bvol.Info.Size > ReduceRawSize(BlockHostingVolumeSize) {
 			return fmt.Errorf("The size configured for "+
 				"automatic creation of block hosting volumes "+
 				"(%v) is too small to host the requested "+

--- a/apps/glusterfs/testapp_mock.go
+++ b/apps/glusterfs/testapp_mock.go
@@ -20,6 +20,7 @@ func NewTestApp(dbfile string) *App {
 		DBfile:                    dbfile,
 		Executor:                  "mock",
 		CreateBlockHostingVolumes: true,
+		BlockHostingVolumeSize:    1100,
 		MaxInflightOperations:     64, // avoid throttling test code
 	}
 	app := NewApp(appConfig)

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -315,6 +315,7 @@ type VolumeInfo struct {
 	} `json:"mount"`
 	BlockInfo struct {
 		FreeSize     int              `json:"freesize,omitempty"`
+		ReservedSize int              `json:"reservedsize,omitempty"`
 		BlockVolumes sort.StringSlice `json:"blockvolume,omitempty"`
 	} `json:"blockinfo,omitempty"`
 }
@@ -469,6 +470,7 @@ func (v *VolumeInfoResponse) String() string {
 		"Mount Options: backup-volfile-servers=%v\n"+
 		"Block: %v\n"+
 		"Free Size: %v\n"+
+		"Reserved Size: %v\n"+
 		"Block Volumes: %v\n"+
 		"Durability Type: %v\n",
 		v.Name,
@@ -479,6 +481,7 @@ func (v *VolumeInfoResponse) String() string {
 		v.Mount.GlusterFS.Options["backup-volfile-servers"],
 		v.Block,
 		v.BlockInfo.FreeSize,
+		v.BlockInfo.ReservedSize,
 		v.BlockInfo.BlockVolumes,
 		v.Durability.Type)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?

A block-hosting volume created with raw size X can not host block files of accumulated size X because the file system uses a certain small amount of the raw size. But the FreeSpace tracking does currently not take this into account. Hence trying to create a block volume of size X with FreeSize X available on the block hosting volume will fail. 

This PR fixes heketi to always track only 99% of the raw space of a newly created (or expanded) block hosting volume as the available FreeSize.

### Does this PR fix issues?

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1596018
