### PR TITLE
apps: don't waste entropy for seeding

### DIFF
--- a/main.go
+++ b/main.go
@@ -291,7 +291,7 @@ func randSeed() {
 	max := big.NewInt(1<<31 - 1)
 	n, err := crand.Int(crand.Reader, max)
 	if err != nil {
-		rand.Seed(time.Now().UTC().UnixNano())
+		rand.Seed(time.Now().UnixNano())
 	} else {
 		rand.Seed(n.Int64())
 	}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ package main
 import (
 	crand "crypto/rand"
 	"fmt"
-	"math"
 	"math/big"
 	"math/rand"
 	"net/http"
@@ -287,9 +286,10 @@ func setupApp(config *config.Config) (a *glusterfs.App) {
 }
 
 func randSeed() {
-	var max big.Int
-	max.Add(big.NewInt(math.MaxInt64), big.NewInt(1))
-	n, err := crand.Int(crand.Reader, &max)
+	// from rand.Seed docs: "Seed values that have the same remainder when
+	// divided by 2^31-1 generate the same pseudo-random sequence."
+	max := big.NewInt(1<<31 - 1)
+	n, err := crand.Int(crand.Reader, max)
 	if err != nil {
 		rand.Seed(time.Now().UTC().UnixNano())
 	} else {


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Seed values that have the same remainder when divided by 2^31-1
generate the same pseudo-random sequence. So there is no need waste
entropy to generate a 64 bit random number.

Also this change removes an unnecessary UTC() call, since UnixNano() ignores the timezone info.
