### PR TITLE
tests: create a testutils package

### DIFF
--- a/pkg/testutils/cluster.go
+++ b/pkg/testutils/cluster.go
@@ -1,0 +1,242 @@
+// +build functional
+
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
+//
+
+package testutils
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	client "github.com/heketi/heketi/client/api/go-client"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/heketi/pkg/utils"
+
+	"github.com/heketi/tests"
+)
+
+var (
+	// The heketi server must be running on the host
+
+	// VMs
+	storage0    = "192.168.10.100"
+	storage1    = "192.168.10.101"
+	storage2    = "192.168.10.102"
+	storage3    = "192.168.10.103"
+	portNum     = "22"
+	storage0ssh = storage0 + ":" + portNum
+	storage1ssh = storage1 + ":" + portNum
+	storage2ssh = storage2 + ":" + portNum
+	storage3ssh = storage3 + ":" + portNum
+
+	// Heketi client
+	heketiUrl = "http://localhost:8080"
+	heketi    = client.NewClientNoAuth(heketiUrl)
+
+	// Storage systems
+	storagevms = []string{
+		storage0,
+		storage1,
+		storage2,
+		storage3,
+	}
+
+	// Disks on each system
+	disks = []string{
+		"/dev/vdb",
+		"/dev/vdc",
+		"/dev/vdd",
+		"/dev/vde",
+
+		"/dev/vdf",
+		"/dev/vdg",
+		"/dev/vdh",
+		"/dev/vdi",
+	}
+)
+
+func setupCluster(t *testing.T, numNodes int, numDisks int) {
+	tests.Assert(t, heketi != nil)
+
+	// Get ssh port first, we need it to create
+	// storageXssh variables
+	env := os.Getenv("HEKETI_TEST_STORAGEPORT")
+	if "" != env {
+		portNum = env
+	}
+
+	env = os.Getenv("HEKETI_TEST_STORAGE0")
+	if "" != env {
+		storage0 = env
+		storage0ssh = storage0 + ":" + portNum
+	}
+	env = os.Getenv("HEKETI_TEST_STORAGE1")
+	if "" != env {
+		storage1 = env
+		storage1ssh = storage1 + ":" + portNum
+	}
+	env = os.Getenv("HEKETI_TEST_STORAGE2")
+	if "" != env {
+		storage2 = env
+		storage2ssh = storage2 + ":" + portNum
+	}
+	env = os.Getenv("HEKETI_TEST_STORAGE3")
+	if "" != env {
+		storage3 = env
+		storage3ssh = storage3 + ":" + portNum
+	}
+
+	// As a testing invariant, we always expect to set up a cluster
+	// at the start of a test on a _clean_ server.
+	// Verify that there are no outstanding operations on the
+	// server. A test that needs to mess with the operations _must_
+	// clean up after itself.
+	oi, err := heketi.OperationsInfo()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, oi.Total == 0, "expected oi.Total == 0, got", oi.Total)
+	tests.Assert(t, oi.InFlight == 0, "expected oi.InFlight == 0, got", oi.Total)
+
+	// Storage systems
+	storagevms = []string{
+		storage0,
+		storage1,
+		storage2,
+		storage3,
+	}
+	// Create a cluster
+	cluster_req := &api.ClusterCreateRequest{
+		ClusterFlags: api.ClusterFlags{
+			Block: true,
+			File:  true,
+		},
+	}
+
+	cluster, err := heketi.ClusterCreate(cluster_req)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// hardcoded limits from the lists above
+	// possible TODO: generalize
+	tests.Assert(t, numNodes <= 4)
+	tests.Assert(t, numDisks <= 8)
+
+	// Add nodes
+	for index, hostname := range storagevms[:numNodes] {
+		nodeReq := &api.NodeAddRequest{}
+		nodeReq.ClusterId = cluster.Id
+		nodeReq.Hostnames.Manage = []string{hostname}
+		nodeReq.Hostnames.Storage = []string{hostname}
+		nodeReq.Zone = index%2 + 1
+
+		node, err := heketi.NodeAdd(nodeReq)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		// Add devices
+		sg := utils.NewStatusGroup()
+		for _, disk := range disks[:numDisks] {
+			sg.Add(1)
+			go func(d string) {
+				defer sg.Done()
+
+				driveReq := &api.DeviceAddRequest{}
+				driveReq.Name = d
+				driveReq.NodeId = node.Id
+
+				err := heketi.DeviceAdd(driveReq)
+				sg.Err(err)
+			}(disk)
+		}
+
+		err = sg.Result()
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	}
+}
+
+func dbStateDump(t *testing.T) {
+	if t.Failed() {
+		fmt.Println("~~~~~ dumping db state prior to teardown ~~~~~")
+		dump, err := heketi.DbDump()
+		if err != nil {
+			fmt.Printf("Unable to get db dump: %v\n", err)
+		} else {
+			fmt.Printf("\n%v\n", dump)
+		}
+		fmt.Println("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+	}
+}
+
+func teardownCluster(t *testing.T) {
+	fmt.Println("~~~ tearing down cluster")
+	dbStateDump(t)
+
+	clusters, err := heketi.ClusterList()
+	tests.Assert(t, err == nil, err)
+
+	for _, cluster := range clusters.Clusters {
+
+		clusterInfo, err := heketi.ClusterInfo(cluster)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		// Delete volumes in this cluster
+		for _, volume := range clusterInfo.Volumes {
+			err := heketi.VolumeDelete(volume)
+			tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		}
+
+		// Delete nodes
+		for _, node := range clusterInfo.Nodes {
+
+			// Get node information
+			nodeInfo, err := heketi.NodeInfo(node)
+			tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+			// Delete each device
+			sg := utils.NewStatusGroup()
+			for _, device := range nodeInfo.DevicesInfo {
+				sg.Add(1)
+				go func(id string) {
+					defer sg.Done()
+
+					stateReq := &api.StateRequest{}
+					stateReq.State = api.EntryStateOffline
+					err := heketi.DeviceState(id, stateReq)
+					if err != nil {
+						sg.Err(err)
+						return
+					}
+
+					stateReq.State = api.EntryStateFailed
+					err = heketi.DeviceState(id, stateReq)
+					if err != nil {
+						sg.Err(err)
+						return
+					}
+
+					err = heketi.DeviceDelete(id)
+					sg.Err(err)
+
+				}(device.Id)
+			}
+			err = sg.Result()
+			tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+			// Delete node
+			err = heketi.NodeDelete(node)
+			tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		}
+
+		// Delete cluster
+		err = heketi.ClusterDelete(cluster)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	}
+}

--- a/pkg/testutils/nodes.go
+++ b/pkg/testutils/nodes.go
@@ -1,0 +1,59 @@
+// +build functional
+
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
+//
+
+package testutils
+
+import (
+	"os"
+	"testing"
+
+	"github.com/heketi/heketi/pkg/logging"
+	"github.com/heketi/heketi/pkg/remoteexec/ssh"
+)
+
+var (
+	DefaultSshUser    = "vagrant"
+	DefaultSshKeyFile = "../config/insecure_private_key"
+)
+
+type sshAccess struct {
+	User    string
+	KeyFile string
+}
+
+// Use returns a new SSH executor given a logger.
+func (a *sshAccess) Use(l *logging.Logger) *ssh.SshExec {
+	return ssh.NewSshExecWithKeyFile(l, a.User, a.KeyFile)
+}
+
+// RequireNodeAccess returns an access helper depending on
+// the test environment. If ssh access is not available or
+// remote access is disabled the function triggers a test skip.
+func RequireNodeAccess(t *testing.T) *sshAccess {
+	// t.Helper()
+	// TODO: Helper not available prior to Go1.9, enable once Go1.8 is dropped
+	v := os.Getenv("HEKETI_TEST_NODE_ACCESS")
+	switch v {
+	// default/traditional behavior
+	case "":
+		return &sshAccess{DefaultSshUser, DefaultSshKeyFile}
+	case "skip":
+		// setting HEKETI_TEST_NODE_ACCESS to no puts
+		// a blanket skip on all tests that want node access
+		t.Skipf("remote node access disabled (HEKETI_TEST_NODE_ACCESS=%v)", v)
+	default:
+		t.Skipf("remote node access unknown (HEKETI_TEST_NODE_ACCESS=%v)", v)
+	}
+	return nil
+}

--- a/pkg/testutils/serverctl.go
+++ b/pkg/testutils/serverctl.go
@@ -102,7 +102,6 @@ func (s *ServerCtl) Start() error {
 	if !s.IsAlive() {
 		return errors.New("server exited early")
 	}
-	// dump some logs if heketi fails to start?
 	return nil
 }
 

--- a/pkg/testutils/serverctl.go
+++ b/pkg/testutils/serverctl.go
@@ -118,6 +118,9 @@ func (s *ServerCtl) IsAlive() bool {
 }
 
 func (s *ServerCtl) Stop() error {
+	// close the log file fd after stopping heketi (or if stop fails)
+	// this is needed in case the process has already died for some reason
+	defer s.logF.Close()
 	if err := s.cmd.Process.Signal(os.Interrupt); err != nil {
 		return err
 	}
@@ -127,7 +130,6 @@ func (s *ServerCtl) Stop() error {
 			return err
 		}
 	}
-	s.logF.Close()
 	return nil
 }
 

--- a/tests/functional/TestEnabledTLS/client_tls_test/client_tls_test.go
+++ b/tests/functional/TestEnabledTLS/client_tls_test/client_tls_test.go
@@ -19,6 +19,7 @@ import (
 
 	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
+	tutils "github.com/heketi/heketi/pkg/testutils"
 
 	"github.com/heketi/tests"
 )
@@ -31,7 +32,7 @@ var (
 )
 
 func TestCreateClusterTLSCert(t *testing.T) {
-	heketiServer := NewServerCtlFromEnv("..")
+	heketiServer := tutils.NewServerCtlFromEnv("..")
 	err := heketiServer.Start()
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	defer heketiServer.Stop()
@@ -46,7 +47,7 @@ func TestCreateClusterTLSCert(t *testing.T) {
 }
 
 func TestCreateClusterTLSNoVerify(t *testing.T) {
-	heketiServer := NewServerCtlFromEnv("..")
+	heketiServer := tutils.NewServerCtlFromEnv("..")
 	err := heketiServer.Start()
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	defer heketiServer.Stop()
@@ -64,7 +65,7 @@ func TestCreateClusterTLSNoVerify(t *testing.T) {
 // a self signed cert and none of the options needed for it
 // are provided.
 func TestClientFailUnknownAuthority(t *testing.T) {
-	heketiServer := NewServerCtlFromEnv("..")
+	heketiServer := tutils.NewServerCtlFromEnv("..")
 	err := heketiServer.Start()
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	defer heketiServer.Stop()

--- a/tests/functional/TestSmokeTest/tests/arbiter_test.go
+++ b/tests/functional/TestSmokeTest/tests/arbiter_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
-	"github.com/heketi/heketi/pkg/remoteexec/ssh"
+	"github.com/heketi/heketi/pkg/testutils"
 	"github.com/heketi/tests"
 )
 
@@ -262,6 +262,7 @@ func testArbiterCreateSimple(t *testing.T) {
 }
 
 func testArbiterCreateAndVerify(t *testing.T) {
+	na := testutils.RequireNodeAccess(t)
 	volReq := &api.VolumeCreateRequest{}
 	volReq.Size = 10
 	volReq.Durability.Type = api.DurabilityReplicate
@@ -272,8 +273,8 @@ func testArbiterCreateAndVerify(t *testing.T) {
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	// SSH into system and check that arbiter is really in use
-	s := ssh.NewSshExecWithKeyFile(
-		logger, "vagrant", "../config/insecure_private_key")
+	s := na.Use(logger)
+
 	cmd := []string{
 		fmt.Sprintf("gluster volume info %v | grep -q \"^Brick.* .arbiter.\"", vcr.Name),
 	}
@@ -288,6 +289,7 @@ func testArbiterCreateAndVerify(t *testing.T) {
 // Test that a volume not flagged for arbiter support does
 // not have arbiter tagging on gluster side.
 func testNonArbiterIsNotArbiter(t *testing.T) {
+	na := testutils.RequireNodeAccess(t)
 	volReq := &api.VolumeCreateRequest{}
 	volReq.Size = 10
 	volReq.Durability.Type = api.DurabilityReplicate
@@ -297,8 +299,8 @@ func testNonArbiterIsNotArbiter(t *testing.T) {
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	// SSH into system and check that arbiter is really in use
-	s := ssh.NewSshExecWithKeyFile(
-		logger, "vagrant", "../config/insecure_private_key")
+	s := na.Use(logger)
+
 	cmd := []string{
 		fmt.Sprintf("gluster volume info %v | grep -q \"^Brick.* .arbiter.\"", vcr.Name),
 	}
@@ -359,6 +361,7 @@ func testArbiterReplaceDataBrick(t *testing.T) {
 }
 
 func testArbiterReplaceArbiterBrick(t *testing.T) {
+	na := testutils.RequireNodeAccess(t)
 	volReq := &api.VolumeCreateRequest{}
 	volReq.Size = 10
 	volReq.Durability.Type = api.DurabilityReplicate
@@ -380,8 +383,8 @@ func testArbiterReplaceArbiterBrick(t *testing.T) {
 	}
 
 	// extra confirmation this is the arbiter brick
-	s := ssh.NewSshExecWithKeyFile(
-		logger, "vagrant", "../config/insecure_private_key")
+	s := na.Use(logger)
+
 	cmd := []string{
 		fmt.Sprintf("gluster volume info %v | grep \"^Brick.* .arbiter.\"", vcr.Name),
 	}
@@ -422,8 +425,8 @@ func testArbiterReplaceArbiterBrick(t *testing.T) {
 			"device still in use by volume", deviceId)
 	}
 
-	s = ssh.NewSshExecWithKeyFile(
-		logger, "vagrant", "../config/insecure_private_key")
+	s = na.Use(logger)
+
 	cmd = []string{
 		fmt.Sprintf("gluster volume info %v | grep \"^Brick.* .arbiter.\"", vcr.Name),
 	}
@@ -436,8 +439,9 @@ func testArbiterReplaceArbiterBrick(t *testing.T) {
 }
 
 func checkArbiterFormatting(t *testing.T, vol *api.VolumeInfoResponse) {
-	s := ssh.NewSshExecWithKeyFile(
-		logger, "vagrant", "../config/insecure_private_key")
+	na := testutils.RequireNodeAccess(t)
+	s := na.Use(logger)
+
 	re := regexp.MustCompile("(imaxpct=[0-9]+)")
 
 	r := sort.StringSlice{}

--- a/tests/functional/TestSmokeTest/tests/arbiter_test.go
+++ b/tests/functional/TestSmokeTest/tests/arbiter_test.go
@@ -277,7 +277,7 @@ func testArbiterCreateAndVerify(t *testing.T) {
 	cmd := []string{
 		fmt.Sprintf("gluster volume info %v | grep -q \"^Brick.* .arbiter.\"", vcr.Name),
 	}
-	_, err = s.ConnectAndExec(storage0ssh, cmd, 10, true)
+	_, err = s.ConnectAndExec(cenv.SshHost(0), cmd, 10, true)
 	tests.Assert(t, err == nil, "No bricks marked as arbiter")
 
 	vi, err := heketi.VolumeInfo(vcr.Id)
@@ -302,7 +302,7 @@ func testNonArbiterIsNotArbiter(t *testing.T) {
 	cmd := []string{
 		fmt.Sprintf("gluster volume info %v | grep -q \"^Brick.* .arbiter.\"", vcr.Name),
 	}
-	_, err = s.ConnectAndExec(storage0ssh, cmd, 10, true)
+	_, err = s.ConnectAndExec(cenv.SshHost(0), cmd, 10, true)
 	tests.Assert(t, err != nil, "Bricks marked as arbiter")
 }
 
@@ -385,7 +385,7 @@ func testArbiterReplaceArbiterBrick(t *testing.T) {
 	cmd := []string{
 		fmt.Sprintf("gluster volume info %v | grep \"^Brick.* .arbiter.\"", vcr.Name),
 	}
-	o, err := s.ConnectAndExec(storage0ssh, cmd, 10, true)
+	o, err := s.ConnectAndExec(cenv.SshHost(0), cmd, 10, true)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, strings.Contains(o[0], path),
 		"expected output to contain brick path",
@@ -427,7 +427,7 @@ func testArbiterReplaceArbiterBrick(t *testing.T) {
 	cmd = []string{
 		fmt.Sprintf("gluster volume info %v | grep \"^Brick.* .arbiter.\"", vcr.Name),
 	}
-	o, err = s.ConnectAndExec(storage0ssh, cmd, 10, true)
+	o, err = s.ConnectAndExec(cenv.SshHost(0), cmd, 10, true)
 	tests.Assert(t, !strings.Contains(o[0], path),
 		"expected output not to contain old brick path",
 		"output:", o, "path:", path)
@@ -444,7 +444,7 @@ func checkArbiterFormatting(t *testing.T, vol *api.VolumeInfoResponse) {
 	for _, b := range vol.Bricks {
 		ni, err := heketi.NodeInfo(b.NodeId)
 		tests.Assert(t, err == nil, "expected err == nil, got:", err)
-		host := ni.Hostnames.Manage[0] + ":" + portNum
+		host := ni.Hostnames.Manage[0] + ":" + cenv.SSHPort
 		cmd := fmt.Sprintf("xfs_info %v", b.Path)
 		o, err := s.ConnectAndExec(host, []string{cmd}, 10, true)
 		tests.Assert(t, err == nil, "expected err == nil, got:", err)

--- a/tests/functional/TestSmokeTest/tests/block_volume_test.go
+++ b/tests/functional/TestSmokeTest/tests/block_volume_test.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
-	"github.com/heketi/heketi/pkg/remoteexec/ssh"
+	"github.com/heketi/heketi/pkg/testutils"
 	"github.com/heketi/tests"
 )
 
@@ -138,6 +138,7 @@ func TestBlockVolumeCreateManyAtOnce(t *testing.T) {
 }
 
 func TestBlockVolumeAlreadyDeleted(t *testing.T) {
+	na := testutils.RequireNodeAccess(t)
 
 	// Setup the VM storage topology
 	setupCluster(t, 3, 4)
@@ -162,8 +163,8 @@ func TestBlockVolumeAlreadyDeleted(t *testing.T) {
 	host := cenv.SshHost(0)
 	cmd := fmt.Sprintf("gluster-block delete %v/%v --json",
 		hvol.Name, bvol.Name)
-	s := ssh.NewSshExecWithKeyFile(
-		logger, "vagrant", "../config/insecure_private_key")
+	s := na.Use(logger)
+
 	o, err := s.ConnectAndExec(host, []string{cmd}, 10, true)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, len(o) == 1, "expected len(o) == 1, got:", len(o))
@@ -173,6 +174,7 @@ func TestBlockVolumeAlreadyDeleted(t *testing.T) {
 }
 
 func TestBlockVolumeDeleteFailureConditions(t *testing.T) {
+	na := testutils.RequireNodeAccess(t)
 
 	// Setup the VM storage topology
 	setupCluster(t, 3, 4)
@@ -197,8 +199,8 @@ func TestBlockVolumeDeleteFailureConditions(t *testing.T) {
 	downHosts := []string{cenv.SshHost(1), cenv.SshHost(2)}
 
 	var cmds []string
-	s := ssh.NewSshExecWithKeyFile(
-		logger, "vagrant", "../config/insecure_private_key")
+	s := na.Use(logger)
+
 	stopServices := func(both bool) {
 		logger.Info("Stopping services for test")
 		for _, host := range downHosts {

--- a/tests/functional/TestSmokeTest/tests/block_volume_test.go
+++ b/tests/functional/TestSmokeTest/tests/block_volume_test.go
@@ -159,7 +159,7 @@ func TestBlockVolumeAlreadyDeleted(t *testing.T) {
 	hvol, err := heketi.VolumeInfo(bvol.BlockHostingVolume)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
-	host := storage0ssh
+	host := cenv.SshHost(0)
 	cmd := fmt.Sprintf("gluster-block delete %v/%v --json",
 		hvol.Name, bvol.Name)
 	s := ssh.NewSshExecWithKeyFile(
@@ -194,7 +194,7 @@ func TestBlockVolumeDeleteFailureConditions(t *testing.T) {
 	_, err = heketi.BlockVolumeInfo(bvol.Id)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
-	downHosts := []string{storage1ssh, storage2ssh}
+	downHosts := []string{cenv.SshHost(1), cenv.SshHost(2)}
 
 	var cmds []string
 	s := ssh.NewSshExecWithKeyFile(

--- a/tests/functional/TestSmokeTest/tests/delete_test.go
+++ b/tests/functional/TestSmokeTest/tests/delete_test.go
@@ -57,7 +57,7 @@ func testDeletedOnGluster(t *testing.T) {
 		fmt.Sprintf("gluster --mode=script volume stop %v", vcr.Name),
 		fmt.Sprintf("gluster --mode=script volume delete %v", vcr.Name),
 	}
-	_, err := s.ConnectAndExec(storage0ssh, cmds, 10, true)
+	_, err := s.ConnectAndExec(cenv.SshHost(0), cmds, 10, true)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	err = heketi.VolumeDelete(vcr.Id)
@@ -74,7 +74,7 @@ func testDeletedUnmountedBrick(t *testing.T) {
 		fmt.Sprintf("gluster --mode=script volume stop %v", vcr.Name),
 		fmt.Sprintf("gluster --mode=script volume delete %v", vcr.Name),
 	}
-	o, err := s.ConnectAndExec(storage0ssh, cmds, 10, true)
+	o, err := s.ConnectAndExec(cenv.SshHost(0), cmds, 10, true)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, len(o) >= 1)
 	var host, brickPath string
@@ -90,7 +90,7 @@ func testDeletedUnmountedBrick(t *testing.T) {
 	cmds = []string{
 		fmt.Sprintf("umount %v", strings.TrimSuffix(brickPath, "/brick")),
 	}
-	_, err = s.ConnectAndExec(host+":"+portNum, cmds, 10, true)
+	_, err = s.ConnectAndExec(host+":"+cenv.SSHPort, cmds, 10, true)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	err = heketi.VolumeDelete(vcr.Id)
@@ -107,7 +107,7 @@ func testDeletedBrickPv(t *testing.T) {
 		fmt.Sprintf("gluster --mode=script volume stop %v", vcr.Name),
 		fmt.Sprintf("gluster --mode=script volume delete %v", vcr.Name),
 	}
-	o, err := s.ConnectAndExec(storage0ssh, cmds, 10, true)
+	o, err := s.ConnectAndExec(cenv.SshHost(0), cmds, 10, true)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, len(o) >= 1)
 	var host, brickPath string
@@ -124,7 +124,7 @@ func testDeletedBrickPv(t *testing.T) {
 		fmt.Sprintf("umount %v", strings.TrimSuffix(brickPath, "/brick")),
 		"lvs --noheadings --sep / -o vg_name,lv_name | grep vg_ | xargs -L1 echo lvremove -f",
 	}
-	_, err = s.ConnectAndExec(host+":"+portNum, cmds, 10, true)
+	_, err = s.ConnectAndExec(host+":"+cenv.SSHPort, cmds, 10, true)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	err = heketi.VolumeDelete(vcr.Id)

--- a/tests/functional/TestSmokeTest/tests/delete_test.go
+++ b/tests/functional/TestSmokeTest/tests/delete_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
-	"github.com/heketi/heketi/pkg/remoteexec/ssh"
+	"github.com/heketi/heketi/pkg/testutils"
 	"github.com/heketi/tests"
 )
 
@@ -49,10 +49,11 @@ func testDeleteNormal(t *testing.T) {
 }
 
 func testDeletedOnGluster(t *testing.T) {
+	na := testutils.RequireNodeAccess(t)
 	vcr := testPrepareVolume(t)
 
-	s := ssh.NewSshExecWithKeyFile(
-		logger, "vagrant", "../config/insecure_private_key")
+	s := na.Use(logger)
+
 	cmds := []string{
 		fmt.Sprintf("gluster --mode=script volume stop %v", vcr.Name),
 		fmt.Sprintf("gluster --mode=script volume delete %v", vcr.Name),
@@ -65,10 +66,11 @@ func testDeletedOnGluster(t *testing.T) {
 }
 
 func testDeletedUnmountedBrick(t *testing.T) {
+	na := testutils.RequireNodeAccess(t)
 	vcr := testPrepareVolume(t)
 
-	s := ssh.NewSshExecWithKeyFile(
-		logger, "vagrant", "../config/insecure_private_key")
+	s := na.Use(logger)
+
 	cmds := []string{
 		fmt.Sprintf("gluster --mode=script volume info %v", vcr.Name),
 		fmt.Sprintf("gluster --mode=script volume stop %v", vcr.Name),
@@ -98,10 +100,11 @@ func testDeletedUnmountedBrick(t *testing.T) {
 }
 
 func testDeletedBrickPv(t *testing.T) {
+	na := testutils.RequireNodeAccess(t)
 	vcr := testPrepareVolume(t)
 
-	s := ssh.NewSshExecWithKeyFile(
-		logger, "vagrant", "../config/insecure_private_key")
+	s := na.Use(logger)
+
 	cmds := []string{
 		fmt.Sprintf("gluster --mode=script volume info %v", vcr.Name),
 		fmt.Sprintf("gluster --mode=script volume stop %v", vcr.Name),

--- a/tests/functional/TestSmokeTest/tests/heketi_test.go
+++ b/tests/functional/TestSmokeTest/tests/heketi_test.go
@@ -161,6 +161,7 @@ func TestHeketiSmokeTest(t *testing.T) {
 }
 
 func HeketiCreateVolumeWithGid(t *testing.T) {
+	na := testutils.RequireNodeAccess(t)
 	// Setup the VM storage topology
 	teardownCluster(t)
 	setupCluster(t, 4, 8)
@@ -182,7 +183,7 @@ func HeketiCreateVolumeWithGid(t *testing.T) {
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	// SSH into system and create two writers belonging to writegroup gid
-	vagrantexec := ssh.NewSshExecWithKeyFile(logger, "vagrant", "../config/insecure_private_key")
+	vagrantexec := na.Use(logger)
 	cmd := []string{
 		"sudo groupadd writegroup",
 		"sudo useradd writer1 -G writegroup -p'$6$WBG5yf03$3DvyE41cicXEZDW.HDeJg3S4oEoELqKWoS/n6l28vorNxhIlcBe2SLQFDhqq6.Pq'",
@@ -392,6 +393,7 @@ func TestRemoveDeviceVsVolumeCreate(t *testing.T) {
 }
 
 func TestHeketiVolumeExpandWithGid(t *testing.T) {
+	na := testutils.RequireNodeAccess(t)
 	// Setup the VM storage topology
 	teardownCluster(t)
 	setupCluster(t, 3, 8)
@@ -421,7 +423,7 @@ func TestHeketiVolumeExpandWithGid(t *testing.T) {
 	tests.Assert(t, newVolInfo.Size == volInfo.Size+300)
 
 	// SSH into system and check gid of bricks
-	vagrantexec := ssh.NewSshExecWithKeyFile(logger, "vagrant", "../config/insecure_private_key")
+	vagrantexec := na.Use(logger)
 	cmd := []string{
 		fmt.Sprintf("sudo ls -l /var/lib/heketi/mounts/vg_*/brick_*/  | grep  -e \"^d\" | cut -d\" \" -f4 | grep -q %v", volReq.Gid),
 	}
@@ -434,6 +436,7 @@ func TestHeketiVolumeExpandWithGid(t *testing.T) {
 }
 
 func TestHeketiVolumeCreateWithOptions(t *testing.T) {
+	na := testutils.RequireNodeAccess(t)
 	// Setup the VM storage topology
 	teardownCluster(t)
 	setupCluster(t, 2, 2)
@@ -457,7 +460,7 @@ func TestHeketiVolumeCreateWithOptions(t *testing.T) {
 	tests.Assert(t, len(volInfo.GlusterVolumeOptions) > 0)
 
 	// SSH into system and check volume options.
-	vagrantexec := ssh.NewSshExecWithKeyFile(logger, "vagrant", "../config/insecure_private_key")
+	vagrantexec := na.Use(logger)
 	cmd := []string{
 		fmt.Sprintf("sudo gluster v info %v | grep performance.rda-cache-limit | grep 10MB", volInfo.Name),
 	}
@@ -467,6 +470,7 @@ func TestHeketiVolumeCreateWithOptions(t *testing.T) {
 }
 
 func TestDeviceRemoveErrorHandling(t *testing.T) {
+	na := testutils.RequireNodeAccess(t)
 	teardownCluster(t)
 	setupCluster(t, 2, 2)
 	defer teardownCluster(t)
@@ -491,8 +495,7 @@ func TestDeviceRemoveErrorHandling(t *testing.T) {
 
 	// place a dummy pv on the vg so that a clean vg remove is not possible
 	host := nodeInfo.Hostnames.Manage[0] + ":" + cenv.SSHPort
-	s := ssh.NewSshExecWithKeyFile(
-		logger, "vagrant", "../config/insecure_private_key")
+	s := na.Use(logger)
 
 	cmds := []string{
 		"lvcreate -qq --autobackup=n --size 1024K --name TEST vg_" + deviceInfo.Id,
@@ -516,6 +519,7 @@ func TestDeviceRemoveErrorHandling(t *testing.T) {
 }
 
 func TestDeviceRemoveForceForget(t *testing.T) {
+	na := testutils.RequireNodeAccess(t)
 	teardownCluster(t)
 	setupCluster(t, 2, 2)
 	defer teardownCluster(t)
@@ -540,8 +544,7 @@ func TestDeviceRemoveForceForget(t *testing.T) {
 
 	// place a dummy pv on the vg so that a clean vg remove is not possible
 	host := nodeInfo.Hostnames.Manage[0] + ":" + cenv.SSHPort
-	s := ssh.NewSshExecWithKeyFile(
-		logger, "vagrant", "../config/insecure_private_key")
+	s := na.Use(logger)
 
 	cmds := []string{
 		"lvcreate -qq --autobackup=n --size 1024K --name TEST vg_" + deviceInfo.Id,

--- a/tests/functional/TestSmokeTest/tests/heketi_test.go
+++ b/tests/functional/TestSmokeTest/tests/heketi_test.go
@@ -13,231 +13,57 @@ package functional
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"testing"
 
 	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/logging"
 	"github.com/heketi/heketi/pkg/remoteexec/ssh"
+	"github.com/heketi/heketi/pkg/testutils"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/heketi/tests"
 )
 
 var (
-	// The heketi server must be running on the host
+	// Heketi client params
 	heketiUrl = "http://localhost:8080"
+	heketi    = client.NewClientNoAuth(heketiUrl)
 
-	// VMs
-	storage0    = "192.168.10.100"
-	storage1    = "192.168.10.101"
-	storage2    = "192.168.10.102"
-	storage3    = "192.168.10.103"
-	portNum     = "22"
-	storage0ssh = storage0 + ":" + portNum
-	storage1ssh = storage1 + ":" + portNum
-	storage2ssh = storage2 + ":" + portNum
-	storage3ssh = storage3 + ":" + portNum
-
-	// Heketi client
-	heketi = client.NewClientNoAuth(heketiUrl)
-	logger = logging.NewLogger("[test]", logging.LEVEL_DEBUG)
-
-	// Storage systems
-	storagevms = []string{
-		storage0,
-		storage1,
-		storage2,
-		storage3,
-	}
-
-	// Disks on each system
-	disks = []string{
-		"/dev/vdb",
-		"/dev/vdc",
-		"/dev/vdd",
-		"/dev/vde",
-
-		"/dev/vdf",
-		"/dev/vdg",
-		"/dev/vdh",
-		"/dev/vdi",
-	}
-)
-
-func setupCluster(t *testing.T, numNodes int, numDisks int) {
-	tests.Assert(t, heketi != nil)
-
-	// Get ssh port first, we need it to create
-	// storageXssh variables
-	env := os.Getenv("HEKETI_TEST_STORAGEPORT")
-	if "" != env {
-		portNum = env
-	}
-
-	env = os.Getenv("HEKETI_TEST_STORAGE0")
-	if "" != env {
-		storage0 = env
-		storage0ssh = storage0 + ":" + portNum
-	}
-	env = os.Getenv("HEKETI_TEST_STORAGE1")
-	if "" != env {
-		storage1 = env
-		storage1ssh = storage1 + ":" + portNum
-	}
-	env = os.Getenv("HEKETI_TEST_STORAGE2")
-	if "" != env {
-		storage2 = env
-		storage2ssh = storage2 + ":" + portNum
-	}
-	env = os.Getenv("HEKETI_TEST_STORAGE3")
-	if "" != env {
-		storage3 = env
-		storage3ssh = storage3 + ":" + portNum
-	}
-
-	// As a testing invariant, we always expect to set up a cluster
-	// at the start of a test on a _clean_ server.
-	// Verify that there are no outstanding operations on the
-	// server. A test that needs to mess with the operations _must_
-	// clean up after itself.
-	oi, err := heketi.OperationsInfo()
-	tests.Assert(t, err == nil, "expected err == nil, got:", err)
-	tests.Assert(t, oi.Total == 0, "expected oi.Total == 0, got", oi.Total)
-	tests.Assert(t, oi.InFlight == 0, "expected oi.InFlight == 0, got", oi.Total)
-
-	// Storage systems
-	storagevms = []string{
-		storage0,
-		storage1,
-		storage2,
-		storage3,
-	}
-	// Create a cluster
-	cluster_req := &api.ClusterCreateRequest{
-		ClusterFlags: api.ClusterFlags{
-			Block: true,
-			File:  true,
+	cenv = &testutils.ClusterEnv{
+		HeketiUrl: heketiUrl,
+		Nodes: []string{
+			"192.168.10.100",
+			"192.168.10.101",
+			"192.168.10.102",
+			"192.168.10.103",
+		},
+		SSHPort: "22",
+		Disks: []string{
+			"/dev/vdb",
+			"/dev/vdc",
+			"/dev/vdd",
+			"/dev/vde",
+			"/dev/vdf",
+			"/dev/vdg",
+			"/dev/vdh",
+			"/dev/vdi",
 		},
 	}
 
-	cluster, err := heketi.ClusterCreate(cluster_req)
-	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	logger = logging.NewLogger("[test]", logging.LEVEL_DEBUG)
+)
 
-	// hardcoded limits from the lists above
-	// possible TODO: generalize
-	tests.Assert(t, numNodes <= 4)
-	tests.Assert(t, numDisks <= 8)
-
-	// Add nodes
-	for index, hostname := range storagevms[:numNodes] {
-		nodeReq := &api.NodeAddRequest{}
-		nodeReq.ClusterId = cluster.Id
-		nodeReq.Hostnames.Manage = []string{hostname}
-		nodeReq.Hostnames.Storage = []string{hostname}
-		nodeReq.Zone = index%2 + 1
-
-		node, err := heketi.NodeAdd(nodeReq)
-		tests.Assert(t, err == nil, "expected err == nil, got:", err)
-
-		// Add devices
-		sg := utils.NewStatusGroup()
-		for _, disk := range disks[:numDisks] {
-			sg.Add(1)
-			go func(d string) {
-				defer sg.Done()
-
-				driveReq := &api.DeviceAddRequest{}
-				driveReq.Name = d
-				driveReq.NodeId = node.Id
-
-				err := heketi.DeviceAdd(driveReq)
-				sg.Err(err)
-			}(disk)
-		}
-
-		err = sg.Result()
-		tests.Assert(t, err == nil, "expected err == nil, got:", err)
-	}
+func setupCluster(t *testing.T, numNodes int, numDisks int) {
+	cenv.Update()
+	cenv.Setup(t, numNodes, numDisks)
 }
 
 func dbStateDump(t *testing.T) {
-	if t.Failed() {
-		fmt.Println("~~~~~ dumping db state prior to teardown ~~~~~")
-		dump, err := heketi.DbDump()
-		if err != nil {
-			fmt.Printf("Unable to get db dump: %v\n", err)
-		} else {
-			fmt.Printf("\n%v\n", dump)
-		}
-		fmt.Println("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-	}
+	cenv.StateDump(t)
 }
 
 func teardownCluster(t *testing.T) {
-	fmt.Println("~~~ tearing down cluster")
-	dbStateDump(t)
-
-	clusters, err := heketi.ClusterList()
-	tests.Assert(t, err == nil, err)
-
-	for _, cluster := range clusters.Clusters {
-
-		clusterInfo, err := heketi.ClusterInfo(cluster)
-		tests.Assert(t, err == nil, "expected err == nil, got:", err)
-
-		// Delete volumes in this cluster
-		for _, volume := range clusterInfo.Volumes {
-			err := heketi.VolumeDelete(volume)
-			tests.Assert(t, err == nil, "expected err == nil, got:", err)
-		}
-
-		// Delete nodes
-		for _, node := range clusterInfo.Nodes {
-
-			// Get node information
-			nodeInfo, err := heketi.NodeInfo(node)
-			tests.Assert(t, err == nil, "expected err == nil, got:", err)
-
-			// Delete each device
-			sg := utils.NewStatusGroup()
-			for _, device := range nodeInfo.DevicesInfo {
-				sg.Add(1)
-				go func(id string) {
-					defer sg.Done()
-
-					stateReq := &api.StateRequest{}
-					stateReq.State = api.EntryStateOffline
-					err := heketi.DeviceState(id, stateReq)
-					if err != nil {
-						sg.Err(err)
-						return
-					}
-
-					stateReq.State = api.EntryStateFailed
-					err = heketi.DeviceState(id, stateReq)
-					if err != nil {
-						sg.Err(err)
-						return
-					}
-
-					err = heketi.DeviceDelete(id)
-					sg.Err(err)
-
-				}(device.Id)
-			}
-			err = sg.Result()
-			tests.Assert(t, err == nil, "expected err == nil, got:", err)
-
-			// Delete node
-			err = heketi.NodeDelete(node)
-			tests.Assert(t, err == nil, "expected err == nil, got:", err)
-		}
-
-		// Delete cluster
-		err = heketi.ClusterDelete(cluster)
-		tests.Assert(t, err == nil, "expected err == nil, got:", err)
-	}
+	cenv.Teardown(t)
 }
 
 func TestConnection(t *testing.T) {
@@ -363,7 +189,7 @@ func HeketiCreateVolumeWithGid(t *testing.T) {
 		"sudo useradd writer2 -G writegroup -p'$6$WBG5yf03$3DvyE41cicXEZDW.HDeJg3S4oEoELqKWoS/n6l28vorNxhIlcBe2SLQFDhqq6.Pq'",
 		fmt.Sprintf("sudo mount -t glusterfs %v /mnt", volInfo.Mount.GlusterFS.MountPoint),
 	}
-	_, err = vagrantexec.ConnectAndExec(storage0ssh, cmd, 10, true)
+	_, err = vagrantexec.ConnectAndExec(cenv.SshHost(0), cmd, 10, true)
 	tests.Assert(t, err == nil, err)
 
 	writer1exec := ssh.NewSshExecWithPassword(logger, "writer1", "$6$WBG5yf03$3DvyE41cicXEZDW.HDeJg3S4oEoELqKWoS/n6l28vorNxhIlcBe2SLQFDhqq6.Pq")
@@ -372,7 +198,7 @@ func HeketiCreateVolumeWithGid(t *testing.T) {
 		"mkdir /mnt/writer1dir",
 		"touch /mnt/writer1dir/testfile",
 	}
-	_, err = writer1exec.ConnectAndExec(storage0ssh, cmd, 10, false)
+	_, err = writer1exec.ConnectAndExec(cenv.SshHost(0), cmd, 10, false)
 	tests.Assert(t, err == nil, err)
 
 	writer2exec := ssh.NewSshExecWithPassword(logger, "writer2", "$6$WBG5yf03$3DvyE41cicXEZDW.HDeJg3S4oEoELqKWoS/n6l28vorNxhIlcBe2SLQFDhqq6.Pq")
@@ -381,13 +207,13 @@ func HeketiCreateVolumeWithGid(t *testing.T) {
 		"mkdir /mnt/writer2dir",
 		"touch /mnt/writer2dir/testfile",
 	}
-	_, err = writer2exec.ConnectAndExec(storage0ssh, cmd, 10, false)
+	_, err = writer2exec.ConnectAndExec(cenv.SshHost(0), cmd, 10, false)
 	tests.Assert(t, err == nil, err)
 	cmd = []string{
 		"mkdir /mnt/writer1dir/writer2subdir",
 		"touch /mnt/writer1dir/writer2testfile",
 	}
-	_, err = writer2exec.ConnectAndExec(storage0ssh, cmd, 10, false)
+	_, err = writer2exec.ConnectAndExec(cenv.SshHost(0), cmd, 10, false)
 	tests.Assert(t, err == nil, err)
 
 }
@@ -460,7 +286,7 @@ func TestRemoveDevice(t *testing.T) {
 
 	// Add a replacement disk
 	driveReq := &api.DeviceAddRequest{}
-	driveReq.Name = disks[2]
+	driveReq.Name = cenv.Disks[2]
 	driveReq.NodeId = diskNode
 	err = heketi.DeviceAdd(driveReq)
 	tests.Assert(t, err == nil, err)
@@ -599,11 +425,11 @@ func TestHeketiVolumeExpandWithGid(t *testing.T) {
 	cmd := []string{
 		fmt.Sprintf("sudo ls -l /var/lib/heketi/mounts/vg_*/brick_*/  | grep  -e \"^d\" | cut -d\" \" -f4 | grep -q %v", volReq.Gid),
 	}
-	_, err = vagrantexec.ConnectAndExec(storage0ssh, cmd, 10, true)
+	_, err = vagrantexec.ConnectAndExec(cenv.SshHost(0), cmd, 10, true)
 	tests.Assert(t, err == nil, "Brick found with different Gid")
-	_, err = vagrantexec.ConnectAndExec(storage1ssh, cmd, 10, true)
+	_, err = vagrantexec.ConnectAndExec(cenv.SshHost(1), cmd, 10, true)
 	tests.Assert(t, err == nil, "Brick found with different Gid")
-	_, err = vagrantexec.ConnectAndExec(storage2ssh, cmd, 10, true)
+	_, err = vagrantexec.ConnectAndExec(cenv.SshHost(2), cmd, 10, true)
 	tests.Assert(t, err == nil, "Brick found with different Gid")
 }
 
@@ -635,7 +461,7 @@ func TestHeketiVolumeCreateWithOptions(t *testing.T) {
 	cmd := []string{
 		fmt.Sprintf("sudo gluster v info %v | grep performance.rda-cache-limit | grep 10MB", volInfo.Name),
 	}
-	_, err = vagrantexec.ConnectAndExec(storage0ssh, cmd, 10, true)
+	_, err = vagrantexec.ConnectAndExec(cenv.SshHost(0), cmd, 10, true)
 	tests.Assert(t, err == nil, "Volume Created with specified options")
 
 }
@@ -664,7 +490,7 @@ func TestDeviceRemoveErrorHandling(t *testing.T) {
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	// place a dummy pv on the vg so that a clean vg remove is not possible
-	host := nodeInfo.Hostnames.Manage[0] + ":" + portNum
+	host := nodeInfo.Hostnames.Manage[0] + ":" + cenv.SSHPort
 	s := ssh.NewSshExecWithKeyFile(
 		logger, "vagrant", "../config/insecure_private_key")
 
@@ -713,7 +539,7 @@ func TestDeviceRemoveForceForget(t *testing.T) {
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	// place a dummy pv on the vg so that a clean vg remove is not possible
-	host := nodeInfo.Hostnames.Manage[0] + ":" + portNum
+	host := nodeInfo.Hostnames.Manage[0] + ":" + cenv.SSHPort
 	s := ssh.NewSshExecWithKeyFile(
 		logger, "vagrant", "../config/insecure_private_key")
 

--- a/tests/functional/TestVolumeNotDeletedWhenNodeIsDown/tests/heketi_test.go
+++ b/tests/functional/TestVolumeNotDeletedWhenNodeIsDown/tests/heketi_test.go
@@ -18,7 +18,7 @@ import (
 	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/logging"
-	"github.com/heketi/heketi/pkg/remoteexec/ssh"
+	"github.com/heketi/heketi/pkg/testutils"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/heketi/tests"
 )
@@ -240,6 +240,7 @@ func TestConnection(t *testing.T) {
 }
 
 func TestVolumeNotDeletedWhenNodeIsDown(t *testing.T) {
+	na := testutils.RequireNodeAccess(t)
 
 	// Setup the VM storage topology
 	teardownCluster(t)
@@ -255,7 +256,7 @@ func TestVolumeNotDeletedWhenNodeIsDown(t *testing.T) {
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	// SSH into one system and power it off
-	exec := ssh.NewSshExecWithKeyFile(logger, "vagrant", "../config/insecure_private_key")
+	exec := na.Use(logger)
 
 	// Turn off glusterd
 	cmd := []string{"service glusterd stop"}

--- a/tests/functional/TestVolumeSnapshotBehavior/tests/heketi_test.go
+++ b/tests/functional/TestVolumeSnapshotBehavior/tests/heketi_test.go
@@ -17,7 +17,7 @@ import (
 	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/logging"
-	"github.com/heketi/heketi/pkg/remoteexec/ssh"
+	"github.com/heketi/heketi/pkg/testutils"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/heketi/tests"
 )
@@ -239,6 +239,7 @@ func TestConnection(t *testing.T) {
 }
 
 func TestHeketiVolumeSnapshotBehavior(t *testing.T) {
+	na := testutils.RequireNodeAccess(t)
 
 	// Setup the VM storage topology
 	teardownCluster(t)
@@ -257,7 +258,7 @@ func TestHeketiVolumeSnapshotBehavior(t *testing.T) {
 	tests.Assert(t, err == nil, err)
 
 	// SSH into system and execute gluster command to create a snapshot
-	exec := ssh.NewSshExecWithKeyFile(logger, "vagrant", "../config/insecure_private_key")
+	exec := na.Use(logger)
 	cmd := []string{
 		fmt.Sprintf("sudo gluster --mode=script snapshot create mysnap %v no-timestamp", volInfo.Name),
 		"sudo gluster --mode=script snapshot activate mysnap",


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

To avoid future copy and paste of test code this PR moves and refactors code that should be reusable across golang functional test packages.

Right now the packages provides two features, one per file:
* Heketi server management for tests that need to stop and start heketi themselves
* Cluster setup and teardown based on the "smoke test" directory

### Notes for the reviewer

For now I've let the some of the commits demonstrate what was changed from when the code was copied from the uniqe source file. This may need to be squashed.

