### PR TITLE
apps:glusterfs update volume hosts info during node deletion

### DIFF
--- a/apps/glusterfs/app_node.go
+++ b/apps/glusterfs/app_node.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/gorilla/mux"
+	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
 )
@@ -289,7 +290,6 @@ func (a *App) NodeDelete(w http.ResponseWriter, r *http.Request) {
 
 		// Remove from db
 		err = a.db.Update(func(tx *bolt.Tx) error {
-
 			// Get Cluster
 			cluster, err := NewClusterEntryFromId(tx, node.Info.ClusterId)
 			if err == ErrNotFound {
@@ -320,6 +320,11 @@ func (a *App) NodeDelete(w http.ResponseWriter, r *http.Request) {
 				return err
 			}
 
+			err = refreshVolumeNodes(tx, node)
+			if err != nil {
+				logger.Err(err)
+				return err
+			}
 			return nil
 
 		})
@@ -334,6 +339,57 @@ func (a *App) NodeDelete(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func refreshVolumeNodes(tx *bolt.Tx, node *NodeEntry) error {
+	clusterID := node.Info.ClusterId
+	deletedNodeHostName := node.StorageHostName()
+	txdb := wdb.WrapTx(tx)
+	// Get Cluster
+	cluster, err := NewClusterEntryFromId(tx, clusterID)
+	if err != nil {
+		logger.Critical("Cluster id %v is expected be in db. Pointed to by node %v",
+			clusterID,
+			clusterID)
+		return err
+	}
+
+	hosts, err := getHostsFromCluster(txdb, clusterID)
+	if err != nil {
+		return err
+	}
+	for _, volID := range cluster.Info.Volumes {
+		volEntry, err := NewVolumeEntryFromId(tx, volID)
+		if err != nil {
+			logger.LogError("Get volume entry for ID %s Failed with error %s", volID, err.Error())
+			continue
+		}
+		if volEntry.Info.Block {
+			for _, id := range volEntry.Info.BlockInfo.BlockVolumes {
+
+				blockEntry, err := NewBlockVolumeEntryFromId(tx, id)
+				if err != nil {
+					logger.LogError("Get block volume entry for ID %s Failed with error %s", id, err.Error())
+					continue
+				}
+
+				blockEntry.updateHosts(hosts)
+
+				if err := blockEntry.Save(tx); err != nil {
+					logger.LogError("Save block entry for ID %s Failed with error %s", id, err.Error())
+					continue
+				}
+			}
+		}
+		//update mountpoint info
+		volEntry.updateHostandMountPoint(hosts, deletedNodeHostName)
+
+		if err = volEntry.Save(tx); err != nil {
+			logger.LogError("Save volume entry for ID  %s Failed with error %s", volEntry.Info.Id, err.Error())
+			continue
+		}
+	}
+
+	return nil
+}
 func (a *App) NodeSetState(w http.ResponseWriter, r *http.Request) {
 	// Get the id from the URL
 	vars := mux.Vars(r)

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -390,3 +390,7 @@ func canHostBlockVolume(tx *bolt.Tx, bv *BlockVolumeEntry, vol *VolumeEntry) (bo
 
 	return true, nil
 }
+
+func (v *BlockVolumeEntry) updateHosts(hosts []string) {
+	v.Info.BlockVolume.Hosts = hosts
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?
during the node delete in heketi, we remove the node from
heketi management, volume info such as Hosts (which may
contain the deleting node hostname). and we need to
update the backup-volfile-servers and volume mountpoint
(this also may contain the deleting node hostname)

if it's a block hosting volume, we need to
fetch all the block volumes belongs to it,
and update the hosts in those volumes, so that
next block volume creation fetches the new
hosts from the heketi cluster.

Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>

### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #1274
Fixes #1273


### Notes for the reviewer


