### PR TITLE
container: add tcp-user-timeout in default option

### DIFF
--- a/extras/docker/fromsource/heketi-start.sh
+++ b/extras/docker/fromsource/heketi-start.sh
@@ -86,6 +86,23 @@ if [[ -d "${BACKUPDB_PATH}" ]]; then
     fi
 fi
 
+info "HEKETI_PRE_REQUEST_VOLUME_OPTIONS is ${HEKETI_PRE_REQUEST_VOLUME_OPTIONS}"
+if [[ -z "$HEKETI_PRE_REQUEST_VOLUME_OPTIONS" ]]
+then
+        # set the env variable as it is not set
+        export HEKETI_PRE_REQUEST_VOLUME_OPTIONS="server.tcp-user-timeout 42"
+else
+        if [[ ! -z "${HEKETI_PRE_REQUEST_VOLUME_OPTIONS##*server.tcp-user-timeout*}" ]]
+        then
+                # variable exists but does not have tcp-user-timeout set, append it
+                echo "did not find server.tcp-user-timeout in options" >> ${HEKETI_PATH}/container.log
+                export HEKETI_PRE_REQUEST_VOLUME_OPTIONS="${HEKETI_PRE_REQUEST_VOLUME_OPTIONS},server.tcp-user-timeout 42"
+        fi
+        # else case would be where tcp-user-timeout is set with some value. don't override it.
+fi
+info "modified HEKETI_PRE_REQUEST_VOLUME_OPTIONS is $HEKETI_PRE_REQUEST_VOLUME_OPTIONS"
+
+
 # if the heketi.db does not exist and HEKETI_TOPOLOGY_FILE is set, start the
 # heketi service in the background and load the topology. Once done, move the
 # heketi service back to the foreground again.


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

    container: add tcp-user-timeout in default option
    
    As identified in glusterfs patch[1], we need option
    'server.user-tcp-timeout' to be set on gluster-block volume to mitigate
    some of the 'hung status' like behavior when a node goes down. It is
    also required for file volumes but the impact is not as critical. Adding
    the option in heketi's default pre_request_volume_options will apply it
    for all new volumes created by heketi.
    
    For existing volumes, users can query the volume list and perform a
    gluster volume set.
    
    [1] https://review.gluster.org/#/c/glusterfs/+/21170/


### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #


### Notes for the reviewer
Obsoletes #1354 

