### PR TITLE
Fail device remove if vgremove hits an error

### DIFF
--- a/executors/cmdexec/device.go
+++ b/executors/cmdexec/device.go
@@ -80,7 +80,8 @@ func (s *CmdExecutor) DeviceTeardown(host, device, vgid string) error {
 	// Execute command
 	_, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 5)
 	if err != nil {
-		logger.LogError("Error while deleting device %v with id %v on host %v: %v",
+		return logger.LogError(
+			"Failed to delete device %v with id %v on host %v: %v",
 			device, vgid, host, err)
 	}
 

--- a/executors/cmdexec/device.go
+++ b/executors/cmdexec/device.go
@@ -85,6 +85,8 @@ func (s *CmdExecutor) DeviceTeardown(host, device, vgid string) error {
 			device, vgid, host, err)
 	}
 
+	// TODO: remove this LBYL check and replace it with the rmdir
+	// followed by error condition check that handles ENOENT
 	pdir := utils.BrickMountPointParent(vgid)
 	commands = []string{
 		fmt.Sprintf("ls %v", pdir),


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

When deleting a device do not ignore failures to remove vg/pv.

### Does this PR fix issues?

Fixes #1359


### Notes for the reviewer

Functional test case added.

