### PR TITLE
Fix handling failures during block volume create rollback

### DIFF
--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -233,8 +233,10 @@ func (v *BlockVolumeEntry) cleanupBlockVolumeCreate(db wdb.DB,
 		return err
 	}
 
-	// best effort removal of anything on system
-	v.deleteBlockVolumeExec(db, hvname, executor)
+	err = v.deleteBlockVolumeExec(db, hvname, executor)
+	if err != nil {
+		return err
+	}
 
 	return v.removeComponents(db, true)
 }


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

By failing to pass on the error conditions when trying to remove a failed
block volume creation we hide the error from the operations framework
which causes it to remove the pending operation entry and we lose
valuable debugging information and the ability to possibly automatically
revert the operation later.


### Does this PR fix issues?

Fixes #1324 



