### PR TITLE
Add volume protection option

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -490,6 +490,13 @@ func (a *App) SetRoutes(router *mux.Router) error {
 			Pattern:     "/volumes/{id:[A-Fa-f0-9]+}/block-restriction",
 			HandlerFunc: a.VolumeSetBlockRestriction},
 
+		// Volume Protection
+		rest.Route{
+			Name:        "VolumeProtect",
+			Method:      "POST",
+			Pattern:     "/volumes/{id:[A-Fa-f0-9]+}/protect",
+			HandlerFunc: a.VolumeProtect},
+
 		// Volume Cloning
 		rest.Route{
 			Name:        "VolumeClone",

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -190,6 +190,7 @@ func NewVolumeEntryFromClone(v *VolumeEntry, name string) *VolumeEntry {
 	entry.Info.Mount = v.Info.Mount
 	entry.Info.Size = v.Info.Size
 	entry.Info.Snapshot = v.Info.Snapshot
+	entry.Info.Protected = v.Info.Protected
 	copy(entry.Info.Mount.GlusterFS.Hosts, v.Info.Mount.GlusterFS.Hosts)
 	entry.Info.Mount.GlusterFS.MountPoint = v.Info.Mount.GlusterFS.Hosts[0] + ":" + entry.Info.Name
 	entry.Info.Mount.GlusterFS.Options = v.Info.Mount.GlusterFS.Options
@@ -229,6 +230,7 @@ func (v *VolumeEntry) NewInfoResponse(tx *bolt.Tx) (*api.VolumeInfoResponse, err
 	info.GlusterVolumeOptions = v.GlusterVolumeOptions
 	info.Block = v.Info.Block
 	info.BlockInfo = v.Info.BlockInfo
+	info.Protected = v.Info.Protected
 
 	for _, brickid := range v.BricksIds() {
 		brick, err := NewBrickEntryFromId(tx, brickid)

--- a/client/api/go-client/volume.go
+++ b/client/api/go-client/volume.go
@@ -288,6 +288,47 @@ func (c *Client) VolumeDelete(id string) error {
 	return nil
 }
 
+func (c *Client) VolumeProtect(id string, request *api.VolumeProtectRequest) (*api.VolumeInfoResponse, error) {
+
+	// Marshal request to JSON
+	buffer, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create request
+	req, err := http.NewRequest("POST", c.host+"/volumes/"+id+"/protect", bytes.NewBuffer(buffer))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Set token
+	err = c.setToken(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get info
+	r, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		return nil, utils.GetErrorFromResponse(r)
+	}
+
+	// Read JSON response
+	var volume api.VolumeInfoResponse
+	err = utils.GetJsonFromResponse(r, &volume)
+	if err != nil {
+		return nil, err
+	}
+
+	return &volume, nil
+}
+
 func (c *Client) VolumeClone(id string, request *api.VolumeCloneRequest) (*api.VolumeInfoResponse, error) {
 	// Marshal request to JSON
 	buffer, err := json.Marshal(request)

--- a/client/cli/go/cmds/volume.go
+++ b/client/cli/go/cmds/volume.go
@@ -48,6 +48,8 @@ func init() {
 	volumeCommand.AddCommand(volumeInfoCommand)
 	volumeCommand.AddCommand(volumeListCommand)
 	volumeCommand.AddCommand(volumeBlockHostingRestrictionCommand)
+	volumeCommand.AddCommand(volumeProtectCommand)
+	volumeCommand.AddCommand(volumeUnprotectCommand)
 	volumeBlockHostingRestrictionCommand.AddCommand(volumeBlockHostingRestrictionUnlockCommand)
 	volumeBlockHostingRestrictionCommand.AddCommand(volumeBlockHostingRestrictionLockCommand)
 
@@ -101,6 +103,8 @@ func init() {
 	volumeDeleteCommand.SilenceUsage = true
 	volumeExpandCommand.SilenceUsage = true
 	volumeInfoCommand.SilenceUsage = true
+	volumeProtectCommand.SilenceUsage = true
+	volumeUnprotectCommand.SilenceUsage = true
 	volumeListCommand.SilenceUsage = true
 	volumeBlockHostingRestrictionCommand.SilenceUsage = true
 
@@ -504,6 +508,92 @@ var volumeListCommand = &cobra.Command{
 		}
 
 		return nil
+	},
+}
+
+var volumeProtectCommand = &cobra.Command{
+	Use:     "protect",
+	Short:   "Protects a volume from deletion",
+	Long:    "Protects a volume from deletion",
+	Example: "  $ heketi-cli volume protect 60d46d518074b13a04ce1022c8c7193c",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		//ensure proper number of args
+		s := cmd.Flags().Args()
+		if len(s) < 1 {
+			return errors.New("Volume id missing")
+		}
+
+		// Set volume id
+		volumeId := cmd.Flags().Arg(0)
+
+		// Create a client to talk to Heketi
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
+		// Create request
+		req := &api.VolumeProtectRequest{true}
+
+		// Protect volume
+		info, err := heketi.VolumeProtect(volumeId, req)
+		if err != nil {
+			return err
+		}
+
+		if options.Json {
+			data, err := json.Marshal(info)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(stdout, string(data))
+		} else {
+			fmt.Fprintf(stdout, "%v", info)
+		}
+		return nil
+
+	},
+}
+
+var volumeUnprotectCommand = &cobra.Command{
+	Use:     "unprotect",
+	Short:   "Unprotects a volume from deletion",
+	Long:    "Unprotects a volume from deletion",
+	Example: "  $ heketi-cli volume unprotect 60d46d518074b13a04ce1022c8c7193c",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		//ensure proper number of args
+		s := cmd.Flags().Args()
+		if len(s) < 1 {
+			return errors.New("Volume id missing")
+		}
+
+		// Set volume id
+		volumeId := cmd.Flags().Arg(0)
+
+		// Create a client to talk to Heketi
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
+		// Create request
+		req := &api.VolumeProtectRequest{false}
+
+		// Protect volume
+		info, err := heketi.VolumeProtect(volumeId, req)
+		if err != nil {
+			return err
+		}
+
+		if options.Json {
+			data, err := json.Marshal(info)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(stdout, string(data))
+		} else {
+			fmt.Fprintf(stdout, "%v", info)
+		}
+		return nil
+
 	},
 }
 

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -326,9 +326,10 @@ func (br BlockRestriction) String() string {
 
 type VolumeInfo struct {
 	VolumeCreateRequest
-	Id      string `json:"id"`
-	Cluster string `json:"cluster"`
-	Mount   struct {
+	Id        string `json:"id"`
+	Cluster   string `json:"cluster"`
+	Protected bool   `json:"protected"`
+	Mount     struct {
 		GlusterFS struct {
 			Hosts      []string          `json:"hosts"`
 			MountPoint string            `json:"device"`
@@ -370,6 +371,10 @@ func (vcr VolumeCloneRequest) Validate() error {
 	return validation.ValidateStruct(&vcr,
 		validation.Field(&vcr.Name, validation.Match(volumeNameRe)),
 	)
+}
+
+type VolumeProtectRequest struct {
+	Protect bool `json:"protect"`
 }
 
 type VolumeBlockRestrictionRequest struct {
@@ -506,7 +511,8 @@ func (v *VolumeInfoResponse) String() string {
 		"Reserved Size: %v\n"+
 		"Block Hosting Restriction: %v\n"+
 		"Block Volumes: %v\n"+
-		"Durability Type: %v\n",
+		"Durability Type: %v\n"+
+		"Protected: %v\n",
 		v.Name,
 		v.Size,
 		v.Id,
@@ -518,7 +524,9 @@ func (v *VolumeInfoResponse) String() string {
 		v.BlockInfo.ReservedSize,
 		v.BlockInfo.Restriction,
 		v.BlockInfo.BlockVolumes,
-		v.Durability.Type)
+		v.Durability.Type,
+		v.Protected,
+	)
 
 	switch v.Durability.Type {
 	case DurabilityEC:


### PR DESCRIPTION
This PR gives the option to protect a volume from an accidental deletion. If for some reason an admin user doesn't want a certain volume to be deleted by Heketi, this option adds an additional confirmation layer that can be very useful to avoid unexpected data loss of critical volumes.