### PR TITLE
Fix  volume info to list only completed (not pending) block volumes

### DIFF
--- a/apps/glusterfs/app_volume.go
+++ b/apps/glusterfs/app_volume.go
@@ -207,6 +207,11 @@ func (a *App) VolumeInfo(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return err
 		}
+		err = UpdateVolumeInfoComplete(tx, info)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return err
+		}
 
 		return nil
 	})

--- a/apps/glusterfs/listing.go
+++ b/apps/glusterfs/listing.go
@@ -51,6 +51,20 @@ func ListCompleteBlockVolumes(tx *bolt.Tx) ([]string, error) {
 	return removeKeysFromList(v, p), nil
 }
 
+// UpdateVolumeInfoComplete updates the given VolumeInfoResponse object so
+// that it only contains references to complete block volumes.
+func UpdateVolumeInfoComplete(tx *bolt.Tx, vi *api.VolumeInfoResponse) error {
+	pblk, err := MapPendingBlockVolumes(tx)
+	if err != nil {
+		return err
+	}
+
+	if len(pblk) > 0 {
+		vi.BlockInfo.BlockVolumes = removeKeysFromList(vi.BlockInfo.BlockVolumes, pblk)
+	}
+	return nil
+}
+
 // UpdateClusterInfoComplete updates the given ClusterInfoResponse object so
 // that it only contains references to complete volumes, etc.
 func UpdateClusterInfoComplete(tx *bolt.Tx, ci *api.ClusterInfoResponse) error {


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Fix the result of VolumInfo for block hosting volumes to spare pending block volumes.

### Does this PR fix issues?

Fixes #1342 

