### PR TITLE
remove waffle io badge & link from main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Stories in Ready](https://badge.waffle.io/heketi/heketi.png?label=in%20progress&title=In%20Progress)](https://waffle.io/heketi/heketi)
 [![Build Status](https://travis-ci.org/heketi/heketi.svg?branch=master)](https://travis-ci.org/heketi/heketi)
 [![Coverage Status](https://coveralls.io/repos/heketi/heketi/badge.svg)](https://coveralls.io/r/heketi/heketi)
 [![Go Report Card](https://goreportcard.com/badge/github.com/heketi/heketi)](https://goreportcard.com/report/github.com/heketi/heketi)


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

None of the current heketi developers use the waffle.io system previously set up for heketi. Since I joined the project the only times I ever viewed it was when I was wondering, "what is this?"
I've also disabled the associated webhook which was apparently failing for months.

This change removes clutter and possible confusion from the project's README



