### PR TITLE
heketi: add support for profiling with pprof

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,114 @@
+Tracking memory usage in Heketi
+===============================
+
+Tracing and profiling with `pprof` is intended for developers only. This can be
+used for debugging memory leaks/consumption, slow flows through the code and so
+on. Users will normally not want profiling enabled on their production systems.
+
+To investigate memory allocations in Heketi, it is needed to enable the
+profiling feature. This can be done by setting the `HEKETI_PROFILING`
+environment variable to a non-empty string or by adding `"profiling": true` to
+the `--config` file (`/etc/heketi/heketi.json` by default).
+
+Enabling profiling makes standard Golang pprof endpoints available. For memory
+allocations `/debug/pprof/heap` is most useful.
+
+Capturing a snapshot of the current allocations in the Heketi service is pretty
+simple. Inside a Heketi container the `curl` command can be used:
+
+```
+sh-4.4# cd /var/lib/heketi
+sh-4.4# curl 'http://localhost:8080/debug/pprof/heap' > heketi_heap.pprof
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  138k    0  138k    0     0  5307k      0 --:--:-- --:--:-- --:--:-- 5111k
+```
+
+The new `heketi_heap.pprof` file has now been written and can be opened by `go
+tool pprof`
+
+```
+sh-4.4# go tool pprof heketi_heap.pprof
+File: heketi
+Build ID: 059f700e17a8784ed6f60251c868dd4b3e002e85
+Type: inuse_space
+Time: Oct 16, 2018 at 11:14am (UTC)
+Entering interactive mode (type "help" for commands, "o" for options)
+(pprof)
+```
+
+For working with the size of the allocations, it is helpful to set all sizes to
+`megabytes`, otherwise `auto` is used as a `unit` and that would add human
+readable B, kB, MB postfixes. This however is not useful for sorting with
+scripts. So, set the `unit` to `megabytes` instead:
+
+```
+(pprof) unit=megabytes
+```
+
+
+
+```
+(pprof) top
+Showing nodes accounting for 172.42MB, 86.24% of 199.94MB total
+Dropped 67 nodes (cum <= 1MB)
+Showing top 10 nodes out of 93
+      flat  flat%   sum%        cum   cum%
+   49.51MB 24.76% 24.76%    50.51MB 25.26%  net/textproto.(*Reader).ReadMIMEHeader
+   30.51MB 15.26% 40.02%    30.51MB 15.26%  net/http.(*Request).WithContext
+   23.83MB 11.92% 51.94%    23.83MB 11.92%  github.com/heketi/heketi/vendor/github.com/gorilla/context.Set
+   19.51MB  9.76% 61.69%    19.51MB  9.76%  reflect.mapassign
+   18.07MB  9.04% 70.73%    18.07MB  9.04%  net/http.newBufioReader
+    6.50MB  3.25% 73.98%     6.50MB  3.25%  reflect.unsafe_New
+    6.50MB  3.25% 77.23%     6.50MB  3.25%  context.WithValue
+    6.50MB  3.25% 80.48%     6.50MB  3.25%  encoding/json.(*decodeState).literalStore
+       6MB  3.00% 83.49%     6.50MB  3.25%  net/textproto.(*Reader).ReadLine
+    5.50MB  2.75% 86.24%    39.51MB 19.76%  github.com/heketi/heketi/vendor/github.com/dgrijalva/jwt-go.(*Parser).ParseWithClaims
+```
+
+```
+(pprof) traces > traces.txt
+Generating report in traces.txt
+```
+
+This `traces.txt` contains the allocations and the functions that lead to it.
+For the `ReadMIMEHeader` that is on the top of the list, the three largest
+allocations are at
+
+```
+sh-4.4# grep ReadMIMEHeader traces.txt | sort -n -r | head -n3
+   21.01MB   net/textproto.(*Reader).ReadMIMEHeader
+      15MB   net/textproto.(*Reader).ReadMIMEHeader
+    3.50MB   net/textproto.(*Reader).ReadMIMEHeader
+```
+
+Of course other statistics may be important too. It is possible that a small
+allocation is done many more times. A summary of that can easily be produced
+too.
+
+```
+sh-4.4# grep ReadMIMEHeader traces.txt | sort -n -r | uniq -c
+      1    21.01MB   net/textproto.(*Reader).ReadMIMEHeader
+      1       15MB   net/textproto.(*Reader).ReadMIMEHeader
+      1     3.50MB   net/textproto.(*Reader).ReadMIMEHeader
+      1        3MB   net/textproto.(*Reader).ReadMIMEHeader
+      2     2.50MB   net/textproto.(*Reader).ReadMIMEHeader
+      1     1.50MB   net/textproto.(*Reader).ReadMIMEHeader
+      1     0.50MB   net/textproto.(*Reader).ReadMIMEHeader
+     18          0   net/textproto.(*Reader).ReadMIMEHeader
+      3              net/textproto.(*Reader).ReadMIMEHeader
+```
+
+By opening the `traces.txt` file with a text editor and searching for the
+allocation (search for `21.01MB`) the callstack for the allocation is found:
+
+```
+     bytes:  352B
+   21.01MB   net/textproto.(*Reader).ReadMIMEHeader
+             net/http.readRequest
+             net/http.(*conn).readRequest
+             net/http.(*conn).serve
+```
+
+
+.... and now to find out whatever that means!

