### PR TITLE
Add option to force remove a device

### DIFF
--- a/client/api/go-client/device.go
+++ b/client/api/go-client/device.go
@@ -15,6 +15,7 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"time"
 
@@ -99,9 +100,23 @@ func (c *Client) DeviceInfo(id string) (*api.DeviceInfoResponse, error) {
 }
 
 func (c *Client) DeviceDelete(id string) error {
+	return c.DeviceDeleteWithOptions(id, nil)
+}
+
+func (c *Client) DeviceDeleteWithOptions(
+	id string, request *api.DeviceDeleteOptions) error {
+
+	var buf io.Reader
+	if request != nil {
+		b, err := json.Marshal(request)
+		if err != nil {
+			return err
+		}
+		buf = bytes.NewBuffer(b)
+	}
 
 	// Create a request
-	req, err := http.NewRequest("DELETE", c.host+"/devices/"+id, nil)
+	req, err := http.NewRequest("DELETE", c.host+"/devices/"+id, buf)
 	if err != nil {
 		return err
 	}

--- a/client/cli/go/cmds/device.go
+++ b/client/cli/go/cmds/device.go
@@ -43,6 +43,8 @@ func init() {
 		"Set the object to this exact set of tags. Overwrites existing tags.")
 	deviceRmTagsCommand.Flags().Bool("all", false,
 		"Remove all tags.")
+	deviceDeleteCommand.Flags().Bool("force-forget", false,
+		"[DANGEROUS] Force heketi to forget a device, regardless of state.")
 	deviceAddCommand.SilenceUsage = true
 	deviceDeleteCommand.SilenceUsage = true
 	deviceRemoveCommand.SilenceUsage = true
@@ -118,6 +120,11 @@ var deviceDeleteCommand = &cobra.Command{
 		//set clusterId
 		deviceId := cmd.Flags().Arg(0)
 
+		forceForget, err := cmd.Flags().GetBool("force-forget")
+		if err != nil {
+			return err
+		}
+
 		// Create a client
 		heketi, err := newHeketiClient()
 		if err != nil {
@@ -125,7 +132,9 @@ var deviceDeleteCommand = &cobra.Command{
 		}
 
 		//set url
-		err = heketi.DeviceDelete(deviceId)
+		var opts api.DeviceDeleteOptions
+		opts.ForceForget = forceForget
+		err = heketi.DeviceDeleteWithOptions(deviceId, &opts)
 		if err == nil {
 			fmt.Fprintf(stdout, "Device %v deleted\n", deviceId)
 		}

--- a/docs/man/heketi-cli.8
+++ b/docs/man/heketi-cli.8
@@ -146,6 +146,14 @@ $ heketi\-cli device add \\
 .RS
 Deletes a device from Heketi node
 .PP
+\fBOptions\fP
+.RS
+.TP
+\fB\-\-force-forget
+Optional:
+Remove the device from heketi regardless of it's state on the node (DANGEROUS).
+.RE
+.PP
 \fBExample\fP
 .RS
 .nf

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -18,6 +18,7 @@ type Executor interface {
 	DeviceSetup(host, device, vgid string, destroy bool) (*DeviceInfo, error)
 	GetDeviceInfo(host, device, vgid string) (*DeviceInfo, error)
 	DeviceTeardown(host, device, vgid string) error
+	DeviceForget(host, device, vgid string) error
 	BrickCreate(host string, brick *BrickRequest) (*BrickInfo, error)
 	BrickDestroy(host string, brick *BrickRequest) (bool, error)
 	VolumeCreate(host string, volume *VolumeRequest) (*Volume, error)

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -221,6 +221,10 @@ func (m *MockExecutor) DeviceTeardown(host, device, vgid string) error {
 	return m.MockDeviceTeardown(host, device, vgid)
 }
 
+func (m *MockExecutor) DeviceForget(host, device, vgid string) error {
+	return m.MockDeviceTeardown(host, device, vgid)
+}
+
 func (m *MockExecutor) BrickCreate(host string, brick *executors.BrickRequest) (*executors.BrickInfo, error) {
 	return m.MockBrickCreate(host, brick)
 }

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -633,3 +633,11 @@ func (as AdminStatus) Validate() error {
 			validation.Required,
 			validation.In(AdminStateNormal, AdminStateReadOnly, AdminStateLocal)))
 }
+
+// DeviceDeleteOptions is used to specify additional behavior for device
+// deletes.
+type DeviceDeleteOptions struct {
+	// force heketi to forget about a device, possibly
+	// orphaning metadata on the node
+	ForceForget bool `json:"forceforget"`
+}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

PR #1360 added (a correct) handling of errors when a device can not be cleanly removed from the system. However, it is possible that the underlying device on the node really has "gone bad" in such a way that it is truly impossible to have heketi clean it up nicely. For that case this pr adds an option to the device delete api, and a corresponding cli option --force-forget that tells heketi to forget about the device even if it can not clean up the lvm metadata on the device.
This flag is still subject to existing restrictions of device remove, namely:
* Device must be free of bricks
* Device must be in failed state

Before PR #1360 the command worked much like --force-forget does now, with a best effort attempt to remove the VG/PV. Now the options are much more clear cut: delete w/o the flag checks for errors while --force-forget does not.

### Does this PR fix issues?

Fixes #


### Notes for the reviewer

I'm not super thrilled with the naming in the executor changes but I didn't not want to pass around opaque boolean flags, which is something I see as a bit of an anti-pattern.
