### PR TITLE
block-volume-optin: add a new network option to block volume

### DIFF
--- a/apps/glusterfs/block_settings.go
+++ b/apps/glusterfs/block_settings.go
@@ -14,5 +14,5 @@ var (
 	CreateBlockHostingVolumes = false
 	// Default 1 TB
 	BlockHostingVolumeSize    = 1024
-	BlockHostingVolumeOptions = "group gluster-block"
+	BlockHostingVolumeOptions = "group gluster-block, server.tcp-user-timeout 42"
 )


### PR DESCRIPTION
As identified in [glusterfs patch](https://review.gluster.org/#/c/glusterfs/+/21170/),
we need option 'server.user-tcp-timeout' to be set on gluster-block volume to mitigate
some of the 'hung status' like behavior when a node goes down. Adding this option on
top of the volume would solve the issue for all the released version of glusterfs,
where this patch is not present, and even in future, if the option is present,
it would serve as no-op, so no need to bother about this.

Signed-off-by: Amar Tumballi <amarts@redhat.com>
