### PR TITLE
middleware: ignore iat claim in jwt

### DIFF
--- a/apps/glusterfs/app_middleware.go
+++ b/apps/glusterfs/app_middleware.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gorilla/context"
 	"github.com/urfave/negroni"
 
+	"github.com/heketi/heketi/middleware"
 	"github.com/heketi/heketi/pkg/kubernetes"
 )
 
@@ -32,10 +33,10 @@ func (a *App) Auth(w http.ResponseWriter, r *http.Request, next http.HandlerFunc
 
 	// Need to change from interface{} to the jwt.Token type
 	token := data.(*jwt.Token)
-	claims := token.Claims.(jwt.MapClaims)
+	claims := token.Claims.(*middleware.HeketiJwtClaims)
 
 	// Check access
-	if "user" == claims["iss"] && r.URL.Path != "/volumes" {
+	if "user" == claims.Issuer && r.URL.Path != "/volumes" {
 		http.Error(w, "Administrator access required", http.StatusUnauthorized)
 		return
 	}

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -115,10 +115,10 @@ func (j *JwtAuth) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.Ha
 		errmsg := fmt.Sprintf("Invalid JWT token: %s", err)
 		// annoying that the types don't actually match
 		if err.Error() == jwt.ErrSignatureInvalid.Error() {
-			errmsg += "\n(client and server secrets may not match)"
+			errmsg += " (client and server secrets may not match)"
 		}
 		if strings.Contains(err.Error(), "used before issued") {
-			errmsg += "\n(client and server clocks may differ)"
+			errmsg += " (client and server clocks may differ)"
 		}
 		http.Error(w, errmsg, http.StatusUnauthorized)
 		return

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -15,22 +15,76 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/auth0/go-jwt-middleware"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/context"
+	"github.com/heketi/heketi/pkg/utils"
 )
+
+var (
+	logger          = utils.NewLogger("[jwt]", utils.LEVEL_DEBUG)
+	iatLeeway int64 = 120
+)
+
+func init() {
+	if leeway, exists := os.LookupEnv("HEKETI_JWT_IAT_LEEWAY_SECONDS"); exists {
+		value, err := strconv.ParseUint(leeway, 10, 64)
+		if err != nil {
+			logger.Info("HEKETI_JWT_IAT_LEEWAY_SECONDS not valid: %v, input string: %v, using default: %v", err, leeway, 120)
+		} else {
+			iatLeeway = int64(value)
+		}
+	}
+}
 
 // From https://github.com/dgrijalva/jwt-go/pull/139 it is understood
 // that if the machine where jwt token is generated and/or the machine
 // where jwt token is verified have any clock skew then there is a
-// possibility of getting a "Token used before issued" error. Considering
-// that we also check for expiration with delta of 5 minutes, disabling
-// iat claim until the patch is merged in jwt.
-var (
-	required_claims = []string{"iss", "exp"}
-)
+// possibility of getting a "Token used before issued" error.
+// Therefore we have implemented a derived claim type of HeketiJwtClaims and
+// the validation function for "iat" compares time with provision for leeway.
+// Also, now that we control the validation function, we make "exp" validation
+// mandatory and get rid of required_claims array.
+type HeketiJwtClaims struct {
+	*jwt.StandardClaims
+	Qsh string `json:"qsh,omitempty"`
+}
+
+func (c *HeketiJwtClaims) Valid() error {
+	vErr := new(jwt.ValidationError)
+	now := jwt.TimeFunc().Unix()
+
+	if c.VerifyExpiresAt(now, true) == false {
+		delta := time.Unix(now, 0).Sub(time.Unix(c.ExpiresAt, 0))
+		vErr.Inner = fmt.Errorf("Token is expired by %v", delta)
+		vErr.Errors |= jwt.ValidationErrorExpired
+		logger.LogError("exp validation failed: %v", vErr.Error())
+	}
+
+	// "iat" check
+	if now < c.IssuedAt-iatLeeway {
+		vErr.Inner = fmt.Errorf("Token used before issued")
+		vErr.Errors |= jwt.ValidationErrorIssuedAt
+		logger.LogError("iat validation failed: %v, time now: %v, time issued: %v", vErr.Error(), time.Unix(now, 0), time.Unix(c.IssuedAt, 0))
+	}
+
+	// "nbf" is not a required claim
+	if c.VerifyNotBefore(now, false) == false {
+		vErr.Inner = fmt.Errorf("token is not valid yet")
+		vErr.Errors |= jwt.ValidationErrorNotValidYet
+	}
+
+	if vErr.Errors > 0 {
+		return vErr
+	}
+
+	return nil
+}
 
 type JwtAuth struct {
 	adminKey []byte
@@ -84,22 +138,19 @@ func (j *JwtAuth) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.Ha
 	}
 
 	// Parse token
-	var claims jwt.MapClaims
-	token, err := jwt.Parse(rawtoken, func(token *jwt.Token) (interface{}, error) {
+	var claims *HeketiJwtClaims
+	token, err := jwt.ParseWithClaims(rawtoken, &HeketiJwtClaims{}, func(token *jwt.Token) (interface{}, error) {
 
 		// Verify Method
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
 		}
 
-		claims = token.Claims.(jwt.MapClaims)
-		if claims == nil {
-			return nil, fmt.Errorf("No claims found in token")
-		}
+		claims = token.Claims.(*HeketiJwtClaims)
 
 		// Get claims
-		if issuer, ok := claims["iss"]; ok {
-			switch issuer {
+		if "" != claims.Issuer {
+			switch claims.Issuer {
 			case "admin":
 				return j.adminKey, nil
 			case "user":
@@ -129,17 +180,8 @@ func (j *JwtAuth) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.Ha
 		return
 	}
 
-	// Check for required claims
-	for _, required_claim := range required_claims {
-		if _, ok := claims[required_claim]; !ok {
-			// Claim missing
-			http.Error(w, fmt.Sprintf("Required claim %v missing from token", required_claim), http.StatusBadRequest)
-			return
-		}
-	}
-
 	// Check qsh claim
-	if claims["qsh"] != generate_qsh(r) {
+	if claims.Qsh != generate_qsh(r) {
 		http.Error(w, "Invalid qsh claim in token", http.StatusUnauthorized)
 		return
 	}

--- a/middleware/jwt_test.go
+++ b/middleware/jwt_test.go
@@ -14,8 +14,12 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/hex"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -176,13 +180,8 @@ func TestJwtMissingClaims(t *testing.T) {
 	req.Header.Set("Authorization", "bearer "+tokenString)
 	r, err := http.DefaultClient.Do(req)
 	tests.Assert(t, err == nil)
-	tests.Assert(t, r.StatusCode == http.StatusBadRequest)
+	tests.Assert(t, r.StatusCode == http.StatusUnauthorized, r.StatusCode, r.Status)
 	tests.Assert(t, called == false)
-
-	s, err := utils.GetStringFromResponse(r)
-	tests.Assert(t, err == nil)
-	tests.Assert(t, strings.Contains(s, "missing from token"))
-
 }
 
 func TestJwtInvalidToken(t *testing.T) {
@@ -348,8 +347,8 @@ func TestJwt(t *testing.T) {
 		tests.Assert(t, data != nil)
 
 		token := data.(*jwt.Token)
-		claims := token.Claims.(jwt.MapClaims)
-		tests.Assert(t, claims["iss"] == "admin")
+		claims := token.Claims.(*HeketiJwtClaims)
+		tests.Assert(t, claims.Issuer == "admin")
 
 		called = true
 
@@ -391,8 +390,412 @@ func TestJwt(t *testing.T) {
 	req.Header.Set("Authorization", "bearer "+tokenString)
 	r, err := http.DefaultClient.Do(req)
 	tests.Assert(t, err == nil)
-	tests.Assert(t, r.StatusCode == http.StatusOK)
+	tests.Assert(t, r.StatusCode == http.StatusOK, r.StatusCode, r.Status)
 	tests.Assert(t, called == true)
+}
+func TestJwtLeewayIAT(t *testing.T) {
+	// Setup jwt
+	c := &JwtAuthConfig{}
+	c.Admin.PrivateKey = "Key"
+	c.User.PrivateKey = "UserKey"
+	j := NewJwtAuth(c)
+	tests.Assert(t, j != nil)
+
+	// Setup middleware framework
+	n := negroni.New(j)
+	tests.Assert(t, n != nil)
+
+	called := false
+	mw := func(rw http.ResponseWriter, r *http.Request) {
+		data := context.Get(r, "jwt")
+		tests.Assert(t, data != nil)
+
+		token := data.(*jwt.Token)
+		claims := token.Claims.(*HeketiJwtClaims)
+		tests.Assert(t, claims.Issuer == "admin")
+		tests.Assert(t, claims.IssuedAt != 0)
+
+		called = true
+
+		rw.WriteHeader(http.StatusOK)
+	}
+	n.UseHandlerFunc(mw)
+
+	// Create test server
+	ts := httptest.NewServer(n)
+
+	// Generate qsh
+	qshstring := "GET&/"
+	hash := sha256.New()
+	hash.Write([]byte(qshstring))
+
+	// Create token
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		// Set issuer
+		"iss": "admin",
+
+		// Set issued at time
+		// and set it to a time later than now but no later than 120 seconds
+		// DO NOT remove this even if we remove the iat claim
+		// from client someday. The intention is to test if we provide
+		// leeway for iat claim or not.
+		"iat": time.Now().Add(time.Second * 65).Unix(),
+
+		// Set expiration
+		"exp": time.Now().Add(time.Second * 10).Unix(),
+
+		// Set qsh
+		"qsh": hex.EncodeToString(hash.Sum(nil)),
+	})
+
+	tokenString, err := token.SignedString([]byte("Key"))
+	tests.Assert(t, err == nil)
+
+	// Setup header
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	tests.Assert(t, err == nil)
+
+	// Miss 'bearer' string
+	req.Header.Set("Authorization", "bearer "+tokenString)
+	r, err := http.DefaultClient.Do(req)
+	tests.Assert(t, err == nil)
+	body, err := ioutil.ReadAll(io.LimitReader(r.Body, r.ContentLength))
+	tests.Assert(t, r.StatusCode == http.StatusOK, r.StatusCode, r.Status, string(body))
+	r.Body.Close()
+	tests.Assert(t, called == true)
+}
+
+func TestJwtExceedLeewayIAT(t *testing.T) {
+	// Setup jwt
+	c := &JwtAuthConfig{}
+	c.Admin.PrivateKey = "Key"
+	c.User.PrivateKey = "UserKey"
+	j := NewJwtAuth(c)
+	tests.Assert(t, j != nil)
+
+	// Setup middleware framework
+	n := negroni.New(j)
+	tests.Assert(t, n != nil)
+
+	called := false
+	mw := func(rw http.ResponseWriter, r *http.Request) {
+		data := context.Get(r, "jwt")
+		tests.Assert(t, data != nil)
+
+		token := data.(*jwt.Token)
+		claims := token.Claims.(*HeketiJwtClaims)
+		tests.Assert(t, claims.Issuer == "admin")
+		tests.Assert(t, claims.IssuedAt != 0)
+
+		called = true
+
+		rw.WriteHeader(http.StatusOK)
+	}
+	n.UseHandlerFunc(mw)
+
+	// Create test server
+	ts := httptest.NewServer(n)
+
+	// Generate qsh
+	qshstring := "GET&/"
+	hash := sha256.New()
+	hash.Write([]byte(qshstring))
+
+	// Create token
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		// Set issuer
+		"iss": "admin",
+
+		// Set issued at time
+		// and set it to a time later than 120 seconds
+		"iat": time.Now().Add(time.Second * 165).Unix(),
+
+		// Set expiration
+		"exp": time.Now().Add(time.Second * 180).Unix(),
+
+		// Set qsh
+		"qsh": hex.EncodeToString(hash.Sum(nil)),
+	})
+
+	tokenString, err := token.SignedString([]byte("Key"))
+	tests.Assert(t, err == nil)
+
+	// Setup header
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	tests.Assert(t, err == nil)
+
+	// Add 'bearer' string
+	req.Header.Set("Authorization", "bearer "+tokenString)
+	r, err := http.DefaultClient.Do(req)
+	tests.Assert(t, err == nil)
+	tests.Assert(t, r.StatusCode == http.StatusUnauthorized)
+	tests.Assert(t, called == false)
+
+	s, err := utils.GetStringFromResponse(r)
+	tests.Assert(t, err == nil)
+	tests.Assert(t, strings.Contains(s, "Token used before issued"), s)
+}
+
+func TestJwtModifiedLeewayIATSuccess(t *testing.T) {
+	value, exists := os.LookupEnv("HEKETI_JWT_IAT_LEEWAY_SECONDS")
+	if exists {
+		logger.Info("leeway env is %v", value)
+		// Setup jwt
+		c := &JwtAuthConfig{}
+		c.Admin.PrivateKey = "Key"
+		c.User.PrivateKey = "UserKey"
+		j := NewJwtAuth(c)
+		tests.Assert(t, j != nil)
+
+		// Setup middleware framework
+		n := negroni.New(j)
+		tests.Assert(t, n != nil)
+
+		called := false
+		mw := func(rw http.ResponseWriter, r *http.Request) {
+			data := context.Get(r, "jwt")
+			tests.Assert(t, data != nil)
+
+			token := data.(*jwt.Token)
+			claims := token.Claims.(*HeketiJwtClaims)
+			tests.Assert(t, claims.Issuer == "admin")
+			tests.Assert(t, claims.IssuedAt != 0)
+
+			called = true
+
+			rw.WriteHeader(http.StatusOK)
+		}
+		n.UseHandlerFunc(mw)
+
+		// Create test server
+		ts := httptest.NewServer(n)
+
+		// Generate qsh
+		qshstring := "GET&/"
+		hash := sha256.New()
+		hash.Write([]byte(qshstring))
+
+		// Create token
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			// Set issuer
+			"iss": "admin",
+
+			// Set issued at time
+			// and set it to a time no later than 20 seconds
+			// That is the leeway set in ENV
+			"iat": time.Now().Add(time.Second * 10).Unix(),
+
+			// Set expiration
+			"exp": time.Now().Add(time.Second * 180).Unix(),
+
+			// Set qsh
+			"qsh": hex.EncodeToString(hash.Sum(nil)),
+		})
+
+		tokenString, err := token.SignedString([]byte("Key"))
+		tests.Assert(t, err == nil)
+
+		// Setup header
+		req, err := http.NewRequest("GET", ts.URL, nil)
+		tests.Assert(t, err == nil)
+
+		// Add 'bearer' string
+		req.Header.Set("Authorization", "bearer "+tokenString)
+		r, err := http.DefaultClient.Do(req)
+		tests.Assert(t, err == nil)
+		body, err := ioutil.ReadAll(io.LimitReader(r.Body, r.ContentLength))
+		tests.Assert(t, r.StatusCode == http.StatusOK, r.StatusCode, r.Status, string(body))
+		r.Body.Close()
+		tests.Assert(t, called == true)
+		return
+	} else {
+		logger.Info("leeway env is not set")
+		cmd := exec.Command(os.Args[0], "-test.run=TestJwtModifiedLeewayIATSuccess")
+		cmd.Env = append(os.Environ(), "HEKETI_JWT_IAT_LEEWAY_SECONDS=20")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err := cmd.Run()
+		if e, ok := err.(*exec.ExitError); ok && e.Success() {
+			return
+		}
+		tests.Assert(t, err == nil, err)
+	}
+}
+
+func TestJwtModifiedLeewayIATFailure(t *testing.T) {
+	value, exists := os.LookupEnv("HEKETI_JWT_IAT_LEEWAY_SECONDS")
+	if exists {
+		logger.Info("leeway env is %v", value)
+		// Setup jwt
+		c := &JwtAuthConfig{}
+		c.Admin.PrivateKey = "Key"
+		c.User.PrivateKey = "UserKey"
+		j := NewJwtAuth(c)
+		tests.Assert(t, j != nil)
+
+		// Setup middleware framework
+		n := negroni.New(j)
+		tests.Assert(t, n != nil)
+
+		called := false
+		mw := func(rw http.ResponseWriter, r *http.Request) {
+			data := context.Get(r, "jwt")
+			tests.Assert(t, data != nil)
+
+			token := data.(*jwt.Token)
+			claims := token.Claims.(*HeketiJwtClaims)
+			tests.Assert(t, claims.Issuer == "admin")
+			tests.Assert(t, claims.IssuedAt != 0)
+
+			called = true
+
+			rw.WriteHeader(http.StatusOK)
+		}
+		n.UseHandlerFunc(mw)
+
+		// Create test server
+		ts := httptest.NewServer(n)
+
+		// Generate qsh
+		qshstring := "GET&/"
+		hash := sha256.New()
+		hash.Write([]byte(qshstring))
+
+		// Create token
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			// Set issuer
+			"iss": "admin",
+
+			// Set issued at time
+			// and set it to a time later than 20 seconds
+			// That is the leeway set in ENV
+			"iat": time.Now().Add(time.Second * 25).Unix(),
+
+			// Set expiration
+			"exp": time.Now().Add(time.Second * 180).Unix(),
+
+			// Set qsh
+			"qsh": hex.EncodeToString(hash.Sum(nil)),
+		})
+
+		tokenString, err := token.SignedString([]byte("Key"))
+		tests.Assert(t, err == nil)
+
+		// Setup header
+		req, err := http.NewRequest("GET", ts.URL, nil)
+		tests.Assert(t, err == nil)
+
+		// Add 'bearer' string
+		req.Header.Set("Authorization", "bearer "+tokenString)
+		r, err := http.DefaultClient.Do(req)
+		tests.Assert(t, err == nil)
+		tests.Assert(t, r.StatusCode == http.StatusUnauthorized)
+		tests.Assert(t, called == false)
+
+		s, err := utils.GetStringFromResponse(r)
+		tests.Assert(t, err == nil)
+		tests.Assert(t, strings.Contains(s, "Token used before issued"), s)
+		return
+	} else {
+		logger.Info("leeway env is not set")
+		cmd := exec.Command(os.Args[0], "-test.run=TestJwtModifiedLeewayIATFailure")
+		cmd.Env = append(os.Environ(), "HEKETI_JWT_IAT_LEEWAY_SECONDS=20")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err := cmd.Run()
+		if e, ok := err.(*exec.ExitError); ok && e.Success() {
+			return
+		}
+		tests.Assert(t, err == nil, err)
+	}
+}
+
+func TestJwtNegativeLeewayIATFailure(t *testing.T) {
+	value, exists := os.LookupEnv("HEKETI_JWT_IAT_LEEWAY_SECONDS")
+	if exists {
+		logger.Info("leeway env is %v", value)
+		// Setup jwt
+		c := &JwtAuthConfig{}
+		c.Admin.PrivateKey = "Key"
+		c.User.PrivateKey = "UserKey"
+		j := NewJwtAuth(c)
+		tests.Assert(t, j != nil)
+
+		// Setup middleware framework
+		n := negroni.New(j)
+		tests.Assert(t, n != nil)
+
+		called := false
+		mw := func(rw http.ResponseWriter, r *http.Request) {
+			data := context.Get(r, "jwt")
+			tests.Assert(t, data != nil)
+
+			token := data.(*jwt.Token)
+			claims := token.Claims.(*HeketiJwtClaims)
+			tests.Assert(t, claims.Issuer == "admin")
+			tests.Assert(t, claims.IssuedAt != 0)
+
+			called = true
+
+			rw.WriteHeader(http.StatusOK)
+		}
+		n.UseHandlerFunc(mw)
+
+		// Create test server
+		ts := httptest.NewServer(n)
+
+		// Generate qsh
+		qshstring := "GET&/"
+		hash := sha256.New()
+		hash.Write([]byte(qshstring))
+
+		// Create token
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			// Set issuer
+			"iss": "admin",
+
+			// Set issued at time
+			// and set it to 139 as it is lesser than abs(-140)
+			// That is the negative leeway set in ENV
+			"iat": time.Now().Add(time.Second * 140).Unix(),
+
+			// Set expiration
+			"exp": time.Now().Add(time.Second * 180).Unix(),
+
+			// Set qsh
+			"qsh": hex.EncodeToString(hash.Sum(nil)),
+		})
+
+		tokenString, err := token.SignedString([]byte("Key"))
+		tests.Assert(t, err == nil)
+
+		// Setup header
+		req, err := http.NewRequest("GET", ts.URL, nil)
+		tests.Assert(t, err == nil)
+
+		// Add 'bearer' string
+		req.Header.Set("Authorization", "bearer "+tokenString)
+		r, err := http.DefaultClient.Do(req)
+		tests.Assert(t, err == nil)
+		tests.Assert(t, r.StatusCode == http.StatusUnauthorized)
+		tests.Assert(t, called == false)
+
+		s, err := utils.GetStringFromResponse(r)
+		tests.Assert(t, err == nil)
+		tests.Assert(t, strings.Contains(s, "Token used before issued"), s)
+		return
+	} else {
+		logger.Info("leeway env is not set")
+		cmd := exec.Command(os.Args[0], "-test.run=TestJwtNegativeLeewayIATFailure")
+		cmd.Env = append(os.Environ(), "HEKETI_JWT_IAT_LEEWAY_SECONDS=-140")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err := cmd.Run()
+		if e, ok := err.(*exec.ExitError); ok && e.Success() {
+			return
+		}
+		tests.Assert(t, err == nil, err)
+	}
 }
 
 func TestJwtUnknownUser(t *testing.T) {
@@ -551,9 +954,9 @@ func TestJwtWrongSigningMethod(t *testing.T) {
 		tests.Assert(t, data != nil, "context.Get failed")
 
 		token := data.(*jwt.Token)
-		claims := token.Claims.(jwt.MapClaims)
-		tests.Assert(t, claims["iss"] == "admin",
-			`expected claims["iss"] == "admin", got:`, claims["iss"])
+		claims := token.Claims.(*HeketiJwtClaims)
+		tests.Assert(t, claims.Issuer == "admin",
+			`expected claims.Issuer == "admin", got:`, claims.Issuer)
 
 		rw.WriteHeader(http.StatusOK)
 	}

--- a/middleware/jwt_test.go
+++ b/middleware/jwt_test.go
@@ -165,7 +165,7 @@ func TestJwtMissingClaims(t *testing.T) {
 	// Create test server
 	ts := httptest.NewServer(n)
 
-	// Create token with missing 'iss' claim
+	// Create token with missing 'exp' claim
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"iss": "admin",
 	})