--- a/etc/heketi.json
+++ b/etc/heketi.json
@@ -30,6 +30,9 @@
   "_backup_db_to_kube_secret": "Backup the heketi database to a Kubernetes secret when running in Kubernetes. Default is off.",
   "backup_db_to_kube_secret": false,
 
+  "_profiling": "Enable go/pprof profiling on the /debug/pprof endpoints.",
+  "profiling": false,
+
   "_glusterfs_comment": "GlusterFS Configuration",
   "glusterfs": {
     "_executor_comment": [

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/heketi/heketi/pkg/metrics"
 	"github.com/heketi/heketi/server/admin"
 	"github.com/heketi/heketi/server/config"
+	"github.com/heketi/heketi/server/profiling"
 )
 
 var (
@@ -265,6 +266,11 @@ func setWithEnvVariables(options *config.Config) {
 	if "" != env {
 		options.BackupDbToKubeSecret = true
 	}
+
+	env = os.Getenv("HEKETI_PROFILING")
+	if "" != env {
+		options.Profiling = true
+	}
 }
 
 func setupApp(config *config.Config) (a *glusterfs.App) {
@@ -349,6 +355,11 @@ func main() {
 		})
 
 	router.Methods("GET").Path("/metrics").Name("Metrics").HandlerFunc(metrics.NewMetricsHandler(app))
+
+	// Enable profiling on "/debug/pprof"
+	if options.Profiling {
+		profiling.EnableProfiling(router)
+	}
 
 	// Create a router and do not allow any routes
 	// unless defined.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	EnableTls            bool                     `json:"enable_tls"`
 	CertFile             string                   `json:"cert_file"`
 	KeyFile              string                   `json:"key_file"`
+	Profiling            bool                     `json:"profiling"`
 
 	// pull in the config sub-object for glusterfs app
 	GlusterFS *glusterfs.GlusterFSConfig `json:"glusterfs"`

--- a/server/profiling/profiling.go
+++ b/server/profiling/profiling.go
@@ -1,0 +1,49 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+
+package profiling
+
+// Based on ideas from https://github.com/mistifyio/negroni-pprof
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	runtime_pprof "runtime/pprof"
+
+	"github.com/gorilla/mux"
+)
+
+var (
+	basePath string = "/debug/pprof/"
+)
+
+func addPath(router *mux.Router, name string, handler http.Handler) {
+	router.Path(basePath + name).Name(name).Handler(handler)
+	fmt.Fprintf(os.Stderr, "DEBUG: registered profiling handler on %s\n", basePath+name)
+}
+
+func EnableProfiling(router *mux.Router) {
+	for _, profile := range runtime_pprof.Profiles() {
+		name := profile.Name()
+		handler := pprof.Handler(name)
+
+		addPath(router, name, handler)
+	}
+
+	// static profiles as listed in net/http/pprof/pprof.go:init()
+	addPath(router, "cmdline", http.HandlerFunc(pprof.Cmdline))
+	addPath(router, "profile", http.HandlerFunc(pprof.Profile))
+	addPath(router, "symbol", http.HandlerFunc(pprof.Symbol))
+	addPath(router, "trace", http.HandlerFunc(pprof.Trace))
+
+	// The index handler only lists the runtime_pprof.Profiles() which does
+	// not include all the endpoints we have. Thus we opt not to use the
+	// common prof.Index endpoint here.
+}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Add support for profiling like "net/http/pprof" does, but through the
"gorilla/mux" router. Profiling is disabled by default, set the
`HEKETI_PROFILING` environment variable to a non-empty string or add
`"profiling": true` to the --config file.

Several endpoints will get registered, and are writter to stderr:

    $ HEKETI_PROFILING=1 ./heketi --config=heketi.json
    ...
    DEBUG: registered profiling handler on /debug/pprof/block
    DEBUG: registered profiling handler on /debug/pprof/goroutine
    DEBUG: registered profiling handler on /debug/pprof/heap
    DEBUG: registered profiling handler on /debug/pprof/mutex
    DEBUG: registered profiling handler on /debug/pprof/threadcreate
    DEBUG: registered profiling handler on /debug/pprof/cmdline
    DEBUG: registered profiling handler on /debug/pprof/profile
    DEBUG: registered profiling handler on /debug/pprof/symbol
    DEBUG: registered profiling handler on /debug/pprof/trace
    ...

Standard tools like `go tool pprof` and `curl` work. Examples:

    $ go tool pprof http://localhost:8080/debug/pprof/profile
    $ go tool pprof http://localhost:8080/debug/pprof/heap
    $ curl http://localhost:8080/debug/pprof/heap?debug=1


### Does this PR fix issues?

Fixes #799

### Notes for the reviewer

https://golang.org/pkg/net/http/pprof/ contains more details about the pprof interface.
