### PR TITLE
heketi cli: add "server operations info" command 

### DIFF
--- a/client/cli/go/cmds/server.go
+++ b/client/cli/go/cmds/server.go
@@ -1,0 +1,69 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
+//
+
+package cmds
+
+import (
+	"os"
+	"text/template"
+
+	"github.com/spf13/cobra"
+)
+
+var serverCommand = &cobra.Command{
+	Use:   "server",
+	Short: "Heketi Server Management",
+	Long:  "Heketi Server Information & Management",
+}
+
+var operationsCommand = &cobra.Command{
+	Use:   "operations",
+	Short: "Manage ongoing server operations",
+	Long:  "Manage ongoing server operations",
+}
+
+var opInfoTemplate = `Operation Counts:
+  Total: {{.Total}}
+  In-Flight: {{.InFlight}}
+  New: {{.New}}
+  Stale: {{.Stale}}
+`
+
+var operationsInfoCommand = &cobra.Command{
+	Use:     "info",
+	Short:   "Get a summary of server operations",
+	Long:    "Get a summary of server operations",
+	Example: `  $ heketi-cli server operations info`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
+		t, err := template.New("opInfo").Parse(opInfoTemplate)
+		if err != nil {
+			return err
+		}
+		opInfo, err := heketi.OperationsInfo()
+		if err == nil {
+			t.Execute(os.Stdout, opInfo)
+		}
+		return err
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(serverCommand)
+	serverCommand.AddCommand(operationsCommand)
+	operationsCommand.SilenceUsage = true
+	operationsCommand.AddCommand(operationsInfoCommand)
+	operationsInfoCommand.SilenceUsage = true
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?
This change adds the command `heketi-cli server operations info` that will list a brief summary that counts the operations in various states.

Example:
```
$ ./heketi-cli server operations info
Operation Counts:
  Total: 3
  In-Flight: 0
  New: 0
  Stale: 3
```

This command makes introspecting some of the server state easier w/o requiring the user dump the db to figure out if the server is still processing operations.

### Notes for the reviewer

This change requires the changes provided by PR #1299 because it adds additional states for the operations that we summarize. Please merge that pr first.
