### PR TITLE
Enable secure I/O communications (using TLS) on volume creation by default config or request field.

### DIFF
--- a/apps/glusterfs/app_config.go
+++ b/apps/glusterfs/app_config.go
@@ -12,6 +12,7 @@ package glusterfs
 import (
 	"github.com/heketi/heketi/executors/kubeexec"
 	"github.com/heketi/heketi/executors/sshexec"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
 type RetryLimitConfig struct {
@@ -45,4 +46,7 @@ type GlusterFSConfig struct {
 
 	// operation retry amounts
 	RetryLimits RetryLimitConfig `json:"operation_retry_limits"`
+
+	// secure communications
+	SecureCommunications *api.SecureCommunications `json:"secure_communications"`
 }

--- a/apps/glusterfs/app_volume.go
+++ b/apps/glusterfs/app_volume.go
@@ -134,6 +134,9 @@ func (a *App) VolumeCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	vol := NewVolumeEntryFromRequest(&msg)
+	if vol.SecureCommunications == nil {
+		vol.SecureCommunications = a.conf.SecureCommunications
+	}
 
 	if uint64(msg.Size)*GB < vol.Durability.MinVolumeSize() {
 		http.Error(w, fmt.Sprintf("Requested volume size (%v GB) is "+

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -64,6 +64,7 @@ type VolumeEntry struct {
 	Durability           VolumeDurability `json:"-"`
 	GlusterVolumeOptions []string
 	Pending              PendingItem
+	SecureCommunications *api.SecureCommunications
 }
 
 func VolumeList(tx *bolt.Tx) ([]string, error) {
@@ -150,6 +151,8 @@ func NewVolumeEntryFromRequest(req *api.VolumeCreateRequest) *VolumeEntry {
 
 	// If it is zero, then it will be assigned during volume creation
 	vol.Info.Clusters = req.Clusters
+
+	vol.SecureCommunications = req.SecureCommunications
 
 	return vol
 }

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -579,6 +579,11 @@ These APIs inform Heketi to create a network file system of a certain size avail
         * factor: _float32_, _optional_, Snapshot reserved space factor.  When creating a volume with snapshot enabled, the size of the brick will be set to _factor * brickSize_, where brickSize is automatically determined to satisfy the volume size request.  If omitted, it will default to _1.5_.
             * Requirement: Value must be greater than one.
     * clusters: _array of string_, _optional_, UUIDs of clusters where the volume should be created.  If omitted, each cluster will be checked until one is found that can satisfy the request.
+    * secure_communications: _map_, _optional_, Secure communications between client and server settings, overrides default values from config.
+        * enable: _bool_, Disable or enable secure communications,
+        * allowed_identities, _array of string_, _optional_, Client identities allowed to authenticate for given volume. All allowed by default.
+        * certificate_depth, _int_, _optional_, SSL certificate depth.
+        * cipher_list, _string_, _optional_, Allowed SSL cipher suites.
     * Example:
 
 ```json
@@ -597,7 +602,13 @@ These APIs inform Heketi to create a network file system of a certain size avail
     "clusters": [
         "2f84c71240f43e16808bc64b05ad0d06",
         "5a2c52d04075373e80dbfa1e291ba0de"
-    ]
+    ],
+    "secure_communications": {
+        "enable": true,
+        "allowed_identities": ["*"],
+        "certificate_depth": 2,
+        "cipher_list": "HIGH:!SSLv2"
+    }
 }
 ```
 Note:

--- a/docs/man/heketi-cli.8
+++ b/docs/man/heketi-cli.8
@@ -470,7 +470,7 @@ $ heketi-cli topology info
 .RE
 .SS "Volume Commands"
 .PP
-\fBheketi\-cli volume create \-\-clusters=<CLUSTER-IDS> \-\-disperse-data=<DISPERSION-VALUE> \-\-durability=<TYPE> \-\-name=<VOLUME-NAME> \-\-redundancy=<REDUNDENCY-VALUE> \-\-replica=<REPLICA-VALUE> \-\-size=<VOLUME-SIZE> \-\-snapshot-factor=<SNAPSHOT-FACTOR-VALUE>\fP
+\fBheketi\-cli volume create \-\-clusters=<CLUSTER-IDS> \-\-disperse-data=<DISPERSION-VALUE> \-\-durability=<TYPE> \-\-name=<VOLUME-NAME> \-\-redundancy=<REDUNDENCY-VALUE> \-\-replica=<REPLICA-VALUE> \-\-size=<VOLUME-SIZE> \-\-snapshot-factor=<SNAPSHOT-FACTOR-VALUE> \-\-secure-communications \-\-auth-allow='*' \-\-cipher-list="HIGH:!SSLv2" \-\-certificate-depth=2\fP
 .RS
 Create a GlusterFS volume
 .PP
@@ -532,6 +532,18 @@ Optional: Amount of storage to allocate for snapshot support.
 Must be greater 1.0.
 For example if a 10TiB volume requires 5TiB of snapshot storage, then snapshot\-factor would be set to 1.5.
 If the value is set to 1, then snapshots will not be enabled for this volume.
+.TP
+\fB\-\-secure-communications\fP[=false]
+Optional: Enable or disable secure communications for volume.
+.TP
+\fB\-\-auth-allow\fP='*'
+Optional: Identities allowed to SSL-authenticate for volume.
+.TP
+\fB\-\-cipher-list\fP="HIGH:!SSLv2"
+Optional: Cipher suites for secure communications.
+.TP
+\fB\-\-certificate-depth\fP=2
+Optional: SSL certificate depth for secure communications.
 .RE
 .PP
 \fBNote:\fP

--- a/etc/heketi.json
+++ b/etc/heketi.json
@@ -87,6 +87,21 @@
     "block_hosting_volume_size": 500,
 
     "_block_hosting_volume_options": "New block hosting volume will be created with the following set of options. Removing the group gluster-block option is NOT recommended. Additional options can be added next to it separated by a comma.",
-    "block_hosting_volume_options": "group gluster-block"
+    "block_hosting_volume_options": "group gluster-block",
+
+    "_secure_communications": "Secure communication settings for newly created volumes.",
+    "secure_communications": {
+      "_enable": "enable secure communications for newly created volumes",
+      "enable": true,
+
+      "_allowed_identities": "identities allowed to authenticate on volume",
+      "allowed_identities": ["*"],
+
+      "_certificate_depth": "ssl certificate depth, optional",
+      "certificate_depth": 2,
+
+      "_cipher_list": "ssl cipher list, optional",
+      "cipher_list": "HIGH:!SSLv2"
+    }
   }
 }

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -272,6 +272,13 @@ type VolumeDurabilityInfo struct {
 	Disperse  DisperseDurability `json:"disperse,omitempty"`
 }
 
+type SecureCommunications struct {
+	Enable            bool     `json:"enable"`
+	AllowedIdentities []string `json:"allowed_identities"`
+	CertificateDepth  *int     `json:"certificate_depth"`
+	CipherList        *string  `json:"cipher_list"`
+}
+
 type VolumeCreateRequest struct {
 	// Size in GiB
 	Size                 int                  `json:"size"`

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -292,6 +292,7 @@ type VolumeCreateRequest struct {
 		Enable bool    `json:"enable"`
 		Factor float32 `json:"factor"`
 	} `json:"snapshot"`
+	SecureCommunications *SecureCommunications `json:"secure_communications,omitempty"`
 }
 
 func (volCreateRequest VolumeCreateRequest) Validate() error {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?
It allows to enable I/O path encryption for newly created volumes (gluster feature).
Actually main change is setting gluster volume options according to request/config.
Preparations needed before using this option: https://gluster.readthedocs.io/en/latest/Administrator%20Guide/SSL/.

### Notes for the reviewer
I didn`t write any tests.
