### PR TITLE
utils: use logger to capture ssh key setup errors

### DIFF
--- a/pkg/utils/ssh/ssh.go
+++ b/pkg/utils/ssh/ssh.go
@@ -36,7 +36,6 @@ func getKeyFile(file string) (key ssh.Signer, err error) {
 	}
 	key, err = ssh.ParsePrivateKey(buf)
 	if err != nil {
-		fmt.Print(err)
 		return
 	}
 	return
@@ -84,7 +83,7 @@ func NewSshExecWithKeyFile(logger *utils.Logger, user string, file string) *SshE
 
 	// Now in the main function DO:
 	if key, err = getKeyFile(file); err != nil {
-		fmt.Println("Unable to get keyfile")
+		logger.LogError("Unable to get keyfile: %v", err)
 		return nil
 	}
 	// Define the Client Config as :


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Within the ssh utils package some error paths were simply printing to stdout.
Instead of just blatting some errors out to stdout (not stderr) we instead we use the nice logger that was already in the package.



