### PR TITLE
makefile: stop using -i in go build options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,6 @@ GOOS := $(shell $(GO) env GOOS)
 GOHOSTARCH := $(shell $(GO) env GOHOSTARCH)
 GOHOSTOS := $(shell $(GO) env GOHOSTOS)
 GOBUILDFLAGS :=
-ifeq ($(GOOS),$(GOHOSTOS))
-ifeq ($(GOARCH),$(GOHOSTARCH))
-	GOBUILDFLAGS :=-i
-endif
-endif
 GLIDEPATH := $(shell command -v glide 2> /dev/null)
 HGPATH := $(shell command -v hg 2> /dev/null)
 DIR=.

--- a/client/cli/go/Makefile
+++ b/client/cli/go/Makefile
@@ -15,11 +15,6 @@ GOOS := $(shell $(GO) env GOOS)
 GOHOSTARCH := $(shell $(GO) env GOHOSTARCH)
 GOHOSTOS := $(shell $(GO) env GOHOSTOS)
 GOBUILDFLAGS :=
-ifeq ($(GOOS), $(GOHOSTOS))
-ifeq ($(GOARCH), $(GOHOSTARCH))
-	GOBUILDFLAGS :=-i
-endif
-endif
 DIR=.
 
 ifeq (master,$(BRANCH))


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

After reading up a bit on go modules (vgo) it appears
that -i is no longer needed or recommended for Go [1].
It may have improved performance on some versions prior to
1.10 but is not needed for correctness and may not
have been much use for containerized builds anyway.

1: golang/go#27285 (comment)

### Notes for the reviewer

Merging this will help enable more experimentation with go module support.