### PR TITLE
Add more comprehensive results for command execution

### DIFF
--- a/executors/cmdexec/cmdexec.go
+++ b/executors/cmdexec/cmdexec.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	"github.com/heketi/heketi/pkg/logging"
+	rex "github.com/heketi/heketi/pkg/remoteexec"
 )
 
 var (
@@ -21,6 +22,7 @@ var (
 
 type RemoteCommandTransport interface {
 	RemoteCommandExecute(host string, commands []string, timeoutMinutes int) ([]string, error)
+	ExecCommands(host string, commands []string, timeoutMinutes int) (rex.Results, error)
 	RebalanceOnExpansion() bool
 	SnapShotLimit() int
 }

--- a/executors/cmdexec/peer_test.go
+++ b/executors/cmdexec/peer_test.go
@@ -12,6 +12,7 @@ package cmdexec
 import (
 	"testing"
 
+	rex "github.com/heketi/heketi/pkg/remoteexec"
 	"github.com/heketi/tests"
 )
 
@@ -25,7 +26,7 @@ func TestSshExecPeerProbe(t *testing.T) {
 	f.FakeConnectAndExec = func(host string,
 		commands []string,
 		timeoutMinutes int,
-		useSudo bool) ([]string, error) {
+		useSudo bool) (rex.Results, error) {
 
 		tests.Assert(t, host == "host:22", host)
 		tests.Assert(t, len(commands) == 1)
@@ -49,7 +50,7 @@ func TestSshExecPeerProbe(t *testing.T) {
 	f.FakeConnectAndExec = func(host string,
 		commands []string,
 		timeoutMinutes int,
-		useSudo bool) ([]string, error) {
+		useSudo bool) (rex.Results, error) {
 
 		switch count {
 		case 0:
@@ -87,7 +88,7 @@ func TestSshExecGlusterdCheck(t *testing.T) {
 	f.FakeConnectAndExec = func(host string,
 		commands []string,
 		timeoutMinutes int,
-		useSudo bool) ([]string, error) {
+		useSudo bool) (rex.Results, error) {
 
 		tests.Assert(t, host == "newhost:22", host)
 		tests.Assert(t, len(commands) == 1)

--- a/executors/sshexec/sshexec_test.go
+++ b/executors/sshexec/sshexec_test.go
@@ -15,25 +15,26 @@ import (
 
 	"github.com/heketi/heketi/executors/cmdexec"
 	"github.com/heketi/heketi/pkg/logging"
+	rex "github.com/heketi/heketi/pkg/remoteexec"
 	"github.com/heketi/tests"
 )
 
 // Mock SSH calls
 type FakeSsh struct {
-	FakeConnectAndExec func(host string,
+	FakeExecCommands func(host string,
 		commands []string,
 		timeoutMinutes int,
-		useSudo bool) ([]string, error)
+		useSudo bool) (rex.Results, error)
 }
 
 func NewFakeSsh() *FakeSsh {
 	f := &FakeSsh{}
 
-	f.FakeConnectAndExec = func(host string,
+	f.FakeExecCommands = func(host string,
 		commands []string,
 		timeoutMinutes int,
-		useSudo bool) ([]string, error) {
-		return []string{""}, nil
+		useSudo bool) (rex.Results, error) {
+		return rex.Results{}, nil
 	}
 
 	return f
@@ -43,7 +44,15 @@ func (f *FakeSsh) ConnectAndExec(host string,
 	commands []string,
 	timeoutMinutes int,
 	useSudo bool) ([]string, error) {
-	return f.FakeConnectAndExec(host, commands, timeoutMinutes, useSudo)
+	return []string{}, nil
+
+}
+
+func (f *FakeSsh) ExecCommands(host string,
+	commands []string,
+	timeoutMinutes int,
+	useSudo bool) (rex.Results, error) {
+	return f.FakeExecCommands(host, commands, timeoutMinutes, useSudo)
 
 }
 

--- a/pkg/remoteexec/result.go
+++ b/pkg/remoteexec/result.go
@@ -1,0 +1,51 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package remoteexec
+
+import (
+	"errors"
+)
+
+// Result is used to capture the result of running a command
+// on a remote system.
+type Result struct {
+	Completed  bool
+	Output     string
+	ErrOutput  string
+	Err        error
+	ExitStatus int
+}
+
+// Ok returns a boolean indicating that the command ran and
+// completed successfully.
+func (r Result) Ok() bool {
+	return r.Completed && r.Err == nil && r.ExitStatus == 0
+}
+
+// Results is used for a grouping of Result items.
+type Results []Result
+
+// SquashErrors converts a fully fledged results array into a
+// simple array of strings and a single error code. This
+// is the style most code in heketi currently expects and
+// exists to ease refactoring.
+func (rs Results) SquashErrors() ([]string, error) {
+	outputs := make([]string, len(rs))
+	for i, result := range rs {
+		if !result.Completed {
+			break
+		}
+		if result.Err != nil || result.ExitStatus != 0 {
+			return nil, errors.New(result.ErrOutput)
+		}
+		outputs[i] = result.Output
+	}
+	return outputs, nil
+}

--- a/pkg/remoteexec/ssh/ssh.go
+++ b/pkg/remoteexec/ssh/ssh.go
@@ -12,16 +12,17 @@ package ssh
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net"
 	"os"
 	"time"
 
-	"github.com/heketi/heketi/pkg/logging"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
+
+	"github.com/heketi/heketi/pkg/logging"
+	rex "github.com/heketi/heketi/pkg/remoteexec"
 )
 
 type SshExec struct {
@@ -115,7 +116,18 @@ func NewSshExecWithPassword(logger *logging.Logger, user string, password string
 // This function was based from https://github.com/coreos/etcd-manager/blob/master/main.go
 func (s *SshExec) ConnectAndExec(host string, commands []string, timeoutMinutes int, useSudo bool) ([]string, error) {
 
-	buffers := make([]string, len(commands))
+	results, err := s.ExecCommands(host, commands, timeoutMinutes, useSudo)
+	if err != nil {
+		return nil, err
+	}
+	return results.SquashErrors()
+}
+
+func (s *SshExec) ExecCommands(
+	host string, commands []string,
+	timeoutMinutes int, useSudo bool) (rex.Results, error) {
+
+	results := make(rex.Results, len(commands))
 
 	// :TODO: Will need a timeout here in case the server does not respond
 	client, err := ssh.Dial("tcp", host, s.clientConfig)
@@ -165,13 +177,33 @@ func (s *SshExec) ConnectAndExec(host string, commands []string, timeoutMinutes 
 		// Wait for either the command completion or timeout
 		select {
 		case err := <-errch:
-			if err != nil {
-				s.logger.LogError("Failed to run command [%v] on %v: Err[%v]: Stdout [%v]: Stderr [%v]",
-					command, host, err, b.String(), berr.String())
-				return nil, fmt.Errorf("%s", berr.String())
+			r := rex.Result{
+				Completed: true,
+				Output:    b.String(),
+				ErrOutput: berr.String(),
+				Err:       err,
 			}
-			s.logger.Debug("Host: %v Command: %v\nResult: %v", host, command, b.String())
-			buffers[index] = b.String()
+			if err == nil {
+				s.logger.Debug(
+					"Ran command [%v] on %v: Stdout [%v]: Stderr [%v]",
+					command, host, r.Output, r.ErrOutput)
+			} else {
+				s.logger.LogError(
+					"Failed to run command [%v] on %v: Err[%v]: Stdout [%v]: Stderr [%v]",
+					command, host, err, r.Output, r.ErrOutput)
+				// extract the real error code if possible
+				if ee, ok := err.(*ssh.ExitError); ok {
+					r.ExitStatus = ee.ExitStatus()
+				} else {
+					r.ExitStatus = 1
+				}
+			}
+			results[index] = r
+			if r.ExitStatus != 0 {
+				// stop running commands on error
+				// TODO: make caller configurable?)
+				return results, nil
+			}
 
 		case <-timeout:
 			s.logger.LogError("Timeout on command [%v] on %v: Err[%v]: Stdout [%v]: Stderr [%v]",
@@ -181,9 +213,9 @@ func (s *SshExec) ConnectAndExec(host string, commands []string, timeoutMinutes 
 				s.logger.LogError("Unable to send kill signal to command [%v] on host [%v]: %v",
 					command, host, err)
 			}
-			return nil, errors.New("SSH command timeout")
+			return results, errors.New("SSH command timeout")
 		}
 	}
 
-	return buffers, nil
+	return results, nil
 }


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

When working on block volume delete it was discovered (or at least brought to the forefront) that Heketi's remote command execution functions were discarding stdout on command error and discarding stderr on command success. This isn't very unixy and quite unhelpful for handling the outputs of gluster-block. This PR reworks adds new types, "Result" and "Results" such that the code can return Results that have a lot more information about each command's result.

These new command running functions are plumbed through the various layers and used to clean up the block volume delete executor function (and demonstrate how they should be used).

### Notes for the reviewer

I originally tried to refactor the functions more but it turned into a lot of churn for little benefit. This PR is much more targeted so that it more immediately testable but also exists to demonstrate the direction I think we should aim for the executor and it's supporting packages.
