### PR TITLE
apps: prevent overuse of block hosting volumes

### DIFF
--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -238,7 +238,7 @@ func (v *BlockVolumeEntry) cleanupBlockVolumeCreate(db wdb.DB,
 		return err
 	}
 
-	return v.removeComponents(db, true)
+	return v.removeComponents(db, false)
 }
 
 func (v *BlockVolumeEntry) Create(db wdb.DB,
@@ -249,7 +249,7 @@ func (v *BlockVolumeEntry) Create(db wdb.DB,
 		executor)
 }
 
-func (v *BlockVolumeEntry) saveCreateBlockVolume(db wdb.DB) error {
+func (v *BlockVolumeEntry) saveNewEntry(db wdb.DB) error {
 	return db.Update(func(tx *bolt.Tx) error {
 
 		err := v.Save(tx)
@@ -277,6 +277,8 @@ func (v *BlockVolumeEntry) saveCreateBlockVolume(db wdb.DB) error {
 		if err := volume.ModifyFreeSize(-v.Info.Size); err != nil {
 			return err
 		}
+		logger.Debug("Reduced free size on volume %v by %v",
+			volume.Info.Id, v.Info.Size)
 
 		volume.BlockVolumeAdd(v.Info.Id)
 		err = volume.Save(tx)


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Previously, block volumes were only reducing the free space from the
Block Hosting volumes in the Finalize step of the operation. This was
incorrect behavior because it meant that Heketi could allow two
concurrent block volume creations to essentially occupy the same free
space. Then one of the operations would fail during the Exec phase,
with a no-space error in gluster-block.

Patches in this series, change the operation so that block volumes are
esablished in the Build phase of the operation along with updating the free space 
n the hosting volume. A unit test is added to verify the low level behavior of the operation
as well as a functional test to check the interaction with gluster-block.
Both tests fail without the initial patch in the series.

### Does this PR fix issues?

Fixes [rhbz#1619017](https://bugzilla.redhat.com/show_bug.cgi?id=1619017)


### Notes for the reviewer

This patch series should be considered along with PR #1325 which is needed to prevent the space being incorrectly returned to the block hosting volume if rollback of the block volume fails.