### PR TITLE
kubeexec: match the stderr output of kubeexec to that of sshexec

### DIFF
--- a/executors/kubeexec/kubeexec.go
+++ b/executors/kubeexec/kubeexec.go
@@ -241,7 +241,7 @@ func (k *KubeExecutor) ConnectAndExec(host, resource string,
 		if err != nil {
 			logger.LogError("Failed to run command [%v] on %v: Err[%v]: Stdout [%v]: Stderr [%v]",
 				command, podName, err, b.String(), berr.String())
-			return nil, fmt.Errorf("Unable to execute command on %v: %v", podName, berr.String())
+			return nil, fmt.Errorf("%v", berr.String())
 		}
 		logger.Debug("Host: %v Pod: %v Command: %v\nResult: %v", host, podName, command, b.String())
 		buffers[index] = b.String()


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Kubeexec was adding extra text to stderr before sending it back to caller. In cases where the stderr text has to be parsed it was leading to parse errors.

It is sufficient to log the details of pod where the commands were hosted and such. Let the error string be passed as-is to the caller.

### Does this PR fix issues?

This is continuation of fixes to rhbz#1624738 along with PR #1340 and #1346 