@@ -176,7 +176,7 @@ func TestJwtMissingClaims(t *testing.T) {
 	req, err := http.NewRequest("GET", ts.URL, nil)
 	tests.Assert(t, err == nil)
 
-	// Miss 'bearer' string
+	// Add 'bearer' string
 	req.Header.Set("Authorization", "bearer "+tokenString)
 	r, err := http.DefaultClient.Do(req)
 	tests.Assert(t, err == nil)
@@ -222,7 +222,7 @@ func TestJwtInvalidToken(t *testing.T) {
 	req, err := http.NewRequest("GET", ts.URL, nil)
 	tests.Assert(t, err == nil)
 
-	// Miss 'bearer' string
+	// Add 'bearer' string
 	req.Header.Set("Authorization", "bearer "+tokenString)
 	r, err := http.DefaultClient.Do(req)
 	tests.Assert(t, err == nil)
@@ -386,7 +386,7 @@ func TestJwt(t *testing.T) {
 	req, err := http.NewRequest("GET", ts.URL, nil)
 	tests.Assert(t, err == nil)
 
-	// Miss 'bearer' string
+	// Add 'bearer' string
 	req.Header.Set("Authorization", "bearer "+tokenString)
 	r, err := http.DefaultClient.Do(req)
 	tests.Assert(t, err == nil)
@@ -455,7 +455,7 @@ func TestJwtLeewayIAT(t *testing.T) {
 	req, err := http.NewRequest("GET", ts.URL, nil)
 	tests.Assert(t, err == nil)
 
-	// Miss 'bearer' string
+	// Add 'bearer' string
 	req.Header.Set("Authorization", "bearer "+tokenString)
 	r, err := http.DefaultClient.Do(req)
 	tests.Assert(t, err == nil)
@@ -839,7 +839,7 @@ func TestJwtUnknownUser(t *testing.T) {
 	req, err := http.NewRequest("GET", ts.URL, nil)
 	tests.Assert(t, err == nil)
 
-	// Miss 'bearer' string
+	// Add 'bearer' string
 	req.Header.Set("Authorization", "bearer "+tokenString)
 	r, err := http.DefaultClient.Do(req)
 	tests.Assert(t, err == nil)
@@ -892,7 +892,7 @@ func TestJwtInvalidKeys(t *testing.T) {
 	req, err := http.NewRequest("GET", ts.URL, nil)
 	tests.Assert(t, err == nil)
 
-	// Miss 'bearer' string
+	// Add 'bearer' string
 	req.Header.Set("Authorization", "bearer "+tokenString)
 	r, err := http.DefaultClient.Do(req)
 	tests.Assert(t, err == nil)
@@ -921,7 +921,7 @@ func TestJwtInvalidKeys(t *testing.T) {
 	req, err = http.NewRequest("GET", ts.URL, nil)
 	tests.Assert(t, err == nil)
 
-	// Miss 'bearer' string
+	// Add 'bearer' string
 	req.Header.Set("Authorization", "bearer "+tokenString)
 	r, err = http.DefaultClient.Do(req)
 	tests.Assert(t, err == nil)


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
This PR implements new claims type and validation function. We need it due to inability of jwt library to handle clock skew.

### Notes for the reviewer
1. required_claims is embedded in validation function and missing claims error is replaced with unauthorized
2. As claims type has changed from map to struct, claims are now accessed as members and not indexed.


