### PR TITLE
extras: add a subdir to support integration with openshift ci

### DIFF
--- a/extras/openshift-ci/README.md
+++ b/extras/openshift-ci/README.md
@@ -1,0 +1,9 @@
+
+# OpenShift CI Integration
+
+This directory contains files used to aid in testing Heketi
+as part of the openshift ci pipeline.
+
+For more information about openshift-ci see:
+* https://github.com/openshift/release
+* https://github.com/openshift/ci-operator

--- a/extras/openshift-ci/build-image/Dockerfile
+++ b/extras/openshift-ci/build-image/Dockerfile
@@ -1,0 +1,11 @@
+# Dockerfile to bootstrap build and test in openshift-ci
+#
+
+FROM openshift/origin-release:golang-1.10
+
+# install tox using pip rather than rpm because the version
+# in centos 7 (which our base image is based on) is
+# too old and lacks features we use
+RUN yum install -y glide python-pip python-virtualenv python36 git \
+    && pip install tox
+


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Add a dockerfile and a readme file that will be used to
help bootstrap testing heketi in openshift-ci.