### PR TITLE
Fix error checking when deleting a deleted block volume

### DIFF
--- a/executors/cmdexec/block_volume.go
+++ b/executors/cmdexec/block_volume.go
@@ -88,7 +88,11 @@ func (s *CmdExecutor) BlockVolumeDestroy(host string, blockHostingVolumeName str
 	godbc.Require(blockVolumeName != "")
 
 	commands := []string{
-		fmt.Sprintf("gluster-block delete %v/%v --json >&2", blockHostingVolumeName, blockVolumeName),
+		// this ugly hack exists so that heketi can extract the error message
+		// from stderr if the command exits non-zero but can scrape the
+		// stdout for errors in case the exit code is zero but the
+		// command still fails (this was found to happen in some cases)
+		fmt.Sprintf("bash -c \"set -o pipefail && gluster-block delete %v/%v --json |tee /dev/stderr\"", blockHostingVolumeName, blockVolumeName),
 	}
 
 	type CliOutput struct {

--- a/executors/cmdexec/block_volume.go
+++ b/executors/cmdexec/block_volume.go
@@ -88,7 +88,7 @@ func (s *CmdExecutor) BlockVolumeDestroy(host string, blockHostingVolumeName str
 	godbc.Require(blockVolumeName != "")
 
 	commands := []string{
-		fmt.Sprintf("gluster-block delete %v/%v --json", blockHostingVolumeName, blockVolumeName),
+		fmt.Sprintf("gluster-block delete %v/%v --json >&2", blockHostingVolumeName, blockVolumeName),
 	}
 
 	type CliOutput struct {
@@ -97,25 +97,36 @@ func (s *CmdExecutor) BlockVolumeDestroy(host string, blockHostingVolumeName str
 		ErrCode      int    `json:"errCode"`
 		ErrMsg       string `json:"errMsg"`
 	}
+	var errOutput string
 	output, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 10)
 	if err != nil {
-		logger.LogError("Unable to delete volume %v: %v", blockVolumeName, err)
-		return err
+		errOutput = err.Error()
+	} else {
+		errOutput = output[0]
 	}
 
-	var blockVolumeDelete CliOutput
-	err = json.Unmarshal([]byte(output[0]), &blockVolumeDelete)
-	if err != nil {
-		err := logger.LogError("Unable to get the block volume delete info for block volume %v", blockVolumeName)
-		return err
-	}
-
-	if blockVolumeDelete.Result == "FAIL" {
-		if strings.Contains(blockVolumeDelete.ErrMsg, "doesn't exist") &&
-			strings.Contains(blockVolumeDelete.ErrMsg, blockVolumeName) {
-			return &executors.VolumeDoesNotExistErr{Name: blockVolumeName}
+	if errOutput != "" {
+		var blockVolumeDelete CliOutput
+		if e := json.Unmarshal([]byte(errOutput), &blockVolumeDelete); e != nil {
+			parseErr := logger.LogError(
+				"Unable to parse output from block volume delete: %v",
+				blockVolumeName)
+			if err == nil {
+				return parseErr
+			}
+		} else {
+			if blockVolumeDelete.Result == "FAIL" {
+				if strings.Contains(blockVolumeDelete.ErrMsg, "doesn't exist") &&
+					strings.Contains(blockVolumeDelete.ErrMsg, blockVolumeName) {
+					return &executors.VolumeDoesNotExistErr{Name: blockVolumeName}
+				}
+				return logger.LogError("%v", blockVolumeDelete.ErrMsg)
+			}
 		}
-		err := logger.LogError("%v", blockVolumeDelete.ErrMsg)
+	}
+	if err != nil {
+		// none of the other checks found a specific error condition
+		// but the command still failed. Return basic error
 		return err
 	}
 

--- a/tests/functional/TestSmokeTest/tests/block_volume_test.go
+++ b/tests/functional/TestSmokeTest/tests/block_volume_test.go
@@ -13,6 +13,7 @@ package functional
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils/ssh"
@@ -167,6 +168,89 @@ func TestBlockVolumeAlreadyDeleted(t *testing.T) {
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, len(o) == 1, "expected len(o) == 1, got:", len(o))
 
+	err = heketi.BlockVolumeDelete(bvol.Id)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+}
+
+func TestBlockVolumeDeleteFailureConditions(t *testing.T) {
+
+	// Setup the VM storage topology
+	setupCluster(t, 3, 4)
+	defer teardownCluster(t)
+	defer teardownBlock(t)
+
+	blockReq := &api.BlockVolumeCreateRequest{}
+	blockReq.Size = 3
+	blockReq.Hacount = 3
+
+	type result struct {
+		index int
+		err   error
+	}
+
+	bvol, err := heketi.BlockVolumeCreate(blockReq)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	_, err = heketi.BlockVolumeInfo(bvol.Id)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	downHosts := []string{storage1ssh, storage2ssh}
+
+	var cmds []string
+	s := ssh.NewSshExecWithKeyFile(
+		logger, "vagrant", "../config/insecure_private_key")
+	stopServices := func(both bool) {
+		logger.Info("Stopping services for test")
+		for _, host := range downHosts {
+			cmds = []string{
+				"systemctl stop gluster-blockd",
+			}
+			if both {
+				cmds = append(cmds, "systemctl stop glusterd")
+			}
+			_, err := s.ConnectAndExec(host, cmds, 10, true)
+			tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		}
+		time.Sleep(time.Second * 5)
+	}
+	startServices := func() {
+		logger.Info("Starting services back up")
+		for _, host := range downHosts {
+			cmds = []string{
+				"systemctl start glusterd",
+				"systemctl start gluster-blockd",
+			}
+			_, err := s.ConnectAndExec(host, cmds, 10, true)
+			tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		}
+		time.Sleep(time.Second * 5)
+	}
+
+	defer startServices()
+
+	l, err := heketi.BlockVolumeList()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(l.BlockVolumes) == 1,
+		"expected len(l.BlockVolumes) == 1, got:", len(l.BlockVolumes))
+
+	stopServices(false)
+	// we need to try a few times in order to potentially run the command
+	// on different gluster nodes. 10 is a nice round number
+	for i := 0; i < 10; i++ {
+		err = heketi.BlockVolumeDelete(bvol.Id)
+		tests.Assert(t, err != nil, "expected err != nil, got:", err)
+	}
+
+	stopServices(true)
+	for i := 0; i < 10; i++ {
+		err = heketi.BlockVolumeDelete(bvol.Id)
+		tests.Assert(t, err != nil, "expected err != nil, got:", err)
+	}
+
+	startServices()
+	_, err = heketi.BlockVolumeInfo(bvol.Id)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	logger.Info("Doing real delete")
 	err = heketi.BlockVolumeDelete(bvol.Id)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 }


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

PR #1340 was incomplete and did not correctly handle the various error reporting modes of gluster-block. It turns out gluster block always prints its status on stdout but does not always exit with a non-zero code when an error is encountered. This PR aims to fix those oversights and add functional tests for these situations.



