### PR TITLE
Default volume options 

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -54,6 +54,14 @@ var (
 	// avoids having to update config files to enable the feature
 	// while avoiding having to touch all of the unit tests.
 	MonitorGlusterNodes = false
+
+	// global var that contains list of volume options that are set *before*
+	// setting the volume options that come as part of volume request.
+	PreReqVolumeOptions = ""
+
+	// global var that contains list of volume options that are set *after*
+	// setting the volume options that come as part of volume request.
+	PostReqVolumeOptions = ""
 )
 
 type App struct {
@@ -311,6 +319,16 @@ func (a *App) setFromEnvironmentalVariable() {
 			a.conf.MaxInflightOperations = uint64(value)
 		}
 	}
+
+	env = os.Getenv("HEKETI_PRE_REQUEST_VOLUME_OPTIONS")
+	if "" != env {
+		a.conf.PreReqVolumeOptions = env
+	}
+
+	env = os.Getenv("HEKETI_POST_REQUEST_VOLUME_OPTIONS")
+	if "" != env {
+		a.conf.PostReqVolumeOptions = env
+	}
 }
 
 func (a *App) setAdvSettings() {
@@ -338,6 +356,15 @@ func (a *App) setAdvSettings() {
 		logger.Info("Average file size on volumes set to %v KiB", a.conf.AverageFileSize)
 		averageFileSize = a.conf.AverageFileSize
 	}
+	if a.conf.PreReqVolumeOptions != "" {
+		logger.Info("Pre Request Volume Options: %v", a.conf.PreReqVolumeOptions)
+		PreReqVolumeOptions = a.conf.PreReqVolumeOptions
+	}
+	if a.conf.PostReqVolumeOptions != "" {
+		logger.Info("Post Request Volume Options: %v", a.conf.PostReqVolumeOptions)
+		PostReqVolumeOptions = a.conf.PostReqVolumeOptions
+	}
+
 }
 
 func (a *App) setBlockSettings() {

--- a/apps/glusterfs/app_config.go
+++ b/apps/glusterfs/app_config.go
@@ -27,10 +27,12 @@ type GlusterFSConfig struct {
 	Loglevel   string              `json:"loglevel"`
 
 	// advanced settings
-	BrickMaxSize    int    `json:"brick_max_size_gb"`
-	BrickMinSize    int    `json:"brick_min_size_gb"`
-	BrickMaxNum     int    `json:"max_bricks_per_volume"`
-	AverageFileSize uint64 `json:"average_file_size_kb"`
+	BrickMaxSize         int    `json:"brick_max_size_gb"`
+	BrickMinSize         int    `json:"brick_min_size_gb"`
+	BrickMaxNum          int    `json:"max_bricks_per_volume"`
+	AverageFileSize      uint64 `json:"average_file_size_kb"`
+	PreReqVolumeOptions  string `json:"pre_request_volume_options"`
+	PostReqVolumeOptions string `json:"post_request_volume_options"`
 
 	//block settings
 	CreateBlockHostingVolumes bool   `json:"auto_create_block_hosting_volume"`

--- a/apps/glusterfs/app_volume_test.go
+++ b/apps/glusterfs/app_volume_test.go
@@ -1334,6 +1334,6 @@ func TestVolumeCreateWithOptions(t *testing.T) {
 	tests.Assert(t, info.Snapshot.Factor == 1)
 	tests.Assert(t, info.Durability.Type == api.DurabilityDistributeOnly)
 	// GlusterVolumeOption should have the "test-option"
-	tests.Assert(t, info.GlusterVolumeOptions[0] == "test-option")
+	tests.Assert(t, strings.Contains(strings.Join(info.GlusterVolumeOptions, ","), "test-option"))
 
 }

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -155,6 +155,18 @@ func NewVolumeEntryFromRequest(req *api.VolumeCreateRequest) *VolumeEntry {
 			vol.GlusterVolumeOptions...)
 	}
 
+	// Add volume options using PreRequestVolumeOptions, this must be
+	// set before volume options from the request are set.
+	preReqVolumeOptions := strings.Split(PreReqVolumeOptions, ",")
+	vol.GlusterVolumeOptions = append(preReqVolumeOptions,
+		vol.GlusterVolumeOptions...)
+
+	// Add volume options using PostRequestVolumeOptions, this must be
+	// set after volume options from the request are set.
+	postReqVolumeOptions := strings.Split(PostReqVolumeOptions, ",")
+	vol.GlusterVolumeOptions = append(vol.GlusterVolumeOptions,
+		postReqVolumeOptions...)
+
 	// If it is zero, then it will be assigned during volume creation
 	vol.Info.Clusters = req.Clusters
 

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -1688,7 +1688,7 @@ func TestNewVolumeEntryWithVolumeOptions(t *testing.T) {
 	tests.Assert(t, v.Info.Size == 1024)
 	tests.Assert(t, len(v.Info.Id) != 0)
 	tests.Assert(t, len(v.Bricks) == 0)
-	tests.Assert(t, v.GlusterVolumeOptions[0] == "test-option")
+	tests.Assert(t, strings.Contains(strings.Join(v.GlusterVolumeOptions, ","), "test-option"))
 
 	err = v.Create(app.db, app.executor)
 	logger.Info("%v", v.Info.Cluster)
@@ -1702,7 +1702,7 @@ func TestNewVolumeEntryWithVolumeOptions(t *testing.T) {
 				Get([]byte(v.Info.Id)))
 	})
 	tests.Assert(t, err == nil)
-	tests.Assert(t, entry.GlusterVolumeOptions[0] == "test-option")
+	tests.Assert(t, strings.Contains(strings.Join(entry.GlusterVolumeOptions, ","), "test-option"))
 
 }
 func TestNewVolumeEntryWithTSPForMountHosts(t *testing.T) {

--- a/etc/heketi.json
+++ b/etc/heketi.json
@@ -87,6 +87,12 @@
     "block_hosting_volume_size": 500,
 
     "_block_hosting_volume_options": "New block hosting volume will be created with the following set of options. Removing the group gluster-block option is NOT recommended. Additional options can be added next to it separated by a comma.",
-    "block_hosting_volume_options": "group gluster-block"
+    "block_hosting_volume_options": "group gluster-block",
+
+    "_pre_request_volume_options": "Volume options that will be applied for all volumes created. Can be overridden by volume options in volume create request.",
+    "pre_request_volume_options": "",
+
+    "_post_request_volume_options": "Volume options that will be applied for all volumes created. To be used to override volume options in volume create request.",
+    "post_request_volume_options": ""
   }
 }


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
    Volume create requests have provision to provide volume options.
    However, a heketi admin does not have any means to set volume options
    by default. This feature allows admin to set default volume options.

    It is possible that heketi admin and heketi volume creator want to
    set different values for the same volume option. To address such use
    cases, admin is provided with two default option lists, as below:

    1. HEKETI_PRE_REQUEST_VOLUME_OPTIONS env variable
       pre_request_volume_options key in config's glusterfs section

    Volume options that will be applied for all volumes created. Can be
    overridden by volume options in volume create request.

    2. HEKETI_POST_REQUEST_VOLUME_OPTIONS env variable
       post_request_volume_options key in config's glusterfs section

    Volume options that will be applied for all volumes created. Will
    override volume options in volume create request.


### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #


### Notes for the reviewer


