### PR TITLE
main: print the error in case starting the app failed

### DIFF
--- a/main.go
+++ b/main.go
@@ -270,8 +270,11 @@ func setWithEnvVariables(options *config.Config) {
 func setupApp(config *config.Config) (a *glusterfs.App) {
 	defer func() {
 		err := recover()
-		if a == nil || err != nil {
+		if a == nil {
 			fmt.Fprintln(os.Stderr, "ERROR: Unable to start application")
+			os.Exit(1)
+		} else if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: Unable to start application: %s\n", err)
 			os.Exit(1)
 		}
 	}()


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

In case initialization of the app fails, the message

    ERROR: Unable to start application

is not very helpful. There might be an actual error that can be displayed. If there is one, it should be logged.


### Notes for the reviewer

Just a minor improvement while debugging deploying within `minikube`.