### PR TITLE
Revert "[RFC] stop testing go 1.7.5 as part of travis ci"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ git:
   depth: 9999999
 matrix:
   include:
+  - go: 1.7.5
+    env: COVERAGE="true"
   - go: 1.8.2
     env: COVERAGE="true"
   - go: 1.9.4


### PR DESCRIPTION
Reverts heketi/heketi#1326

It was merged prematurely. Sorry for the inconvenience...