### PR TITLE
apps: make block rollback more robust

### DIFF
--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -315,7 +315,11 @@ func (v *BlockVolumeEntry) deleteBlockVolumeExec(db wdb.RODB,
 	logger.Debug("Using executor host [%v]", executorhost)
 
 	err = executor.BlockVolumeDestroy(executorhost, hvname, v.Info.Name)
-	if err != nil {
+	if _, ok := err.(*executors.VolumeDoesNotExistErr); ok {
+		logger.Warning(
+			"Block volume %v (%v) does not exist: assuming already deleted",
+			v.Info.Id, v.Info.Name)
+	} else if err != nil {
 		logger.LogError("Unable to delete volume: %v", err)
 		return err
 	}

--- a/executors/cmdexec/block_volume.go
+++ b/executors/cmdexec/block_volume.go
@@ -111,6 +111,10 @@ func (s *CmdExecutor) BlockVolumeDestroy(host string, blockHostingVolumeName str
 	}
 
 	if blockVolumeDelete.Result == "FAIL" {
+		if strings.Contains(blockVolumeDelete.ErrMsg, "doesn't exist") &&
+			strings.Contains(blockVolumeDelete.ErrMsg, blockVolumeName) {
+			return &executors.VolumeDoesNotExistErr{Name: blockVolumeName}
+		}
 		err := logger.LogError("%v", blockVolumeDelete.ErrMsg)
 		return err
 	}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

When block volume create fails due to an insufficient number of nodes due to the request specifying an HA count Heketi was not cleaning up the operation even though no gluster-block level volume ever got created.

The HA count triggers an internal error condition within heketi, but originating in the Exec phase of the operation. This triggers a rollback but the rollback was failing due to gluster block not being able to delete an non-existing volume. This change makes it so that deleting a non-existing volume is handled and treated as a success within the Heketi delete function. A test is added to check for this condition.

### Does this PR fix issues?


Fixes [rhbz#1624738](https://bugzilla.redhat.com/show_bug.cgi?id=1624738)



