### PR TITLE
Replace errors package with github.com/pkg/errors

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -16,13 +16,14 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/gorilla/mux"
+	"github.com/heketi/rest"
+	"github.com/pkg/errors"
+
 	"github.com/heketi/heketi/executors"
 	"github.com/heketi/heketi/executors/kubeexec"
 	"github.com/heketi/heketi/executors/mockexec"
 	"github.com/heketi/heketi/executors/sshexec"
 	"github.com/heketi/heketi/pkg/logging"
-	"github.com/heketi/rest"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -10,8 +10,6 @@
 package glusterfs
 
 import (
-	"errors"
-	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -24,6 +22,7 @@ import (
 	"github.com/heketi/heketi/executors/sshexec"
 	"github.com/heketi/heketi/pkg/logging"
 	"github.com/heketi/rest"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -246,7 +245,7 @@ func SetLogLevel(level string) error {
 		// treat empty string as a no-op & don't complain
 		// about it
 	default:
-		return fmt.Errorf("invalid log level: %s", level)
+		return errors.Errorf("invalid log level: %s", level)
 	}
 	return nil
 }

--- a/apps/glusterfs/app_block_volume_test.go
+++ b/apps/glusterfs/app_block_volume_test.go
@@ -11,7 +11,6 @@ package glusterfs
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -28,6 +27,7 @@ import (
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/heketi/tests"
+	"github.com/pkg/errors"
 )
 
 func TestBlockVolumeCreateBadJson(t *testing.T) {
@@ -384,7 +384,7 @@ func makeGlusterdCheck(available map[string]bool) func(string) error {
 			available[host] = (len(available) % 2) == 0
 		}
 		if !available[host] {
-			return fmt.Errorf("host %s unavailable", host)
+			return errors.Errorf("host %s unavailable", host)
 		}
 		return nil
 	}

--- a/apps/glusterfs/app_block_volume_test.go
+++ b/apps/glusterfs/app_block_volume_test.go
@@ -24,10 +24,11 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/gorilla/mux"
-	"github.com/heketi/heketi/pkg/glusterfs/api"
-	"github.com/heketi/heketi/pkg/utils"
 	"github.com/heketi/tests"
 	"github.com/pkg/errors"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/heketi/pkg/utils"
 )
 
 func TestBlockVolumeCreateBadJson(t *testing.T) {

--- a/apps/glusterfs/app_cluster_test.go
+++ b/apps/glusterfs/app_cluster_test.go
@@ -11,7 +11,6 @@ package glusterfs
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -23,6 +22,7 @@ import (
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/heketi/tests"
+	"github.com/pkg/errors"
 )
 
 func TestClusterCreate(t *testing.T) {

--- a/apps/glusterfs/app_cluster_test.go
+++ b/apps/glusterfs/app_cluster_test.go
@@ -19,10 +19,11 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/gorilla/mux"
-	"github.com/heketi/heketi/pkg/glusterfs/api"
-	"github.com/heketi/heketi/pkg/utils"
 	"github.com/heketi/tests"
 	"github.com/pkg/errors"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/heketi/pkg/utils"
 )
 
 func TestClusterCreate(t *testing.T) {

--- a/apps/glusterfs/app_logging.go
+++ b/apps/glusterfs/app_logging.go
@@ -17,6 +17,7 @@ import (
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/logging"
 	"github.com/heketi/heketi/pkg/utils"
+	"github.com/pkg/errors"
 )
 
 func (a *App) logLevelName() string {
@@ -60,7 +61,7 @@ func (a *App) SetLogLevel(w http.ResponseWriter, r *http.Request) {
 	}
 	wantLevel, ok := msg.LogLevel["glusterfs"]
 	if !ok {
-		err := fmt.Errorf("Only \"glusterfs\" logger may be modified")
+		err := errors.Errorf("Only \"glusterfs\" logger may be modified")
 		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 		return
 	}

--- a/apps/glusterfs/app_logging.go
+++ b/apps/glusterfs/app_logging.go
@@ -14,10 +14,11 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/pkg/errors"
+
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/logging"
 	"github.com/heketi/heketi/pkg/utils"
-	"github.com/pkg/errors"
 )
 
 func (a *App) logLevelName() string {

--- a/apps/glusterfs/app_node_test.go
+++ b/apps/glusterfs/app_node_test.go
@@ -11,7 +11,6 @@ package glusterfs
 
 import (
 	"bytes"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -28,6 +27,7 @@ import (
 	"github.com/heketi/heketi/pkg/sortedstrings"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/heketi/tests"
+	"github.com/pkg/errors"
 )
 
 func TestNodeAddBadRequests(t *testing.T) {

--- a/apps/glusterfs/app_node_test.go
+++ b/apps/glusterfs/app_node_test.go
@@ -21,13 +21,14 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/gorilla/mux"
+	"github.com/heketi/tests"
+	"github.com/pkg/errors"
+
 	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/idgen"
 	"github.com/heketi/heketi/pkg/sortedstrings"
 	"github.com/heketi/heketi/pkg/utils"
-	"github.com/heketi/tests"
-	"github.com/pkg/errors"
 )
 
 func TestNodeAddBadRequests(t *testing.T) {

--- a/apps/glusterfs/app_volume.go
+++ b/apps/glusterfs/app_volume.go
@@ -20,6 +20,7 @@ import (
 	"github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -245,7 +246,7 @@ func (a *App) VolumeDelete(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if volume.Info.Name == db.HeketiStorageVolumeName {
-			err := fmt.Errorf("Cannot delete volume containing the Heketi database")
+			err := errors.Errorf("Cannot delete volume containing the Heketi database")
 			http.Error(w, err.Error(), http.StatusConflict)
 			return err
 		}

--- a/apps/glusterfs/app_volume.go
+++ b/apps/glusterfs/app_volume.go
@@ -17,10 +17,11 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+
 	"github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/apps/glusterfs/app_volume_test.go
+++ b/apps/glusterfs/app_volume_test.go
@@ -11,7 +11,6 @@ package glusterfs
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -33,6 +32,7 @@ import (
 	"github.com/heketi/heketi/pkg/sortedstrings"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/heketi/tests"
+	"github.com/pkg/errors"
 )
 
 func TestVolumeCreateBadGid(t *testing.T) {
@@ -1250,7 +1250,7 @@ func TestVolumeCreateVsTopologyInfo(t *testing.T) {
 			}
 
 			if volume.Size != volumeReq.Size {
-				sg.Err(fmt.Errorf("Unexpected Volume size "+
+				sg.Err(errors.Errorf("Unexpected Volume size "+
 					"[%d] instead of [%d].",
 					volume.Size, volumeReq.Size))
 			}
@@ -1262,7 +1262,7 @@ func TestVolumeCreateVsTopologyInfo(t *testing.T) {
 
 			_, err := c.TopologyInfo()
 			if err != nil {
-				err = fmt.Errorf("TopologyInfo failed: %s", err)
+				err = errors.Errorf("TopologyInfo failed: %s", err)
 			}
 			sg.Err(err)
 		}()

--- a/apps/glusterfs/app_volume_test.go
+++ b/apps/glusterfs/app_volume_test.go
@@ -26,13 +26,14 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/gorilla/mux"
+	"github.com/heketi/tests"
+	"github.com/pkg/errors"
+
 	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/sortedstrings"
 	"github.com/heketi/heketi/pkg/utils"
-	"github.com/heketi/tests"
-	"github.com/pkg/errors"
 )
 
 func TestVolumeCreateBadGid(t *testing.T) {

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -12,7 +12,6 @@ package glusterfs
 import (
 	"bytes"
 	"encoding/gob"
-	"fmt"
 
 	"github.com/boltdb/bolt"
 	"github.com/heketi/heketi/executors"
@@ -20,6 +19,7 @@ import (
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/idgen"
 	"github.com/lpabon/godbc"
+	"github.com/pkg/errors"
 )
 
 type BlockVolumeEntry struct {
@@ -46,13 +46,13 @@ func NewVolumeEntryForBlockHosting(clusters []string) (*VolumeEntry, error) {
 	vol := NewVolumeEntryFromRequest(&msg)
 
 	if !CreateBlockHostingVolumes {
-		return nil, fmt.Errorf("Block Hosting Volume Creation is " +
+		return nil, errors.Errorf("Block Hosting Volume Creation is " +
 			"disabled. Create a Block hosting volume and try " +
 			"again.")
 	}
 
 	if uint64(msg.Size)*GB < vol.Durability.MinVolumeSize() {
-		return nil, fmt.Errorf("Requested volume size (%v GB) is "+
+		return nil, errors.Errorf("Requested volume size (%v GB) is "+
 			"smaller than the minimum supported volume size (%v)",
 			msg.Size, vol.Durability.MinVolumeSize())
 	}

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -14,12 +14,13 @@ import (
 	"encoding/gob"
 
 	"github.com/boltdb/bolt"
+	"github.com/lpabon/godbc"
+	"github.com/pkg/errors"
+
 	"github.com/heketi/heketi/executors"
 	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/idgen"
-	"github.com/lpabon/godbc"
-	"github.com/pkg/errors"
 )
 
 type BlockVolumeEntry struct {

--- a/apps/glusterfs/block_volume_entry_create.go
+++ b/apps/glusterfs/block_volume_entry_create.go
@@ -10,13 +10,13 @@
 package glusterfs
 
 import (
-	"fmt"
 	"math/rand"
 
 	"github.com/boltdb/bolt"
 	"github.com/heketi/heketi/executors"
 	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/lpabon/godbc"
+	"github.com/pkg/errors"
 )
 
 // Creates a block volume
@@ -68,7 +68,7 @@ func (v *BlockVolumeEntry) createBlockVolumeRequest(db wdb.RODB,
 			for _, i := range rand.Perm(len(bhvol.Info.Mount.GlusterFS.Hosts)) {
 				managehostname, e := GetManageHostnameFromStorageHostname(tx, bhvol.Info.Mount.GlusterFS.Hosts[i])
 				if e != nil {
-					return fmt.Errorf("Could not find managehostname for %v", bhvol.Info.Mount.GlusterFS.Hosts[i])
+					return errors.Errorf("Could not find managehostname for %v", bhvol.Info.Mount.GlusterFS.Hosts[i])
 				}
 				e = executor.GlusterdCheck(managehostname)
 				if e == nil {
@@ -79,7 +79,7 @@ func (v *BlockVolumeEntry) createBlockVolumeRequest(db wdb.RODB,
 				}
 			}
 			if len(v.Info.BlockVolume.Hosts) < v.Info.Hacount {
-				return fmt.Errorf("insufficient block hosts online")
+				return errors.Errorf("insufficient block hosts online")
 			}
 		} else {
 			v.Info.BlockVolume.Hosts = bhvol.Info.Mount.GlusterFS.Hosts

--- a/apps/glusterfs/block_volume_entry_create.go
+++ b/apps/glusterfs/block_volume_entry_create.go
@@ -13,10 +13,11 @@ import (
 	"math/rand"
 
 	"github.com/boltdb/bolt"
-	"github.com/heketi/heketi/executors"
-	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/lpabon/godbc"
 	"github.com/pkg/errors"
+
+	"github.com/heketi/heketi/executors"
+	wdb "github.com/heketi/heketi/pkg/db"
 )
 
 // Creates a block volume

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -17,6 +17,7 @@ import (
 
 	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/idgen"
+	"github.com/pkg/errors"
 )
 
 type BrickSet struct {
@@ -49,7 +50,7 @@ func (bs *BrickSet) Add(b *BrickEntry) {
 func (bs *BrickSet) Insert(index int, b *BrickEntry) {
 	switch {
 	case index >= bs.SetSize:
-		panic(fmt.Errorf("Insert index (%v) out of bounds", index))
+		panic(errors.Errorf("Insert index (%v) out of bounds", index))
 	case index == len(bs.Bricks):
 		// we grow the bricks slice by one item
 		bs.Bricks = append(bs.Bricks, b)
@@ -57,7 +58,7 @@ func (bs *BrickSet) Insert(index int, b *BrickEntry) {
 		// we replace an existing item
 		bs.Bricks[index] = b
 	default:
-		panic(fmt.Errorf(
+		panic(errors.Errorf(
 			"Brick set may only be extended one (index=%v, len=%v)",
 			index, len(bs.Bricks)))
 	}
@@ -137,7 +138,7 @@ func (ds *DeviceSet) Add(d *DeviceEntry) {
 func (ds *DeviceSet) Insert(index int, d *DeviceEntry) {
 	switch {
 	case index >= ds.SetSize:
-		panic(fmt.Errorf("Insert index (%v) out of bounds", index))
+		panic(errors.Errorf("Insert index (%v) out of bounds", index))
 	case index == len(ds.Devices):
 		// we grow the bricks slice by one item
 		ds.Devices = append(ds.Devices, d)
@@ -145,7 +146,7 @@ func (ds *DeviceSet) Insert(index int, d *DeviceEntry) {
 		// we replace an existing item
 		ds.Devices[index] = d
 	default:
-		panic(fmt.Errorf(
+		panic(errors.Errorf(
 			"Brick set may only be extended one (index=%v, len=%v)",
 			index, len(ds.Devices)))
 	}
@@ -485,7 +486,7 @@ func (bp *StandardBrickPlacer) Replace(
 	*BrickAllocation, error) {
 
 	if index < 0 || index >= bs.SetSize {
-		return nil, fmt.Errorf(
+		return nil, errors.Errorf(
 			"brick replace index out of bounds (got %v, set size %v)",
 			index, bs.SetSize)
 	}

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/lpabon/godbc"
+	"github.com/pkg/errors"
 
 	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/idgen"
-	"github.com/pkg/errors"
 )
 
 type BrickSet struct {

--- a/apps/glusterfs/db_operations.go
+++ b/apps/glusterfs/db_operations.go
@@ -15,8 +15,9 @@ import (
 	"strings"
 
 	"github.com/boltdb/bolt"
-	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/pkg/errors"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
 func dbDumpInternal(db *bolt.DB) (Db, error) {

--- a/apps/glusterfs/device_entry.go
+++ b/apps/glusterfs/device_entry.go
@@ -22,6 +22,7 @@ import (
 	"github.com/heketi/heketi/pkg/idgen"
 	"github.com/heketi/heketi/pkg/sortedstrings"
 	"github.com/lpabon/godbc"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -107,7 +108,7 @@ func (d *DeviceEntry) Register(tx *bolt.Tx) error {
 			return logger.Err(err)
 		}
 
-		return fmt.Errorf("Device %v is already used on node %v by device %v",
+		return errors.Errorf("Device %v is already used on node %v by device %v",
 			d.Info.Name,
 			d.NodeId,
 			conflictId)
@@ -230,11 +231,11 @@ func (d *DeviceEntry) stateCheck(s api.EntryState) error {
 		case api.EntryStateFailed:
 			return nil
 		case api.EntryStateOnline:
-			return fmt.Errorf("Cannot move a failed/removed device to online state")
+			return errors.Errorf("Cannot move a failed/removed device to online state")
 		case api.EntryStateOffline:
 			return nil
 		default:
-			return fmt.Errorf("Unknown state type: %v", s)
+			return errors.Errorf("Unknown state type: %v", s)
 		}
 
 	// Device is in enabled/online state
@@ -245,9 +246,9 @@ func (d *DeviceEntry) stateCheck(s api.EntryState) error {
 		case api.EntryStateOffline:
 			return nil
 		case api.EntryStateFailed:
-			return fmt.Errorf("Device must be offline before remove operation is performed, device:%v", d.Id())
+			return errors.Errorf("Device must be offline before remove operation is performed, device:%v", d.Id())
 		default:
-			return fmt.Errorf("Unknown state type: %v", s)
+			return errors.Errorf("Unknown state type: %v", s)
 		}
 
 	// Device is in disabled/offline state
@@ -260,7 +261,7 @@ func (d *DeviceEntry) stateCheck(s api.EntryState) error {
 		case api.EntryStateFailed:
 			return nil
 		default:
-			return fmt.Errorf("Unknown state type: %v", s)
+			return errors.Errorf("Unknown state type: %v", s)
 		}
 	}
 
@@ -451,7 +452,7 @@ func (d *DeviceEntry) Remove(db wdb.DB,
 func (d *DeviceEntry) removeBricksFromDevice(db wdb.DB,
 	executor executors.Executor) (e error) {
 
-	var errBrickWithEmptyPath error = fmt.Errorf("Brick has no path")
+	var errBrickWithEmptyPath error = errors.Errorf("Brick has no path")
 
 	for _, brickId := range d.Bricks {
 		var brickEntry *BrickEntry
@@ -483,7 +484,7 @@ func (d *DeviceEntry) removeBricksFromDevice(db wdb.DB,
 		logger.Info("Replacing brick %v on device %v on node %v", brickEntry.Id(), d.Id(), d.NodeId)
 		err = volumeEntry.replaceBrickInVolume(db, executor, brickEntry.Id())
 		if err != nil {
-			return logger.Err(fmt.Errorf("Failed to remove device, error: %v", err))
+			return logger.Err(errors.Errorf("Failed to remove device, error: %v", err))
 		}
 	}
 	return nil

--- a/apps/glusterfs/device_entry.go
+++ b/apps/glusterfs/device_entry.go
@@ -16,13 +16,14 @@ import (
 	"sort"
 
 	"github.com/boltdb/bolt"
+	"github.com/lpabon/godbc"
+	"github.com/pkg/errors"
+
 	"github.com/heketi/heketi/executors"
 	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/idgen"
 	"github.com/heketi/heketi/pkg/sortedstrings"
-	"github.com/lpabon/godbc"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/apps/glusterfs/health_cache_test.go
+++ b/apps/glusterfs/health_cache_test.go
@@ -10,16 +10,15 @@
 package glusterfs
 
 import (
-	"fmt"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/boltdb/bolt"
-	"github.com/heketi/tests"
-
 	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/tests"
+	"github.com/pkg/errors"
 )
 
 func TestCreateNodeHeathCache(t *testing.T) {
@@ -134,7 +133,7 @@ func TestNodeHeathCacheSomeUnhealthy(t *testing.T) {
 	app.xo.MockGlusterdCheck = func(host string) error {
 		var e error
 		if cc&1 == 1 {
-			e = fmt.Errorf("Bloop %v", cc)
+			e = errors.Errorf("Bloop %v", cc)
 		}
 		cc++
 		return e
@@ -181,7 +180,7 @@ func TestNodeHeathCacheMultiRefresh(t *testing.T) {
 	app.xo.MockGlusterdCheck = func(host string) error {
 		var e error
 		if cc&1 == 1 {
-			e = fmt.Errorf("Bloop %v", cc)
+			e = errors.Errorf("Bloop %v", cc)
 		}
 		cc++
 		return e

--- a/apps/glusterfs/health_cache_test.go
+++ b/apps/glusterfs/health_cache_test.go
@@ -15,10 +15,11 @@ import (
 	"time"
 
 	"github.com/boltdb/bolt"
-	wdb "github.com/heketi/heketi/pkg/db"
-	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/tests"
 	"github.com/pkg/errors"
+
+	wdb "github.com/heketi/heketi/pkg/db"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
 func TestCreateNodeHeathCache(t *testing.T) {

--- a/apps/glusterfs/node_entry.go
+++ b/apps/glusterfs/node_entry.go
@@ -16,13 +16,14 @@ import (
 	"sort"
 
 	"github.com/boltdb/bolt"
+	"github.com/lpabon/godbc"
+	"github.com/pkg/errors"
+
 	"github.com/heketi/heketi/executors"
 	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/idgen"
 	"github.com/heketi/heketi/pkg/sortedstrings"
-	"github.com/lpabon/godbc"
-	"github.com/pkg/errors"
 )
 
 type NodeEntry struct {

--- a/apps/glusterfs/node_entry.go
+++ b/apps/glusterfs/node_entry.go
@@ -22,6 +22,7 @@ import (
 	"github.com/heketi/heketi/pkg/idgen"
 	"github.com/heketi/heketi/pkg/sortedstrings"
 	"github.com/lpabon/godbc"
+	"github.com/pkg/errors"
 )
 
 type NodeEntry struct {
@@ -175,7 +176,7 @@ func (n *NodeEntry) Register(tx *bolt.Tx) error {
 			}
 
 			// Return that we found a conflict
-			return fmt.Errorf("Hostname %v already used by node with id %v\n",
+			return errors.Errorf("Hostname %v already used by node with id %v\n",
 				h, conflictId)
 		} else if err != nil {
 			return err
@@ -199,7 +200,7 @@ func (n *NodeEntry) Register(tx *bolt.Tx) error {
 			}
 
 			// Return that we found a conflict
-			return fmt.Errorf("Hostname %v already used by node with id %v\n",
+			return errors.Errorf("Hostname %v already used by node with id %v\n",
 				h, conflictId)
 		} else if err != nil {
 			return err
@@ -293,11 +294,11 @@ func (n *NodeEntry) SetState(db wdb.DB, e executors.Executor,
 		case api.EntryStateFailed:
 			return nil
 		case api.EntryStateOnline:
-			return fmt.Errorf("Cannot move a failed/removed node to online state")
+			return errors.Errorf("Cannot move a failed/removed node to online state")
 		case api.EntryStateOffline:
-			return fmt.Errorf("Cannot move a failed/removed node to offline state")
+			return errors.Errorf("Cannot move a failed/removed node to offline state")
 		default:
-			return fmt.Errorf("Unknown state type: %v", s)
+			return errors.Errorf("Unknown state type: %v", s)
 		}
 
 	// Node is in enabled/online state
@@ -320,9 +321,9 @@ func (n *NodeEntry) SetState(db wdb.DB, e executors.Executor,
 				return err
 			}
 		case api.EntryStateFailed:
-			return fmt.Errorf("Node must be offline before remove operation is performed, node:%v", n.Info.Id)
+			return errors.Errorf("Node must be offline before remove operation is performed, node:%v", n.Info.Id)
 		default:
-			return fmt.Errorf("Unknown state type: %v", s)
+			return errors.Errorf("Unknown state type: %v", s)
 		}
 
 	// Node is in disabled/offline state
@@ -376,7 +377,7 @@ func (n *NodeEntry) SetState(db wdb.DB, e executors.Executor,
 			}
 
 		default:
-			return fmt.Errorf("Unknown state type: %v", s)
+			return errors.Errorf("Unknown state type: %v", s)
 		}
 	}
 	return nil

--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -12,11 +12,11 @@ package glusterfs
 import (
 	"fmt"
 
-	"github.com/heketi/heketi/executors"
-	wdb "github.com/heketi/heketi/pkg/db"
-
 	"github.com/boltdb/bolt"
 	"github.com/pkg/errors"
+
+	"github.com/heketi/heketi/executors"
+	wdb "github.com/heketi/heketi/pkg/db"
 )
 
 const (

--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -16,6 +16,7 @@ import (
 	wdb "github.com/heketi/heketi/pkg/db"
 
 	"github.com/boltdb/bolt"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -162,7 +163,7 @@ func expandSizeFromOp(op *PendingOperationEntry) (sizeGB int, e error) {
 			return
 		}
 	}
-	e = fmt.Errorf("no OpExpandVolume action in pending op: %v",
+	e = errors.Errorf("no OpExpandVolume action in pending op: %v",
 		op.Id)
 	return
 }

--- a/apps/glusterfs/operations_block_restriction.go
+++ b/apps/glusterfs/operations_block_restriction.go
@@ -12,11 +12,11 @@ package glusterfs
 import (
 	"fmt"
 
+	"github.com/boltdb/bolt"
 	"github.com/heketi/heketi/executors"
 	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
-
-	"github.com/boltdb/bolt"
+	"github.com/pkg/errors"
 )
 
 // VolumeSetBlockRestrictionOperation implements the operation functions
@@ -55,7 +55,7 @@ func (ro *VolumeSetBlockRestrictionOperation) ResourceUrl() string {
 // Build sets the state when adding restrictions.
 func (ro *VolumeSetBlockRestrictionOperation) Build() error {
 	if !ro.vol.Info.Block {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"Block restrictions can only be set on block hosting volumes")
 	}
 	// do a "pre flight check" of unlock stuff
@@ -131,7 +131,7 @@ func (ro *VolumeSetBlockRestrictionOperation) checkCanUnlock(
 			// there is enough free space to reserve (some of) it
 			return nil
 		}
-		return fmt.Errorf(
+		return errors.Errorf(
 			"Can not unlock volume. %vGiB free space is required, but found %vGiB",
 			rSize, v.Info.BlockInfo.FreeSize)
 	case api.Unrestricted:
@@ -139,7 +139,7 @@ func (ro *VolumeSetBlockRestrictionOperation) checkCanUnlock(
 		// is OK
 		return nil
 	default:
-		return fmt.Errorf("Unexpected restriction state: %v",
+		return errors.Errorf("Unexpected restriction state: %v",
 			v.Info.BlockInfo.Restriction)
 	}
 }

--- a/apps/glusterfs/operations_block_restriction.go
+++ b/apps/glusterfs/operations_block_restriction.go
@@ -13,10 +13,11 @@ import (
 	"fmt"
 
 	"github.com/boltdb/bolt"
+	"github.com/pkg/errors"
+
 	"github.com/heketi/heketi/executors"
 	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
-	"github.com/pkg/errors"
 )
 
 // VolumeSetBlockRestrictionOperation implements the operation functions

--- a/apps/glusterfs/operations_block_volume.go
+++ b/apps/glusterfs/operations_block_volume.go
@@ -12,10 +12,11 @@ package glusterfs
 import (
 	"fmt"
 
+	"github.com/boltdb/bolt"
+	"github.com/pkg/errors"
+
 	"github.com/heketi/heketi/executors"
 	wdb "github.com/heketi/heketi/pkg/db"
-
-	"github.com/boltdb/bolt"
 )
 
 // BlockVolumeCreateOperation  implements the operation functions used to
@@ -64,7 +65,7 @@ func (bvc *BlockVolumeCreateOperation) Build() error {
 			bvc.bvol.Info.BlockHostingVolume = volumes[0].Info.Id
 			bvc.bvol.Info.Cluster = volumes[0].Info.Cluster
 		} else if bvc.bvol.Info.Size > reducedSize {
-			return fmt.Errorf("The size configured for "+
+			return errors.Errorf("The size configured for "+
 				"automatic creation of block hosting volumes "+
 				"(%v) is too small to host the requested "+
 				"block volume of size %v. The available "+

--- a/apps/glusterfs/operations_block_volume_test.go
+++ b/apps/glusterfs/operations_block_volume_test.go
@@ -10,15 +10,15 @@
 package glusterfs
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
-	"github.com/heketi/heketi/executors"
-	"github.com/heketi/heketi/pkg/glusterfs/api"
-
 	"github.com/boltdb/bolt"
 	"github.com/heketi/tests"
+	"github.com/pkg/errors"
+
+	"github.com/heketi/heketi/executors"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
 func TestBlockHostingVolumeExpandOperation(t *testing.T) {
@@ -1128,7 +1128,7 @@ func TestBlockVolumeCreateRollbackCleanupFailure(t *testing.T) {
 	// now we're going to pretend exec failed and inject an
 	// error condition into BlockVolumeDestroy
 	app.xo.MockBlockVolumeDestroy = func(host, bhv, volume string) error {
-		return fmt.Errorf("fake error")
+		return errors.Errorf("fake error")
 	}
 
 	e = vc.Rollback(app.executor)
@@ -1409,7 +1409,7 @@ func TestBlockVolumeCreateInsufficientHosts(t *testing.T) {
 			zapHosts[host] = true
 		}
 		if zapHosts[host] {
-			return fmt.Errorf("you shall not pass")
+			return errors.Errorf("you shall not pass")
 		}
 		return nil
 	}

--- a/apps/glusterfs/operations_device.go
+++ b/apps/glusterfs/operations_device.go
@@ -10,12 +10,11 @@
 package glusterfs
 
 import (
-	"fmt"
+	"github.com/boltdb/bolt"
+	"github.com/pkg/errors"
 
 	"github.com/heketi/heketi/executors"
 	wdb "github.com/heketi/heketi/pkg/db"
-
-	"github.com/boltdb/bolt"
 )
 
 // DeviceRemoveOperation is a phony-ish operation that exists
@@ -92,7 +91,7 @@ func (dro *DeviceRemoveOperation) deviceId() (string, error) {
 		return "", nil
 	}
 	if dro.op.Actions[0].Change != OpRemoveDevice {
-		return "", fmt.Errorf("Unexpected action (%v) on DeviceRemoveOperation pending op",
+		return "", errors.Errorf("Unexpected action (%v) on DeviceRemoveOperation pending op",
 			dro.op.Actions[0].Change)
 	}
 	return dro.op.Actions[0].Id, nil

--- a/apps/glusterfs/operations_test.go
+++ b/apps/glusterfs/operations_test.go
@@ -10,14 +10,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/heketi/heketi/executors"
-	"github.com/heketi/heketi/pkg/glusterfs/api"
-
 	"github.com/boltdb/bolt"
+	"github.com/gorilla/mux"
 	"github.com/heketi/tests"
 	"github.com/pkg/errors"
 
-	"github.com/gorilla/mux"
+	"github.com/heketi/heketi/executors"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
 type testOperation struct {

--- a/apps/glusterfs/operations_test.go
+++ b/apps/glusterfs/operations_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/heketi/tests"
+	"github.com/pkg/errors"
 
 	"github.com/gorilla/mux"
 )
@@ -120,7 +121,7 @@ func TestAsyncHttpOperationBuildFailure(t *testing.T) {
 	o := &testOperation{}
 	o.rurl = "/myresource"
 	o.build = func() error {
-		return fmt.Errorf("buildfail")
+		return errors.Errorf("buildfail")
 	}
 	testAsyncHttpOperation(t, o, func(t *testing.T, url string) {
 		client := &http.Client{
@@ -138,7 +139,7 @@ func TestAsyncHttpOperationExecFailure(t *testing.T) {
 	o := &testOperation{}
 	o.rurl = "/myresource"
 	o.exec = func() error {
-		return fmt.Errorf("execfail")
+		return errors.Errorf("execfail")
 	}
 	testAsyncHttpOperation(t, o, func(t *testing.T, url string) {
 		client := &http.Client{
@@ -186,12 +187,12 @@ func TestAsyncHttpOperationRollbackFailure(t *testing.T) {
 	o := &testOperation{}
 	o.rurl = "/myresource"
 	o.exec = func() error {
-		return fmt.Errorf("execfail")
+		return errors.Errorf("execfail")
 	}
 	rollback_cc := 0
 	o.rollback = func() error {
 		rollback_cc++
-		return fmt.Errorf("rollbackfail")
+		return errors.Errorf("rollbackfail")
 	}
 	testAsyncHttpOperation(t, o, func(t *testing.T, url string) {
 		client := &http.Client{
@@ -240,7 +241,7 @@ func TestAsyncHttpOperationFinalizeFailure(t *testing.T) {
 	o := &testOperation{}
 	o.rurl = "/myresource"
 	o.finalize = func() error {
-		return fmt.Errorf("finfail")
+		return errors.Errorf("finfail")
 	}
 	testAsyncHttpOperation(t, o, func(t *testing.T, url string) {
 		client := &http.Client{
@@ -322,12 +323,12 @@ func TestRunOperationRollbackFailure(t *testing.T) {
 	o := &testOperation{}
 	o.rurl = "/myresource"
 	o.exec = func() error {
-		return fmt.Errorf("execfail")
+		return errors.Errorf("execfail")
 	}
 	rollback_cc := 0
 	o.rollback = func() error {
 		rollback_cc++
-		return fmt.Errorf("rollbackfail")
+		return errors.Errorf("rollbackfail")
 	}
 	e := RunOperation(o, app.executor)
 	// even if rollback fails we expect the error from Exec
@@ -347,7 +348,7 @@ func TestRunOperationFinalizeFailure(t *testing.T) {
 	o.label = "Funky Fresh"
 	o.rurl = "/myresource"
 	o.finalize = func() error {
-		return fmt.Errorf("finfail")
+		return errors.Errorf("finfail")
 	}
 
 	e := RunOperation(o, app.executor)
@@ -366,7 +367,7 @@ func TestRunOperationExecRetryError(t *testing.T) {
 	o.retryMax = 4
 	o.exec = func() error {
 		return OperationRetryError{
-			OriginalError: fmt.Errorf("foobar"),
+			OriginalError: errors.Errorf("foobar"),
 		}
 	}
 	rollback_cc := 0
@@ -394,13 +395,13 @@ func TestRunOperationExecRetryRollbackFail(t *testing.T) {
 	o.retryMax = 4
 	o.exec = func() error {
 		return OperationRetryError{
-			OriginalError: fmt.Errorf("foobar"),
+			OriginalError: errors.Errorf("foobar"),
 		}
 	}
 	rollback_cc := 0
 	o.rollback = func() error {
 		rollback_cc++
-		return fmt.Errorf("rollbackfail")
+		return errors.Errorf("rollbackfail")
 	}
 	build_cc := 0
 	o.build = func() error {
@@ -429,7 +430,7 @@ func TestRunOperationExecRetryThenBuildFail(t *testing.T) {
 	o.retryMax = 4
 	o.exec = func() error {
 		return OperationRetryError{
-			OriginalError: fmt.Errorf("foobar"),
+			OriginalError: errors.Errorf("foobar"),
 		}
 	}
 	rollback_cc := 0
@@ -441,7 +442,7 @@ func TestRunOperationExecRetryThenBuildFail(t *testing.T) {
 	o.build = func() error {
 		build_cc++
 		if build_cc > 1 {
-			return fmt.Errorf("buildfail")
+			return errors.Errorf("buildfail")
 		}
 		return nil
 	}
@@ -472,7 +473,7 @@ func TestRunOperationExecRetryThenSucceed(t *testing.T) {
 			return nil
 		}
 		return OperationRetryError{
-			OriginalError: fmt.Errorf("foobar"),
+			OriginalError: errors.Errorf("foobar"),
 		}
 	}
 	rollback_cc := 0
@@ -499,10 +500,10 @@ func TestRunOperationExecRetryThenNonRetryError(t *testing.T) {
 	o.exec = func() error {
 		exec_cc++
 		if exec_cc > 2 {
-			return fmt.Errorf("execfail")
+			return errors.Errorf("execfail")
 		}
 		return OperationRetryError{
-			OriginalError: fmt.Errorf("foobar"),
+			OriginalError: errors.Errorf("foobar"),
 		}
 	}
 	rollback_cc := 0

--- a/apps/glusterfs/operations_volume_test.go
+++ b/apps/glusterfs/operations_volume_test.go
@@ -10,17 +10,17 @@
 package glusterfs
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"sync"
 	"testing"
 
-	"github.com/heketi/heketi/executors"
-	"github.com/heketi/heketi/pkg/glusterfs/api"
-
 	"github.com/boltdb/bolt"
 	"github.com/heketi/tests"
+	"github.com/pkg/errors"
+
+	"github.com/heketi/heketi/executors"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
 func TestVolumeCreatePendingCreatedCleared(t *testing.T) {
@@ -262,7 +262,7 @@ func TestVolumeCreateRollbackCleanupFailure(t *testing.T) {
 	// error condition into VolumeDestroy
 
 	app.xo.MockVolumeDestroy = func(host string, volume string) error {
-		return fmt.Errorf("fake error")
+		return errors.Errorf("fake error")
 	}
 
 	e = vc.Rollback(app.executor)
@@ -503,7 +503,7 @@ func TestVolumeCreateOperationRetrying(t *testing.T) {
 		if brickCreates[host] > 1 {
 			return bCreate(host, brick)
 		}
-		return nil, fmt.Errorf("FAKE ERR")
+		return nil, errors.Errorf("FAKE ERR")
 	}
 
 	vc.maxRetries = 10

--- a/apps/glusterfs/pendingop.go
+++ b/apps/glusterfs/pendingop.go
@@ -9,9 +9,7 @@
 
 package glusterfs
 
-import (
-	"fmt"
-)
+import "github.com/pkg/errors"
 
 // The pendingop.go file defines the basic structures needed to track
 // life-cycle of database entries w/in Heketi. There are generally two
@@ -89,5 +87,5 @@ func (a PendingOperationAction) ExpandSize() (int, error) {
 			return v, nil
 		}
 	}
-	return 0, fmt.Errorf("Action delta for ExpandSize is missing/invalid")
+	return 0, errors.Errorf("Action delta for ExpandSize is missing/invalid")
 }

--- a/apps/glusterfs/pendingop.go
+++ b/apps/glusterfs/pendingop.go
@@ -9,7 +9,9 @@
 
 package glusterfs
 
-import "github.com/pkg/errors"
+import (
+	"github.com/pkg/errors"
+)
 
 // The pendingop.go file defines the basic structures needed to track
 // life-cycle of database entries w/in Heketi. There are generally two

--- a/apps/glusterfs/placer_arbiter.go
+++ b/apps/glusterfs/placer_arbiter.go
@@ -10,13 +10,13 @@
 package glusterfs
 
 import (
-	"fmt"
-
 	"github.com/heketi/heketi/pkg/idgen"
+
+	"github.com/pkg/errors"
 )
 
 var (
-	tryPlaceAgain error = fmt.Errorf("Placement failed. Try again.")
+	tryPlaceAgain error = errors.Errorf("Placement failed. Try again.")
 )
 
 const (
@@ -104,10 +104,10 @@ func (bp *ArbiterBrickPlacer) PlaceAll(
 			return r, err
 		}
 		if bs.IsSparse() {
-			return r, fmt.Errorf("Did not fully populate brick set")
+			return r, errors.Errorf("Did not fully populate brick set")
 		}
 		if ds.IsSparse() {
-			return r, fmt.Errorf("Did not fully populate device set")
+			return r, errors.Errorf("Did not fully populate device set")
 		}
 		r.BrickSets = append(r.BrickSets, bs)
 		r.DeviceSets = append(r.DeviceSets, ds)
@@ -127,7 +127,7 @@ func (bp *ArbiterBrickPlacer) Replace(
 	*BrickAllocation, error) {
 
 	if index < 0 || index >= bs.SetSize {
-		return nil, fmt.Errorf(
+		return nil, errors.Errorf(
 			"brick replace index out of bounds (got %v, set size %v)",
 			index, bs.SetSize)
 	}
@@ -402,7 +402,7 @@ func discountBrickSize(dataBrickSize, averageFileSize uint64) (brickSize uint64,
 	err error) {
 
 	if dataBrickSize < averageFileSize {
-		return 0, fmt.Errorf(
+		return 0, errors.Errorf(
 			"Average file size (%v) is greater than Brick size (%v)",
 			averageFileSize, dataBrickSize)
 	}

--- a/apps/glusterfs/placer_arbiter.go
+++ b/apps/glusterfs/placer_arbiter.go
@@ -10,9 +10,9 @@
 package glusterfs
 
 import (
-	"github.com/heketi/heketi/pkg/idgen"
-
 	"github.com/pkg/errors"
+
+	"github.com/heketi/heketi/pkg/idgen"
 )
 
 var (

--- a/apps/glusterfs/placer_arbiter_test.go
+++ b/apps/glusterfs/placer_arbiter_test.go
@@ -10,11 +10,11 @@
 package glusterfs
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/heketi/tests"
+	"github.com/pkg/errors"
 )
 
 type TestDeviceSource struct {
@@ -282,7 +282,7 @@ func TestArbiterBrickPlacerTooSmall(t *testing.T) {
 
 func TestArbiterBrickPlacerDevicesFail(t *testing.T) {
 	dsrc := NewTestDeviceSource()
-	dsrc.devicesError = fmt.Errorf("Zonk!")
+	dsrc.devicesError = errors.Errorf("Zonk!")
 
 	opts := &TestPlacementOpts{
 		brickSize:       800,
@@ -634,7 +634,7 @@ func TestArbiterBrickPlacerReplaceDevicesFail(t *testing.T) {
 		"expected len(ba.BrickSets[0].Bricks) == 3, got:",
 		len(ba.BrickSets[0].Bricks))
 
-	dsrc.devicesError = fmt.Errorf("Zonk!")
+	dsrc.devicesError = errors.Errorf("Zonk!")
 	_, err = abplacer.Replace(dsrc, opts, nil, ba.BrickSets[0], 0)
 	tests.Assert(t, err == dsrc.devicesError,
 		"expected err == dsrc.devicesError, got:", err)

--- a/apps/glusterfs/try_on_host.go
+++ b/apps/glusterfs/try_on_host.go
@@ -10,7 +10,7 @@
 package glusterfs
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 )
 
 // nodeHosts is a mapping from the node ID to the hosts's
@@ -52,5 +52,5 @@ func (c *tryOnHosts) run(f func(host string) error) error {
 		}
 		logger.Warning("error running on node %v (%v): %v", nodeId, host, err)
 	}
-	return fmt.Errorf("no hosts available (%v total)", len(c.Hosts))
+	return errors.Errorf("no hosts available (%v total)", len(c.Hosts))
 }

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -18,6 +18,9 @@ import (
 	"strings"
 
 	"github.com/boltdb/bolt"
+	"github.com/lpabon/godbc"
+	"github.com/pkg/errors"
+
 	"github.com/heketi/heketi/executors"
 	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
@@ -25,8 +28,6 @@ import (
 	"github.com/heketi/heketi/pkg/paths"
 	"github.com/heketi/heketi/pkg/sortedstrings"
 	"github.com/heketi/heketi/pkg/utils"
-	"github.com/lpabon/godbc"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -12,7 +12,6 @@ package glusterfs
 import (
 	"bytes"
 	"encoding/gob"
-	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -27,6 +26,7 @@ import (
 	"github.com/heketi/heketi/pkg/sortedstrings"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/lpabon/godbc"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -342,11 +342,11 @@ func (v *VolumeEntry) ModifyFreeSize(delta int) error {
 		v.Info.BlockInfo.FreeSize, delta)
 	v.Info.BlockInfo.FreeSize += delta
 	if v.Info.BlockInfo.FreeSize < 0 {
-		return logger.Err(fmt.Errorf(
+		return logger.Err(errors.Errorf(
 			"Volume %v free size may not be set less than zero", v.Info.Id))
 	}
 	if v.Info.BlockInfo.FreeSize+v.Info.BlockInfo.ReservedSize > v.Info.Size {
-		return logger.Err(fmt.Errorf(
+		return logger.Err(errors.Errorf(
 			"Volume %v free size may not be set greater than %v",
 			v.Info.Id, v.Info.Size))
 	}
@@ -358,11 +358,11 @@ func (v *VolumeEntry) ModifyReservedSize(delta int) error {
 		v.Info.BlockInfo.ReservedSize, delta)
 	v.Info.BlockInfo.ReservedSize += delta
 	if v.Info.BlockInfo.ReservedSize < 0 {
-		return logger.Err(fmt.Errorf(
+		return logger.Err(errors.Errorf(
 			"Volume %v reserved size may not be set less than zero", v.Info.Id))
 	}
 	if v.Info.BlockInfo.ReservedSize+v.Info.BlockInfo.FreeSize > v.Info.Size {
-		return logger.Err(fmt.Errorf(
+		return logger.Err(errors.Errorf(
 			"Volume %v reserved size may not be set greater than %v",
 			v.Info.Id, v.Info.Size))
 	}
@@ -404,7 +404,7 @@ func (v *VolumeEntry) SetRawCapacity(delta int) error {
 // volumes in the db to calculate the total.
 func (v *VolumeEntry) TotalSizeBlockVolumes(tx *bolt.Tx) (int, error) {
 	if !v.Info.Block {
-		return 0, fmt.Errorf(
+		return 0, errors.Errorf(
 			"Volume %v is not a block hosting volume", v.Info.Id)
 	}
 	bvsum := 0
@@ -501,7 +501,7 @@ func (v *VolumeEntry) cleanupCreateVolume(db wdb.DB,
 	})
 	if err != nil {
 		logger.LogError("failed to delete volume in cleanup: %v", err)
-		return fmt.Errorf("failed to clean up volume: %v", v.Info.Id)
+		return errors.Errorf("failed to clean up volume: %v", v.Info.Id)
 	}
 
 	// from a quick read its "safe" to unconditionally try to delete
@@ -730,7 +730,7 @@ func (v *VolumeEntry) manageHostFromBricks(db wdb.DB,
 			sshhost = node.ManageHostName()
 			return nil
 		}
-		return fmt.Errorf("Unable to get management host from bricks")
+		return errors.Errorf("Unable to get management host from bricks")
 	})
 	return
 }
@@ -1031,7 +1031,7 @@ func updateCloneBrickPaths(bricks []*BrickEntry,
 		pathIndex[brick.Info.Path] = i
 	}
 	if len(pathIndex) != len(bricks) {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"Unexpected number of brick paths. %v unique paths, %v bricks",
 			len(pathIndex), len(bricks))
 	}
@@ -1043,7 +1043,7 @@ func updateCloneBrickPaths(bricks []*BrickEntry,
 
 		bidx, ok := pathIndex[origPath]
 		if !ok {
-			return fmt.Errorf(
+			return errors.Errorf(
 				"Failed to find brick path %v in known brick paths",
 				origPath)
 		}

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -16,6 +16,7 @@ import (
 	"github.com/heketi/heketi/executors"
 	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/pkg/errors"
 )
 
 func (v *VolumeEntry) allocBricksInCluster(db wdb.DB,
@@ -169,7 +170,7 @@ func (v *VolumeEntry) canReplaceBrickInBrickSet(db wdb.DB,
 		}
 		iBrickEntry, found := bmap[brickHealStatus.Name]
 		if !found {
-			return fmt.Errorf("Unable to determine heal status of brick")
+			return errors.Errorf("Unable to determine heal status of brick")
 		}
 		if iBrickEntry.Id() == brickId {
 			// If we are here, it means the brick to be replaced is
@@ -177,7 +178,7 @@ func (v *VolumeEntry) canReplaceBrickInBrickSet(db wdb.DB,
 			// source for any files.
 			if brickHealStatus.NumberOfEntries != "-" &&
 				brickHealStatus.NumberOfEntries != "0" {
-				return fmt.Errorf("Cannot replace brick %v as it is source brick for data to be healed", iBrickEntry.Id())
+				return errors.Errorf("Cannot replace brick %v as it is source brick for data to be healed", iBrickEntry.Id())
 			}
 		}
 		for i, brickInSet := range bs.Bricks {
@@ -187,7 +188,7 @@ func (v *VolumeEntry) canReplaceBrickInBrickSet(db wdb.DB,
 		}
 	}
 	if onlinePeerBrickCount < v.Durability.QuorumBrickCount() {
-		return fmt.Errorf("Cannot replace brick %v as only %v of %v "+
+		return errors.Errorf("Cannot replace brick %v as only %v of %v "+
 			"required peer bricks are online",
 			brickId, onlinePeerBrickCount,
 			v.Durability.QuorumBrickCount())
@@ -308,7 +309,7 @@ func (v *VolumeEntry) replaceBrickInVolume(db wdb.DB, executor executors.Executo
 	oldBrickId string) (e error) {
 
 	if api.DurabilityDistributeOnly == v.Info.Durability.Type {
-		return fmt.Errorf("replace brick is not supported for volume durability type %v", v.Info.Durability.Type)
+		return errors.Errorf("replace brick is not supported for volume durability type %v", v.Info.Durability.Type)
 	}
 
 	ri, node, err := v.prepForBrickReplacement(

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -13,10 +13,11 @@ import (
 	"fmt"
 
 	"github.com/boltdb/bolt"
+	"github.com/pkg/errors"
+
 	"github.com/heketi/heketi/executors"
 	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
-	"github.com/pkg/errors"
 )
 
 func (v *VolumeEntry) allocBricksInCluster(db wdb.DB,

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -19,12 +19,13 @@ import (
 	"testing"
 
 	"github.com/boltdb/bolt"
+	"github.com/heketi/tests"
+	"github.com/pkg/errors"
+
 	"github.com/heketi/heketi/executors"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/sortedstrings"
 	"github.com/heketi/heketi/pkg/utils"
-	"github.com/heketi/tests"
-	"github.com/pkg/errors"
 )
 
 func createSampleReplicaVolumeEntry(size int, replica int) *VolumeEntry {

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -10,7 +10,6 @@
 package glusterfs
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -25,6 +24,7 @@ import (
 	"github.com/heketi/heketi/pkg/sortedstrings"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/heketi/tests"
+	"github.com/pkg/errors"
 )
 
 func createSampleReplicaVolumeEntry(size int, replica int) *VolumeEntry {

--- a/client/api/go-client/client.go
+++ b/client/api/go-client/client.go
@@ -18,7 +18,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
-	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -27,6 +26,7 @@ import (
 
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/heketi/heketi/pkg/utils"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -130,11 +130,11 @@ func (c *Client) SetTLSOptions(o *ClientTLSOptions) error {
 		for _, path := range o.VerifyCerts {
 			pem, err := ioutil.ReadFile(path)
 			if err != nil {
-				return fmt.Errorf("failed to read cert file %v: %v",
+				return errors.Errorf("failed to read cert file %v: %v",
 					path, err)
 			}
 			if ok := tlsConfig.RootCAs.AppendCertsFromPEM(pem); !ok {
-				return fmt.Errorf("failed to load PEM encoded cert from %s",
+				return errors.Errorf("failed to load PEM encoded cert from %s",
 					path)
 			}
 		}

--- a/client/api/go-client/client.go
+++ b/client/api/go-client/client.go
@@ -25,8 +25,9 @@ import (
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/heketi/heketi/pkg/utils"
 	"github.com/pkg/errors"
+
+	"github.com/heketi/heketi/pkg/utils"
 )
 
 const (

--- a/client/cli/go/cmds/block_volume.go
+++ b/client/cli/go/cmds/block_volume.go
@@ -11,8 +11,9 @@ package cmds
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
+
+	"github.com/pkg/errors"
 	//	"os"
 	"strings"
 

--- a/client/cli/go/cmds/block_volume.go
+++ b/client/cli/go/cmds/block_volume.go
@@ -12,13 +12,12 @@ package cmds
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/pkg/errors"
-	//	"os"
 	"strings"
 
-	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
 var (

--- a/client/cli/go/cmds/cluster.go
+++ b/client/cli/go/cmds/cluster.go
@@ -11,12 +11,12 @@ package cmds
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/client/cli/go/cmds/cluster.go
+++ b/client/cli/go/cmds/cluster.go
@@ -15,9 +15,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
 var (

--- a/client/cli/go/cmds/device.go
+++ b/client/cli/go/cmds/device.go
@@ -11,10 +11,10 @@ package cmds
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/client/cli/go/cmds/device.go
+++ b/client/cli/go/cmds/device.go
@@ -13,9 +13,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
 var (

--- a/client/cli/go/cmds/heketi_storage.go
+++ b/client/cli/go/cmds/heketi_storage.go
@@ -18,6 +18,7 @@ import (
 	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	kubeapi "k8s.io/kubernetes/pkg/api/v1"
@@ -119,7 +120,7 @@ func createHeketiStorageVolume(c *client.Client, dt api.DurabilityType, replicaC
 
 			// Check volume name
 			if volume.Name == db.HeketiStorageVolumeName {
-				return nil, fmt.Errorf("Volume %v alreay exists", db.HeketiStorageVolumeName)
+				return nil, errors.Errorf("Volume %v alreay exists", db.HeketiStorageVolumeName)
 			}
 		}
 	}
@@ -136,7 +137,7 @@ func createHeketiStorageVolume(c *client.Client, dt api.DurabilityType, replicaC
 	case api.DurabilityDistributeOnly:
 		// no further options needed
 	default:
-		return nil, fmt.Errorf("Durability %s is not supported for heketi database storage", dt)
+		return nil, errors.Errorf("Durability %s is not supported for heketi database storage", dt)
 	}
 
 	// Create volume
@@ -154,7 +155,7 @@ func createHeketiSecretFromDb(c *client.Client) (*kubeapi.Secret, error) {
 	// Save db
 	err := c.BackupDb(&dbfile)
 	if err != nil {
-		return nil, fmt.Errorf("ERROR: %v\nUnable to get database from Heketi server", err.Error())
+		return nil, errors.Errorf("ERROR: %v\nUnable to get database from Heketi server", err.Error())
 	}
 
 	// Create Secret

--- a/client/cli/go/cmds/heketi_storage.go
+++ b/client/cli/go/cmds/heketi_storage.go
@@ -15,11 +15,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
 	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 
 	kubeapi "k8s.io/kubernetes/pkg/api/v1"
 	batch "k8s.io/kubernetes/pkg/apis/batch/v1"

--- a/client/cli/go/cmds/loglevel.go
+++ b/client/cli/go/cmds/loglevel.go
@@ -12,6 +12,7 @@ package cmds
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
@@ -56,10 +57,10 @@ var logLevelSetCommand = &cobra.Command{
 	Example: `  $ heketi-cli loglevel set debug`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			return fmt.Errorf("missing log-level argument")
+			return errors.Errorf("missing log-level argument")
 		}
 		if len(args) > 1 {
-			return fmt.Errorf("too many arguments")
+			return errors.Errorf("too many arguments")
 		}
 		heketi, err := newHeketiClient()
 		if err != nil {

--- a/client/cli/go/cmds/node.go
+++ b/client/cli/go/cmds/node.go
@@ -11,10 +11,10 @@ package cmds
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/client/cli/go/cmds/node.go
+++ b/client/cli/go/cmds/node.go
@@ -13,9 +13,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
 var (

--- a/client/cli/go/cmds/server.go
+++ b/client/cli/go/cmds/server.go
@@ -18,7 +18,7 @@ import (
 	"text/template"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
-
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -95,10 +95,10 @@ var setModeCommand = &cobra.Command{
 	Example: `  $ heketi-cli server operations info`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			return fmt.Errorf("missing mode argument")
+			return errors.Errorf("missing mode argument")
 		}
 		if len(args) > 1 {
-			return fmt.Errorf("too many arguments")
+			return errors.Errorf("too many arguments")
 		}
 		heketi, err := newHeketiClient()
 		if err != nil {

--- a/client/cli/go/cmds/server.go
+++ b/client/cli/go/cmds/server.go
@@ -17,9 +17,10 @@ import (
 	"os"
 	"text/template"
 
-	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
 var serverCommand = &cobra.Command{

--- a/client/cli/go/cmds/topology.go
+++ b/client/cli/go/cmds/topology.go
@@ -11,12 +11,12 @@ package cmds
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -161,7 +161,7 @@ var topologyLoadCommand = &cobra.Command{
 		// Load current topolgy
 		heketiTopology, err := heketi.TopologyInfo()
 		if err != nil {
-			return fmt.Errorf("Unable to get topology information: %v", err)
+			return errors.Errorf("Unable to get topology information: %v", err)
 		}
 
 		// Register topology
@@ -180,7 +180,7 @@ var topologyLoadCommand = &cobra.Command{
 					clusterInfo, err = heketi.ClusterInfo(nodeInfo.ClusterId)
 					if err != nil {
 						fmt.Fprintf(stdout, "Unable to get cluster information\n")
-						return fmt.Errorf("Unable to get cluster information")
+						return errors.Errorf("Unable to get cluster information")
 					}
 				} else {
 					var err error

--- a/client/cli/go/cmds/topology.go
+++ b/client/cli/go/cmds/topology.go
@@ -15,9 +15,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
 const (

--- a/client/cli/go/cmds/utils.go
+++ b/client/cli/go/cmds/utils.go
@@ -10,10 +10,9 @@
 package cmds
 
 import (
-	"errors"
-	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	client "github.com/heketi/heketi/client/api/go-client"
@@ -43,7 +42,7 @@ func setTagsCommand(cmd *cobra.Command,
 	for _, t := range s[1:] {
 		parts := strings.SplitN(t, ":", 2)
 		if len(parts) < 2 {
-			return fmt.Errorf(
+			return errors.Errorf(
 				"expected colon (:) between tag name and value, got: %v",
 				t)
 		}

--- a/client/cli/go/cmds/volume.go
+++ b/client/cli/go/cmds/volume.go
@@ -11,13 +11,13 @@ package cmds
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/kubernetes"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -152,7 +152,7 @@ var volumeCreateCommand = &cobra.Command{
 		if kubePv && kubePvEndpoint == "" {
 			fmt.Fprintf(stderr, "--persistent-volume-endpoint must be provided "+
 				"when using --persistent-volume\n")
-			return fmt.Errorf("Missing endpoint")
+			return errors.Errorf("Missing endpoint")
 		}
 
 		// Create request blob

--- a/client/cli/go/cmds/volume.go
+++ b/client/cli/go/cmds/volume.go
@@ -15,10 +15,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/heketi/heketi/pkg/glusterfs/api"
-	"github.com/heketi/heketi/pkg/kubernetes"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/heketi/pkg/kubernetes"
 )
 
 var (

--- a/executors/cmdexec/block_volume.go
+++ b/executors/cmdexec/block_volume.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/lpabon/godbc"
+	"github.com/pkg/errors"
 
 	"github.com/heketi/heketi/executors"
 	rex "github.com/heketi/heketi/pkg/remoteexec"
@@ -60,13 +61,13 @@ func (s *CmdExecutor) BlockVolumeCreate(host string,
 	var blockVolumeCreate CliOutput
 	err = json.Unmarshal([]byte(results[0].Output), &blockVolumeCreate)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to get the block volume create info for block volume %v", volume.Name)
+		return nil, errors.Errorf("Unable to get the block volume create info for block volume %v", volume.Name)
 	}
 
 	if blockVolumeCreate.Result == "FAIL" {
 		s.BlockVolumeDestroy(host, volume.GlusterVolumeName, volume.Name)
 		logger.LogError("%v", blockVolumeCreate.ErrMsg)
-		return nil, fmt.Errorf("%v", blockVolumeCreate.ErrMsg)
+		return nil, errors.Errorf("%v", blockVolumeCreate.ErrMsg)
 	}
 
 	var blockVolumeInfo executors.BlockVolumeInfo

--- a/executors/cmdexec/brick.go
+++ b/executors/cmdexec/brick.go
@@ -19,6 +19,7 @@ import (
 	"github.com/heketi/heketi/pkg/paths"
 	rex "github.com/heketi/heketi/pkg/remoteexec"
 	"github.com/lpabon/godbc"
+	"github.com/pkg/errors"
 )
 
 func (s *CmdExecutor) BrickCreate(host string,
@@ -139,7 +140,7 @@ func (s *CmdExecutor) countThinLVsInPool(host, tp string) (int, error) {
 	}
 	thin_count, err := strconv.Atoi(strings.TrimSpace(results[0].Output))
 	if err != nil {
-		return 0, fmt.Errorf("Failed to convert number of logical volumes in thin pool %v on host %v: %v", tp, host, err)
+		return 0, errors.Errorf("Failed to convert number of logical volumes in thin pool %v on host %v: %v", tp, host, err)
 	}
 	return thin_count, nil
 }
@@ -218,7 +219,7 @@ func (s *CmdExecutor) BrickDestroy(host string,
 			thin_count = 0
 		} else {
 			logger.Err(err)
-			return spaceReclaimed, fmt.Errorf(
+			return spaceReclaimed, errors.Errorf(
 				"Unable to determine number of logical volumes in "+
 					"thin pool %v on host %v", tp, host)
 		}

--- a/executors/cmdexec/brick.go
+++ b/executors/cmdexec/brick.go
@@ -14,12 +14,13 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/lpabon/godbc"
+	"github.com/pkg/errors"
+
 	"github.com/heketi/heketi/executors"
 	conv "github.com/heketi/heketi/pkg/conversions"
 	"github.com/heketi/heketi/pkg/paths"
 	rex "github.com/heketi/heketi/pkg/remoteexec"
-	"github.com/lpabon/godbc"
-	"github.com/pkg/errors"
 )
 
 func (s *CmdExecutor) BrickCreate(host string,

--- a/executors/cmdexec/device.go
+++ b/executors/cmdexec/device.go
@@ -10,10 +10,11 @@
 package cmdexec
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/heketi/heketi/executors"
 	conv "github.com/heketi/heketi/pkg/conversions"

--- a/executors/cmdexec/snapshot.go
+++ b/executors/cmdexec/snapshot.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 
 	"github.com/lpabon/godbc"
+	"github.com/pkg/errors"
 
 	"github.com/heketi/heketi/executors"
 	rex "github.com/heketi/heketi/pkg/remoteexec"
@@ -37,17 +38,17 @@ func (s *CmdExecutor) snapshotActivate(host string, snapshot string) error {
 	results, err := s.RemoteExecutor.ExecCommands(host, command,
 		s.GlusterCliExecTimeout())
 	if err := rex.AnyError(results, err); err != nil {
-		return fmt.Errorf("Unable to activate snapshot %v: %v", snapshot, err)
+		return errors.Errorf("Unable to activate snapshot %v: %v", snapshot, err)
 	}
 
 	var snapActivate CliOutput
 	err = xml.Unmarshal([]byte(results[0].Output), &snapActivate)
 	if err != nil {
-		return fmt.Errorf("Unable to parse output from activate snapshot %v: %v", snapshot, err)
+		return errors.Errorf("Unable to parse output from activate snapshot %v: %v", snapshot, err)
 	}
 	logger.Debug("%+v\n", snapActivate)
 	if snapActivate.OpRet != 0 {
-		return fmt.Errorf("Failed to activate snapshot %v: %v", snapshot, snapActivate.OpErrStr)
+		return errors.Errorf("Failed to activate snapshot %v: %v", snapshot, snapActivate.OpErrStr)
 	}
 
 	return nil
@@ -71,17 +72,17 @@ func (s *CmdExecutor) snapshotDeactivate(host string, snapshot string) error {
 	results, err := s.RemoteExecutor.ExecCommands(host, command,
 		s.GlusterCliExecTimeout())
 	if err := rex.AnyError(results, err); err != nil {
-		return fmt.Errorf("Unable to deactivate snapshot %v: %v", snapshot, err)
+		return errors.Errorf("Unable to deactivate snapshot %v: %v", snapshot, err)
 	}
 
 	var snapDeactivate CliOutput
 	err = xml.Unmarshal([]byte(results[0].Output), &snapDeactivate)
 	if err != nil {
-		return fmt.Errorf("Unable to parse output from deactivate snapshot %v: %v", snapshot, err)
+		return errors.Errorf("Unable to parse output from deactivate snapshot %v: %v", snapshot, err)
 	}
 	logger.Debug("%+v\n", snapDeactivate)
 	if snapDeactivate.OpRet != 0 {
-		return fmt.Errorf("Failed to deactivate snapshot %v: %v", snapshot, snapDeactivate.OpErrStr)
+		return errors.Errorf("Failed to deactivate snapshot %v: %v", snapshot, snapDeactivate.OpErrStr)
 	}
 
 	return nil
@@ -114,17 +115,17 @@ func (s *CmdExecutor) SnapshotCloneVolume(host string, vcr *executors.SnapshotCl
 	results, err := s.RemoteExecutor.ExecCommands(host, command,
 		s.GlusterCliExecTimeout())
 	if err := rex.AnyError(results, err); err != nil {
-		return nil, fmt.Errorf("Unable to clone snapshot %v: %v", vcr.Snapshot, err)
+		return nil, errors.Errorf("Unable to clone snapshot %v: %v", vcr.Snapshot, err)
 	}
 
 	var cliOutput CliOutput
 	err = xml.Unmarshal([]byte(results[0].Output), &cliOutput)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to parse output from clone snapshot %v: %v", vcr.Snapshot, err)
+		return nil, errors.Errorf("Unable to parse output from clone snapshot %v: %v", vcr.Snapshot, err)
 	}
 	logger.Debug("%+v\n", cliOutput)
 	if cliOutput.OpRet != 0 {
-		return nil, fmt.Errorf("Failed to clone snapshot %v to volume %v: %v", vcr.Snapshot, vcr.Volume, cliOutput.OpErrStr)
+		return nil, errors.Errorf("Failed to clone snapshot %v to volume %v: %v", vcr.Snapshot, vcr.Volume, cliOutput.OpErrStr)
 	}
 
 	// start the newly cloned volume
@@ -136,7 +137,7 @@ func (s *CmdExecutor) SnapshotCloneVolume(host string, vcr *executors.SnapshotCl
 		s.GlusterCliExecTimeout()))
 	if err != nil {
 		s.VolumeDestroy(host, vcr.Volume)
-		return nil, fmt.Errorf("Unable to start volume %v, clone of snapshot %v: %v", vcr.Volume, vcr.Snapshot, err)
+		return nil, errors.Errorf("Unable to start volume %v, clone of snapshot %v: %v", vcr.Volume, vcr.Snapshot, err)
 	}
 
 	return s.VolumeInfo(host, vcr.Volume)
@@ -144,7 +145,7 @@ func (s *CmdExecutor) SnapshotCloneVolume(host string, vcr *executors.SnapshotCl
 
 func (s *CmdExecutor) SnapshotCloneBlockVolume(host string, vcr *executors.SnapshotCloneRequest) (*executors.BlockVolumeInfo, error) {
 	// TODO: cloning of block volume is not implemented yet
-	return nil, fmt.Errorf("block snapshot %v can not be cloned, not implemented yet", vcr.Snapshot)
+	return nil, errors.Errorf("block snapshot %v can not be cloned, not implemented yet", vcr.Snapshot)
 }
 
 func (s *CmdExecutor) SnapshotDestroy(host string, snapshot string) error {
@@ -165,17 +166,17 @@ func (s *CmdExecutor) SnapshotDestroy(host string, snapshot string) error {
 	results, err := s.RemoteExecutor.ExecCommands(host, command,
 		s.GlusterCliExecTimeout())
 	if err := rex.AnyError(results, err); err != nil {
-		return fmt.Errorf("Unable to delete snapshot %v: %v", snapshot, err)
+		return errors.Errorf("Unable to delete snapshot %v: %v", snapshot, err)
 	}
 
 	var snapDelete CliOutput
 	err = xml.Unmarshal([]byte(results[0].Output), &snapDelete)
 	if err != nil {
-		return fmt.Errorf("Unable to parse output from delete snapshot %v: %v", snapshot, err)
+		return errors.Errorf("Unable to parse output from delete snapshot %v: %v", snapshot, err)
 	}
 	logger.Debug("%+v\n", snapDelete)
 	if snapDelete.OpRet != 0 {
-		return fmt.Errorf("Failed to delete snapshot %v: %v", snapshot, snapDelete.OpErrStr)
+		return errors.Errorf("Failed to delete snapshot %v: %v", snapshot, snapDelete.OpErrStr)
 	}
 
 	return nil

--- a/executors/kubeexec/kubeexec.go
+++ b/executors/kubeexec/kubeexec.go
@@ -10,12 +10,12 @@
 package kubeexec
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
 
 	"github.com/lpabon/godbc"
+	"github.com/pkg/errors"
 
 	"github.com/heketi/heketi/executors/cmdexec"
 	"github.com/heketi/heketi/pkg/kubernetes"
@@ -111,7 +111,7 @@ func NewKubeExecutor(config *KubeConfig) (*KubeExecutor, error) {
 	if k.namespace == "" {
 		k.namespace, err = kubernetes.GetNamespace()
 		if err != nil {
-			return nil, fmt.Errorf("Namespace must be provided in configuration: %v", err)
+			return nil, errors.Errorf("Namespace must be provided in configuration: %v", err)
 		}
 	}
 

--- a/executors/sshexec/sshexec.go
+++ b/executors/sshexec/sshexec.go
@@ -10,12 +10,11 @@
 package sshexec
 
 import (
-	"errors"
-	"fmt"
 	"os"
 	"strconv"
 
 	"github.com/lpabon/godbc"
+	"github.com/pkg/errors"
 
 	"github.com/heketi/heketi/executors/cmdexec"
 	"github.com/heketi/heketi/pkg/logging"
@@ -92,7 +91,7 @@ func NewSshExecutor(config *SshConfig) (*SshExecutor, error) {
 
 	// Set configuration
 	if config.PrivateKeyFile == "" {
-		return nil, fmt.Errorf("Missing ssh private key file in configuration")
+		return nil, errors.Errorf("Missing ssh private key file in configuration")
 	}
 	s.private_keyfile = config.PrivateKeyFile
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: 5fc263bfacc703e0a599166ccae968891dd53d7b4e42a3d8356b3194e45833bb
-updated: 2018-06-01T15:20:52.053211272+02:00
+hash: a0d827c44acfe32e2ca3451fe5ed9698ae05a6699501c62d62e25eb8c45c1b07
+updated: 2018-09-12T14:53:08.51941599+02:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
 - name: github.com/asaskevich/govalidator
-  version: 852d82c746b23d9b357b210ea470d99f4e023b72
+  version: 593d64559f7600f29581a3ee42177f5dbded27a9
 - name: github.com/auth0/go-jwt-middleware
   version: f3f7de3b9e394e3af3b88e1b9457f6f71d1ae0ac
 - name: github.com/Azure/go-ansiterm
@@ -12,17 +12,17 @@ imports:
   subpackages:
   - winterm
 - name: github.com/beorn7/perks
-  version: 3a771d992973f24aa725d07868b467d1ddfceafb
+  version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
   subpackages:
   - quantile
 - name: github.com/boltdb/bolt
-  version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
+  version: 2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
 - name: github.com/dgrijalva/jwt-go
-  version: d2709f9f1f31ebcda9651b03077758c1f3a0018c
+  version: 06ea1031745cb8b3dab3f6a236daf2b0aa468b7e
 - name: github.com/docker/distribution
   version: cd27f179f2c10c5d300e6d09025b538c475b0d51
   subpackages:
@@ -73,7 +73,7 @@ imports:
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 3a3da3a4e26776cc22a79ef46d5d58477532dede
+  version: 8616e8ee5e20a1704615e6c8d7afcdac06087a67
   subpackages:
   - proto
 - name: github.com/google/gofuzz
@@ -101,11 +101,13 @@ imports:
   - jlexer
   - jwriter
 - name: github.com/matttproud/golang_protobuf_extensions
-  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:
-  - pbuti
+  - pbutil
 - name: github.com/mitchellh/go-wordwrap
   version: ad45545899c7b13c020ea92b2072220eefad42b8
+- name: github.com/pkg/errors
+  version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/prometheus/client_golang
   version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:
@@ -126,7 +128,7 @@ imports:
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
-- name: github.com/sirupsen/logrus
+- name: github.com/Sirupsen/logrus
   version: 51fe59aca108dc5680109e7b2051cbdcfa5a253c
 - name: github.com/spf13/cobra
   version: ca57f0f5dba473a8a58765d16d7e811fb8027add
@@ -137,7 +139,7 @@ imports:
   subpackages:
   - codec
 - name: github.com/urfave/negroni
-  version: fde5e16d32adc7ad637e9cd9ad21d4ebc6192535
+  version: 5dbbc83f748fc3ad38585842b0aedab546d0ea1e
 - name: golang.org/x/crypto
   version: d172538b2cfce0c13cee31e647d0367aa8cd2486
   subpackages:
@@ -297,7 +299,6 @@ imports:
   - pkg/apis/storage/install
   - pkg/apis/storage/v1
   - pkg/apis/storage/v1beta1
-  - pkg/client/clientset_generated
   - pkg/client/clientset_generated/clientset
   - pkg/client/clientset_generated/clientset/fake
   - pkg/client/clientset_generated/clientset/scheme

--- a/glide.yaml
+++ b/glide.yaml
@@ -24,3 +24,5 @@ import:
   version: v3.0.0-beta.0
 - package: github.com/go-ozzo/ozzo-validation
   version: v3.3
+- package: github.com/pkg/errors
+  version: ^0.8.0

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -22,8 +22,9 @@ import (
 	"github.com/auth0/go-jwt-middleware"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/context"
-	"github.com/heketi/heketi/pkg/logging"
 	"github.com/pkg/errors"
+
+	"github.com/heketi/heketi/pkg/logging"
 )
 
 var (

--- a/pkg/db/wrap.go
+++ b/pkg/db/wrap.go
@@ -10,9 +10,8 @@
 package db
 
 import (
-	"errors"
-
 	"github.com/boltdb/bolt"
+	"github.com/pkg/errors"
 )
 
 // RODB provides an abstraction for all types of db connection that

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-ozzo/ozzo-validation"
 	"github.com/go-ozzo/ozzo-validation/is"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -45,7 +46,7 @@ func ValidateUUID(value interface{}) error {
 	s, _ := value.(string)
 	err := validation.Validate(s, validation.RuneLength(32, 32), is.Hexadecimal)
 	if err != nil {
-		return fmt.Errorf("%v is not a valid UUID", s)
+		return errors.Errorf("%v is not a valid UUID", s)
 	}
 	return nil
 }
@@ -64,7 +65,7 @@ func ValidateEntryState(value interface{}) error {
 	s, _ := value.(EntryState)
 	err := validation.Validate(s, validation.Required, validation.In(EntryStateOnline, EntryStateOffline, EntryStateFailed))
 	if err != nil {
-		return fmt.Errorf("%v is not valid state", s)
+		return errors.Errorf("%v is not valid state", s)
 	}
 	return nil
 }
@@ -81,7 +82,7 @@ func ValidateDurabilityType(value interface{}) error {
 	s, _ := value.(DurabilityType)
 	err := validation.Validate(s, validation.Required, validation.In(DurabilityReplicate, DurabilityDistributeOnly, DurabilityEC))
 	if err != nil {
-		return fmt.Errorf("%v is not a valid durability type", s)
+		return errors.Errorf("%v is not a valid durability type", s)
 	}
 	return nil
 }
@@ -114,7 +115,7 @@ func ValidateManagementHostname(value interface{}) error {
 	for _, fqdn := range s {
 		err := validation.Validate(fqdn, validation.Required, is.Host)
 		if err != nil {
-			return fmt.Errorf("%v is not a valid manage hostname", s)
+			return errors.Errorf("%v is not a valid manage hostname", s)
 		}
 	}
 	return nil
@@ -125,7 +126,7 @@ func ValidateStorageHostname(value interface{}) error {
 	for _, ip := range s {
 		err := validation.Validate(ip, validation.Required, is.Host)
 		if err != nil {
-			return fmt.Errorf("%v is not a valid storage hostname", s)
+			return errors.Errorf("%v is not a valid storage hostname", s)
 		}
 	}
 	return nil
@@ -459,24 +460,24 @@ func (tcr TagsChangeRequest) Validate() error {
 func ValidateTags(v interface{}) error {
 	t, ok := v.(map[string]string)
 	if !ok {
-		return fmt.Errorf("tags must be a map of strings to strings")
+		return errors.Errorf("tags must be a map of strings to strings")
 	}
 	if len(t) > 32 {
-		return fmt.Errorf("too many tags specified (%v), up to %v supported",
+		return errors.Errorf("too many tags specified (%v), up to %v supported",
 			len(t), 32)
 	}
 	for k, v := range t {
 		if len(k) == 0 {
-			return fmt.Errorf("tag names may not be empty")
+			return errors.Errorf("tag names may not be empty")
 		}
 		if err := validation.Validate(k, validation.RuneLength(1, 32)); err != nil {
-			return fmt.Errorf("tag name %v: %v", k, err)
+			return errors.Errorf("tag name %v: %v", k, err)
 		}
 		if err := validation.Validate(v, validation.RuneLength(0, 64)); err != nil {
-			return fmt.Errorf("value of tag %v: %v", k, err)
+			return errors.Errorf("value of tag %v: %v", k, err)
 		}
 		if !tagNameRe.MatchString(k) {
-			return fmt.Errorf("invalid characters in tag name %+v", k)
+			return errors.Errorf("invalid characters in tag name %+v", k)
 		}
 	}
 	return nil

--- a/pkg/kubernetes/backupdb_test.go
+++ b/pkg/kubernetes/backupdb_test.go
@@ -12,15 +12,14 @@ package kubernetes
 import (
 	"bytes"
 	"compress/gzip"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/boltdb/bolt"
-
 	"github.com/heketi/tests"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
@@ -39,7 +38,7 @@ func TestBackupToKubeSecretFailedClusterConfig(t *testing.T) {
 	incluster_count := 0
 	defer tests.Patch(&inClusterConfig, func() (*restclient.Config, error) {
 		incluster_count++
-		return nil, fmt.Errorf("TEST")
+		return nil, errors.Errorf("TEST")
 	}).Restore()
 
 	config_count := 0
@@ -81,7 +80,7 @@ func TestBackupToKubeSecretFailedNewConfig(t *testing.T) {
 	config_count := 0
 	defer tests.Patch(&newForConfig, func(c *restclient.Config) (clientset.Interface, error) {
 		config_count++
-		return nil, fmt.Errorf("TEST")
+		return nil, errors.Errorf("TEST")
 	}).Restore()
 
 	ns := "default"
@@ -123,7 +122,7 @@ func TestBackupToKubeSecretFailedNamespace(t *testing.T) {
 	ns_count := 0
 	defer tests.Patch(&getNamespace, func() (string, error) {
 		ns_count++
-		return "", fmt.Errorf("TEST")
+		return "", errors.Errorf("TEST")
 	}).Restore()
 
 	// Try to backup

--- a/pkg/kubernetes/namespace.go
+++ b/pkg/kubernetes/namespace.go
@@ -10,10 +10,10 @@
 package kubernetes
 
 import (
-	"fmt"
 	"io/ioutil"
 	"strings"
 
+	"github.com/pkg/errors"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/v1"
 )
@@ -26,7 +26,7 @@ const (
 func GetNamespace() (string, error) {
 	data, err := ioutil.ReadFile(KubeNameSpaceFile)
 	if err != nil {
-		return "", fmt.Errorf("File %v not found", KubeNameSpaceFile)
+		return "", errors.Errorf("File %v not found", KubeNameSpaceFile)
 	}
 	if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
 		return ns, nil

--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/lpabon/godbc"
+	"github.com/pkg/errors"
 )
 
 type LogLevel int
@@ -115,7 +116,7 @@ func (l *Logger) LogError(format string, v ...interface{}) error {
 		logWithLongFile(l.errorlog, format, v...)
 	}
 
-	return fmt.Errorf(format, v...)
+	return errors.Errorf(format, v...)
 }
 
 // Log error variable

--- a/pkg/logging/log_test.go
+++ b/pkg/logging/log_test.go
@@ -11,12 +11,11 @@ package logging
 
 import (
 	"bytes"
-	"errors"
-	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/heketi/tests"
+	"github.com/pkg/errors"
 )
 
 func TestLogLevel(t *testing.T) {
@@ -109,7 +108,7 @@ func TestLogWarnErr(t *testing.T) {
 	tests.Assert(t, err == ErrSample)
 	testbuffer.Reset()
 
-	err = l.WarnErr(fmt.Errorf("GOT %v", err))
+	err = l.WarnErr(errors.Errorf("GOT %v", err))
 	tests.Assert(t, strings.Contains(testbuffer.String(), "[testing] WARNING "), testbuffer.String())
 	tests.Assert(t, strings.Contains(testbuffer.String(), "TEST ERROR"), testbuffer.String())
 	tests.Assert(t, strings.Contains(testbuffer.String(), "log_test.go"), testbuffer.String())
@@ -187,7 +186,7 @@ func TestLogErr(t *testing.T) {
 	tests.Assert(t, err == ErrSample)
 	testbuffer.Reset()
 
-	err = l.Err(fmt.Errorf("GOT %v", err))
+	err = l.Err(errors.Errorf("GOT %v", err))
 	tests.Assert(t, strings.Contains(testbuffer.String(), "[testing] ERROR "), testbuffer.String())
 	tests.Assert(t, strings.Contains(testbuffer.String(), "TEST ERROR"), testbuffer.String())
 	tests.Assert(t, strings.Contains(testbuffer.String(), "log_test.go"), testbuffer.String())

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -10,9 +10,10 @@
 package paths
 
 import (
-	"errors"
 	"path"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 const (

--- a/pkg/remoteexec/kube/conn.go
+++ b/pkg/remoteexec/kube/conn.go
@@ -10,8 +10,7 @@
 package kube
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	restclient "k8s.io/client-go/rest"
 	client "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/typed/core/v1"
@@ -54,14 +53,14 @@ func NewKubeConnWithConfig(l logger, rc *restclient.Config) (*KubeConn, error) {
 	// Get a raw REST client.  This is still needed for kube-exec
 	restCore, err := coreclient.NewForConfig(k.kubeConfig)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to create a client connection: %v", err)
+		return nil, errors.Errorf("Unable to create a client connection: %v", err)
 	}
 	k.rest = restCore.RESTClient()
 
 	// Get a Go-client for Kubernetes
 	k.kube, err = client.NewForConfig(k.kubeConfig)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to create a client set: %v", err)
+		return nil, errors.Errorf("Unable to create a client set: %v", err)
 	}
 	return k, nil
 }
@@ -73,7 +72,7 @@ func NewKubeConn(l logger) (*KubeConn, error) {
 	// Create a Kube client configuration using pkg callback
 	rc, err := InClusterConfig()
 	if err != nil {
-		return nil, fmt.Errorf(
+		return nil, errors.Errorf(
 			"Unable to create configuration for Kubernetes: %v", err)
 	}
 	return NewKubeConnWithConfig(l, rc)

--- a/pkg/remoteexec/kube/conn_test.go
+++ b/pkg/remoteexec/kube/conn_test.go
@@ -13,15 +13,15 @@ import (
 	"fmt"
 	"testing"
 
-	restclient "k8s.io/client-go/rest"
-
 	"github.com/heketi/tests"
+	"github.com/pkg/errors"
+	restclient "k8s.io/client-go/rest"
 )
 
 type dummyLogger struct{}
 
 func (*dummyLogger) LogError(s string, v ...interface{}) error {
-	e := fmt.Errorf(s, v...)
+	e := errors.Errorf(s, v...)
 	fmt.Printf("Error: %v\n", e)
 	return e
 }

--- a/pkg/remoteexec/kube/exec.go
+++ b/pkg/remoteexec/kube/exec.go
@@ -11,9 +11,9 @@ package kube
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/unversioned/remotecommand"
 	kubeletcmd "k8s.io/kubernetes/pkg/kubelet/server/remotecommand"
@@ -58,7 +58,7 @@ func ExecCommands(
 		exec, err := remotecommand.NewExecutor(k.kubeConfig, "POST", req.URL())
 		if err != nil {
 			k.logger.Err(err)
-			return nil, fmt.Errorf("Unable to setup a session with %v", t.PodName)
+			return nil, errors.Errorf("Unable to setup a session with %v", t.PodName)
 		}
 
 		// Create a buffer to trap session output

--- a/pkg/remoteexec/kube/target.go
+++ b/pkg/remoteexec/kube/target.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/heketi/heketi/pkg/kubernetes"
@@ -54,7 +55,7 @@ func (t TargetLabel) GetTargetPod(k *KubeConn) (TargetPod, error) {
 	if ns == "" {
 		ns, err = kubernetes.GetNamespace()
 		if err != nil {
-			return tp, fmt.Errorf("Namespace must be provided in configuration: %v", err)
+			return tp, errors.Errorf("Namespace must be provided in configuration: %v", err)
 		}
 	}
 	tp.Namespace = ns
@@ -65,13 +66,13 @@ func (t TargetLabel) GetTargetPod(k *KubeConn) (TargetPod, error) {
 	})
 	if err != nil {
 		k.logger.Err(err)
-		return tp, fmt.Errorf("Failed to get list of pods")
+		return tp, errors.Errorf("Failed to get list of pods")
 	}
 
 	numPods := len(pods.Items)
 	if numPods == 0 {
 		// No pods found with that label
-		err := fmt.Errorf("No pods with the label '%v=%v' were found",
+		err := errors.Errorf("No pods with the label '%v=%v' were found",
 			t.Key, t.Value)
 		k.logger.Critical(err.Error())
 		return tp, err
@@ -82,7 +83,7 @@ func (t TargetLabel) GetTargetPod(k *KubeConn) (TargetPod, error) {
 		for i, p := range pods.Items {
 			names[i] = p.Name
 		}
-		err := fmt.Errorf("Found %v pods sharing the same label '%v=%v': %v",
+		err := errors.Errorf("Found %v pods sharing the same label '%v=%v': %v",
 			numPods, t.Key, t.Value, strings.Join(names, ", "))
 		k.logger.Critical(err.Error())
 		return tp, err
@@ -120,7 +121,7 @@ func (t TargetDaemonSet) GetTargetPod(k *KubeConn) (TargetPod, error) {
 	if ns == "" {
 		ns, err = kubernetes.GetNamespace()
 		if err != nil {
-			return tp, fmt.Errorf("Namespace must be provided in configuration: %v", err)
+			return tp, errors.Errorf("Namespace must be provided in configuration: %v", err)
 		}
 	}
 	tp.Namespace = ns
@@ -176,7 +177,7 @@ func (t TargetPod) FirstContainer(k *KubeConn) (TargetContainer, error) {
 	tc := TargetContainer{TargetPod: t}
 	podSpec, err := k.kube.Core().Pods(t.Namespace).Get(t.PodName, v1.GetOptions{})
 	if err != nil {
-		return tc, fmt.Errorf("Unable to get pod spec for %v: %v",
+		return tc, errors.Errorf("Unable to get pod spec for %v: %v",
 			t.PodName, err)
 	}
 	tc.ContainerName = podSpec.Spec.Containers[0].Name

--- a/pkg/remoteexec/result.go
+++ b/pkg/remoteexec/result.go
@@ -10,7 +10,7 @@
 package remoteexec
 
 import (
-	"errors"
+	"github.com/pkg/errors"
 )
 
 // Result is used to capture the result of running a command

--- a/pkg/remoteexec/result_test.go
+++ b/pkg/remoteexec/result_test.go
@@ -10,10 +10,10 @@
 package remoteexec
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/heketi/tests"
+	"github.com/pkg/errors"
 )
 
 func TestResultOk(t *testing.T) {
@@ -35,7 +35,7 @@ func TestResultOk(t *testing.T) {
 	r = Result{
 		Completed:  true,
 		ErrOutput:  "Bar bar bar",
-		Err:        fmt.Errorf("command exited 1"),
+		Err:        errors.Errorf("command exited 1"),
 		ExitStatus: 1,
 	}
 	tests.Assert(t, !r.Ok(), "expected r.Ok() to be false")
@@ -43,7 +43,7 @@ func TestResultOk(t *testing.T) {
 	// only error set. possibly indicating a conn error
 	r = Result{
 		Completed: true,
-		Err:       fmt.Errorf("something broke"),
+		Err:       errors.Errorf("something broke"),
 	}
 	tests.Assert(t, !r.Ok(), "expected r.Ok() to be false")
 }
@@ -67,7 +67,7 @@ func TestResultError(t *testing.T) {
 	r = Result{
 		Completed:  true,
 		ErrOutput:  "Bar bar bar",
-		Err:        fmt.Errorf("command exited 1"),
+		Err:        errors.Errorf("command exited 1"),
 		ExitStatus: 1,
 	}
 	tests.Assert(t, r.Error() == "Bar bar bar",
@@ -76,7 +76,7 @@ func TestResultError(t *testing.T) {
 	// only error set. possibly indicating a conn error
 	r = Result{
 		Completed: true,
-		Err:       fmt.Errorf("something broke"),
+		Err:       errors.Errorf("something broke"),
 	}
 	tests.Assert(t, r.Error() == "something broke",
 		"expected \"something broke\" got:", r.Error())
@@ -108,7 +108,7 @@ func TestSquashErrors(t *testing.T) {
 	rs = append(rs, Result{
 		Completed:  true,
 		ErrOutput:  "Bar bar bar",
-		Err:        fmt.Errorf("command exited 1"),
+		Err:        errors.Errorf("command exited 1"),
 		ExitStatus: 1,
 	})
 	o, e = rs.SquashErrors()
@@ -164,7 +164,7 @@ func TestResultsOk(t *testing.T) {
 	rs[2] = Result{
 		Completed:  true,
 		ErrOutput:  "Bar bar bar",
-		Err:        fmt.Errorf("command exited 1"),
+		Err:        errors.Errorf("command exited 1"),
 		ExitStatus: 1,
 	}
 
@@ -204,7 +204,7 @@ func TestResultsFirstErrorIndexed(t *testing.T) {
 	rs[2] = Result{
 		Completed:  true,
 		ErrOutput:  "Bar bar bar",
-		Err:        fmt.Errorf("command exited 1"),
+		Err:        errors.Errorf("command exited 1"),
 		ExitStatus: 1,
 	}
 
@@ -227,7 +227,7 @@ func TestResultsFirstErrorIndexed(t *testing.T) {
 	rs[1] = Result{
 		Completed:  true,
 		ErrOutput:  "Robble robble",
-		Err:        fmt.Errorf("command exited 1"),
+		Err:        errors.Errorf("command exited 1"),
 		ExitStatus: 1,
 	}
 
@@ -267,7 +267,7 @@ func TestResultsFirstError(t *testing.T) {
 	rs[2] = Result{
 		Completed:  true,
 		ErrOutput:  "Bar bar bar",
-		Err:        fmt.Errorf("command exited 1"),
+		Err:        errors.Errorf("command exited 1"),
 		ExitStatus: 1,
 	}
 
@@ -288,7 +288,7 @@ func TestResultsFirstError(t *testing.T) {
 	rs[1] = Result{
 		Completed:  true,
 		ErrOutput:  "Robble robble",
-		Err:        fmt.Errorf("command exited 1"),
+		Err:        errors.Errorf("command exited 1"),
 		ExitStatus: 1,
 	}
 
@@ -324,7 +324,7 @@ func TestAnyError(t *testing.T) {
 	e = AnyError(rs, nil)
 	tests.Assert(t, e == nil, "expected e == nil, got:", e)
 
-	e = AnyError(rs, fmt.Errorf("Robble robble"))
+	e = AnyError(rs, errors.Errorf("Robble robble"))
 	tests.Assert(t, e != nil, "expected e != nil, got:", e)
 	tests.Assert(t, e.Error() == "Robble robble",
 		"expected \"Robble robble\" got:", e.Error())
@@ -332,7 +332,7 @@ func TestAnyError(t *testing.T) {
 	rs[2] = Result{
 		Completed:  true,
 		ErrOutput:  "Bar bar bar",
-		Err:        fmt.Errorf("command exited 1"),
+		Err:        errors.Errorf("command exited 1"),
 		ExitStatus: 1,
 	}
 
@@ -341,7 +341,7 @@ func TestAnyError(t *testing.T) {
 	tests.Assert(t, e.Error() == "Bar bar bar",
 		"expected \"Bar bar bar\" got:", e.Error())
 
-	e = AnyError(rs, fmt.Errorf("Robble robble"))
+	e = AnyError(rs, errors.Errorf("Robble robble"))
 	tests.Assert(t, e != nil, "expected e != nil, got:", e)
 	tests.Assert(t, e.Error() == "Robble robble",
 		"expected \"Robble robble\" got:", e.Error())

--- a/pkg/remoteexec/ssh/ssh.go
+++ b/pkg/remoteexec/ssh/ssh.go
@@ -11,13 +11,13 @@ package ssh
 
 import (
 	"bytes"
-	"errors"
 	"io/ioutil"
 	"log"
 	"net"
 	"os"
 	"time"
 
+	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 

--- a/pkg/testutils/serverctl.go
+++ b/pkg/testutils/serverctl.go
@@ -15,13 +15,14 @@
 package testutils
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path"
 	"syscall"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 type ServerCfg struct {

--- a/pkg/utils/bodystring.go
+++ b/pkg/utils/bodystring.go
@@ -13,12 +13,12 @@
 package utils
 
 import (
-	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // Return the body from a response as a string
@@ -40,7 +40,7 @@ func GetErrorFromResponse(r *http.Response) error {
 
 	s = strings.TrimSpace(s)
 	if len(s) == 0 {
-		return fmt.Errorf("server did not provide a message (status %v: %v)", r.StatusCode, http.StatusText(r.StatusCode))
+		return errors.Errorf("server did not provide a message (status %v: %v)", r.StatusCode, http.StatusText(r.StatusCode))
 	}
 	return errors.New(s)
 }

--- a/pkg/utils/bodystring_test.go
+++ b/pkg/utils/bodystring_test.go
@@ -14,11 +14,11 @@ package utils
 
 import (
 	"bytes"
-	"errors"
 	"net/http"
 	"testing"
 
 	"github.com/heketi/tests"
+	"github.com/pkg/errors"
 )
 
 type testGetStringFromResponseBody struct {

--- a/pkg/utils/jsonutils_test.go
+++ b/pkg/utils/jsonutils_test.go
@@ -14,12 +14,12 @@ package utils
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"net/http"
 	"testing"
 
 	"github.com/heketi/tests"
+	"github.com/pkg/errors"
 )
 
 type testDest struct {

--- a/pkg/utils/statusgroup_test.go
+++ b/pkg/utils/statusgroup_test.go
@@ -13,11 +13,12 @@
 package utils
 
 import (
-	"errors"
 	"fmt"
-	"github.com/heketi/tests"
 	"testing"
 	"time"
+
+	"github.com/heketi/tests"
+	"github.com/pkg/errors"
 )
 
 func TestNewStatusGroup(t *testing.T) {


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

The errors we return and handle are forwarded through many levels of the function call stack, so often -- especially while debugging -- it can be very hard to see, where an error really is originating from. This is especially true if errors are forwarded through channels to different goroutines or asynchronously from 3rd party libraries.

In order to improve this situation the advice of [this](https://dave.cheney.net/2016/06/12/stack-traces-and-the-errors-package) blog article has been followed. That is the [github.com/pkg/errors](https://godoc.org/github.com/pkg/errors) package is used instead of the standard errors package throughout the code base, which annotates all errors with a stack trace, and also allows to wrap errors with new stack traces, in case of "stack-switches", like when they are transferred asynchronously over channels or come in from 3rd party libraries. The only "old" errors that are kept are the sentinel errors defined in apps/glusterfs/errors.go.
