### PR TITLE
apps:glusterfs fix logger format for go 1.11

### DIFF
--- a/apps/glusterfs/device_entry.go
+++ b/apps/glusterfs/device_entry.go
@@ -581,7 +581,7 @@ func (d *DeviceEntry) DeleteBricksWithEmptyPath(tx *bolt.Tx) error {
 		brick, err := NewBrickEntryFromId(tx, id)
 		if err == ErrNotFound {
 			logger.Warning("Ignoring nonexistent brick [%v] on "+
-				"disk [%d].", id, d.Info.Id)
+				"disk [%v].", id, d.Info.Id)
 			continue
 		}
 		if err != nil {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?

DeviceInfo.Id is actually a string, which makes the %d formatter an error with upcoming go 1.11.
Use %v for consistency.

### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #


### Notes for the reviewer


