### PR TITLE
Heketi client uses new port for every get

### DIFF
--- a/apps/glusterfs/operations_manage.go
+++ b/apps/glusterfs/operations_manage.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/heketi/heketi/executors"
 
@@ -97,6 +98,7 @@ func AsyncHttpOperation(app *App,
 		// decrement the op counter once the operation is done
 		// either success or failure
 		defer app.opcounter.Dec()
+		time.Sleep(10 * time.Second)
 		logger.Info("Started async operation: %v", label)
 		if err := op.Exec(app.executor); err != nil {
 			if _, ok := err.(OperationRetryError); ok && op.MaxRetries() > 0 {


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
This is a WIP PR to show that heketi client library creates a new http client for every GET operation that it performs while checking the status of a async operation. It should rather create a http client object when the heketi client object is created and should be cached.

### Notes for the reviewer
Note that the PR currently ignores many other options that are stored in the client struct of heketi. I will update the patch if we all agree that the http client object should be reused.


