### PR TITLE
Fix error message in glusterfs.DbCreate()

### DIFF
--- a/apps/glusterfs/db_operations.go
+++ b/apps/glusterfs/db_operations.go
@@ -299,7 +299,7 @@ func DbCreate(jsonfile string, dbfile string) error {
 				volume.Durability = NewNoneDurability()
 
 			default:
-				return fmt.Errorf("Not a known volume type: %v", err.Error())
+				return fmt.Errorf("Not a known volume durability type: %v", durability)
 			}
 
 			// Set the default values accordingly


### PR DESCRIPTION
The created error message in https://github.com/heketi/heketi/blob/master/apps/glusterfs/db_operations.go#L302 incorporates `err`, which refers to an `err` variable that is always `nil` by https://github.com/heketi/heketi/blob/master/apps/glusterfs/db_operations.go#L272-L275 .

I assume this is a copy and paste mistake and replaced it with the value of the `durability` variable, which this switch is about and hence makes more sense to report.