### PR TITLE
Convert topology info to a template and add tags to template

### DIFF
--- a/client/cli/go/cmds/topology.go
+++ b/client/cli/go/cmds/topology.go
@@ -358,6 +358,9 @@ Cluster Id: {{.Id}}
 	Zone: {{.Zone}}
 	Management Hostnames: {{join .Hostnames.Manage ", "}}
 	Storage Hostnames: {{join .Hostnames.Storage ", "}}
+{{- if len .Tags | ne 0 }}
+	Tags:{{range $tk, $tv := .Tags }} {{$tk}}:{{$tv -}}{{end}}
+{{end}}
 	Devices:
 {{- range .DevicesInfo}}
 		Id:{{.Id | printf "%-35v" -}}
@@ -366,6 +369,9 @@ Cluster Id: {{.Id}}
 		Size (GiB):{{kibToGib .Storage.Total | printf "%-8v" -}}
 		Used (GiB):{{kibToGib .Storage.Used | printf "%-8v" -}}
 		Free (GiB):{{kibToGib .Storage.Free | printf "%-8v"}}
+{{- if len .Tags | ne 0 }}
+			Tags:{{range $tk, $tv := .Tags }} {{$tk}}:{{$tv -}}{{end}}
+{{end}}
 			Bricks:
 {{- range .Bricks}}
 				Id:{{.Id | printf "%-35v" -}}

--- a/client/cli/go/cmds/topology.go
+++ b/client/cli/go/cmds/topology.go
@@ -298,114 +298,116 @@ var topologyInfoCommand = &cobra.Command{
 			}
 			fmt.Fprintf(stdout, string(data))
 		} else {
-
 			// Get the cluster list and iterate over
-			for i := range topoinfo.ClusterList {
-				fmt.Fprintf(stdout, "\nCluster Id: %v\n", topoinfo.ClusterList[i].Id)
-				fmt.Fprintf(stdout, "\n    File:  %v\n", topoinfo.ClusterList[i].File)
-				fmt.Fprintf(stdout, "    Block: %v\n", topoinfo.ClusterList[i].Block)
-				fmt.Fprintf(stdout, "\n    %s\n", "Volumes:")
-				for k := range topoinfo.ClusterList[i].Volumes {
-
-					// Format and print volumeinfo  on this cluster
-					v := topoinfo.ClusterList[i].Volumes[k]
-					s := fmt.Sprintf("\n\tName: %v\n"+
-						"\tSize: %v\n"+
-						"\tId: %v\n"+
-						"\tCluster Id: %v\n"+
-						"\tMount: %v\n"+
-						"\tMount Options: backup-volfile-servers=%v\n"+
-						"\tDurability Type: %v\n",
-						v.Name,
-						v.Size,
-						v.Id,
-						v.Cluster,
-						v.Mount.GlusterFS.MountPoint,
-						v.Mount.GlusterFS.Options["backup-volfile-servers"],
-						v.Durability.Type)
-
-					switch v.Durability.Type {
-					case api.DurabilityEC:
-						s += fmt.Sprintf("\tDisperse Data: %v\n"+
-							"\tDisperse Redundancy: %v\n",
-							v.Durability.Disperse.Data,
-							v.Durability.Disperse.Redundancy)
-					case api.DurabilityReplicate:
-						s += fmt.Sprintf("\tReplica: %v\n",
-							v.Durability.Replicate.Replica)
-					}
-					if v.Snapshot.Enable {
-						s += fmt.Sprintf("\tSnapshot: Enabled\n"+
-							"\tSnapshot Factor: %.2f\n",
-							v.Snapshot.Factor)
-					} else {
-						s += "\tSnapshot: Disabled\n"
-					}
-					s += "\n\t\tBricks:\n"
-					for _, b := range v.Bricks {
-						s += fmt.Sprintf("\t\t\tId: %v\n"+
-							"\t\t\tPath: %v\n"+
-							"\t\t\tSize (GiB): %v\n"+
-							"\t\t\tNode: %v\n"+
-							"\t\t\tDevice: %v\n\n",
-							b.Id,
-							b.Path,
-							b.Size/(1024*1024),
-							b.NodeId,
-							b.DeviceId)
-					}
-					fmt.Fprintf(stdout, "%s", s)
-				}
-
-				// format and print each Node information on this cluster
-				fmt.Fprintf(stdout, "\n    %s\n", "Nodes:")
-				for j := range topoinfo.ClusterList[i].Nodes {
-					info := topoinfo.ClusterList[i].Nodes[j]
-					fmt.Fprintf(stdout, "\n\tNode Id: %v\n"+
-						"\tState: %v\n"+
-						"\tCluster Id: %v\n"+
-						"\tZone: %v\n"+
-						"\tManagement Hostnames: %v\n"+
-						"\tStorage Hostnames: %v\n",
-						info.Id,
-						info.State,
-						info.ClusterId,
-						info.Zone,
-						strings.Join(info.Hostnames.Manage, ", "),
-						strings.Join(info.Hostnames.Storage, ", "))
-					fmt.Fprintf(stdout, "\tDevices:\n")
-
-					// format and print the device info
-					for j, d := range info.DevicesInfo {
-						fmt.Fprintf(stdout, "\t\tId:%-35v"+
-							"Name:%-20v"+
-							"State:%-10v"+
-							"Size (GiB):%-8v"+
-							"Used (GiB):%-8v"+
-							"Free (GiB):%-8v\n",
-							d.Id,
-							d.Name,
-							d.State,
-							d.Storage.Total/(1024*1024),
-							d.Storage.Used/(1024*1024),
-							d.Storage.Free/(1024*1024))
-
-						// format and print the brick information
-						fmt.Fprintf(stdout, "\t\t\tBricks:\n")
-						for _, d := range info.DevicesInfo[j].Bricks {
-							fmt.Fprintf(stdout, "\t\t\t\tId:%-35v"+
-								"Size (GiB):%-8v"+
-								"Path: %v\n",
-								d.Id,
-								d.Size/(1024*1024),
-								d.Path)
-						}
-					}
-				}
+			for _, c := range topoinfo.ClusterList {
+				printClusterInfo(c)
 			}
-
 		}
 
 		return nil
 	},
+}
+
+func printClusterInfo(cluster api.Cluster) {
+	fmt.Fprintf(stdout, "\nCluster Id: %v\n", cluster.Id)
+	fmt.Fprintf(stdout, "\n    File:  %v\n", cluster.File)
+	fmt.Fprintf(stdout, "    Block: %v\n", cluster.Block)
+	fmt.Fprintf(stdout, "\n    %s\n", "Volumes:")
+	for k := range cluster.Volumes {
+
+		// Format and print volumeinfo  on this cluster
+		v := cluster.Volumes[k]
+		s := fmt.Sprintf("\n\tName: %v\n"+
+			"\tSize: %v\n"+
+			"\tId: %v\n"+
+			"\tCluster Id: %v\n"+
+			"\tMount: %v\n"+
+			"\tMount Options: backup-volfile-servers=%v\n"+
+			"\tDurability Type: %v\n",
+			v.Name,
+			v.Size,
+			v.Id,
+			v.Cluster,
+			v.Mount.GlusterFS.MountPoint,
+			v.Mount.GlusterFS.Options["backup-volfile-servers"],
+			v.Durability.Type)
+
+		switch v.Durability.Type {
+		case api.DurabilityEC:
+			s += fmt.Sprintf("\tDisperse Data: %v\n"+
+				"\tDisperse Redundancy: %v\n",
+				v.Durability.Disperse.Data,
+				v.Durability.Disperse.Redundancy)
+		case api.DurabilityReplicate:
+			s += fmt.Sprintf("\tReplica: %v\n",
+				v.Durability.Replicate.Replica)
+		}
+		if v.Snapshot.Enable {
+			s += fmt.Sprintf("\tSnapshot: Enabled\n"+
+				"\tSnapshot Factor: %.2f\n",
+				v.Snapshot.Factor)
+		} else {
+			s += "\tSnapshot: Disabled\n"
+		}
+		s += "\n\t\tBricks:\n"
+		for _, b := range v.Bricks {
+			s += fmt.Sprintf("\t\t\tId: %v\n"+
+				"\t\t\tPath: %v\n"+
+				"\t\t\tSize (GiB): %v\n"+
+				"\t\t\tNode: %v\n"+
+				"\t\t\tDevice: %v\n\n",
+				b.Id,
+				b.Path,
+				b.Size/(1024*1024),
+				b.NodeId,
+				b.DeviceId)
+		}
+		fmt.Fprintf(stdout, "%s", s)
+	}
+
+	// format and print each Node information on this cluster
+	fmt.Fprintf(stdout, "\n    %s\n", "Nodes:")
+	for j := range cluster.Nodes {
+		info := cluster.Nodes[j]
+		fmt.Fprintf(stdout, "\n\tNode Id: %v\n"+
+			"\tState: %v\n"+
+			"\tCluster Id: %v\n"+
+			"\tZone: %v\n"+
+			"\tManagement Hostnames: %v\n"+
+			"\tStorage Hostnames: %v\n",
+			info.Id,
+			info.State,
+			info.ClusterId,
+			info.Zone,
+			strings.Join(info.Hostnames.Manage, ", "),
+			strings.Join(info.Hostnames.Storage, ", "))
+		fmt.Fprintf(stdout, "\tDevices:\n")
+
+		// format and print the device info
+		for j, d := range info.DevicesInfo {
+			fmt.Fprintf(stdout, "\t\tId:%-35v"+
+				"Name:%-20v"+
+				"State:%-10v"+
+				"Size (GiB):%-8v"+
+				"Used (GiB):%-8v"+
+				"Free (GiB):%-8v\n",
+				d.Id,
+				d.Name,
+				d.State,
+				d.Storage.Total/(1024*1024),
+				d.Storage.Used/(1024*1024),
+				d.Storage.Free/(1024*1024))
+
+			// format and print the brick information
+			fmt.Fprintf(stdout, "\t\t\tBricks:\n")
+			for _, d := range info.DevicesInfo[j].Bricks {
+				fmt.Fprintf(stdout, "\t\t\t\tId:%-35v"+
+					"Size (GiB):%-8v"+
+					"Path: %v\n",
+					d.Id,
+					d.Size/(1024*1024),
+					d.Path)
+			}
+		}
+	}
 }

--- a/client/cli/go/cmds/topology.go
+++ b/client/cli/go/cmds/topology.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"text/template"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/spf13/cobra"
@@ -308,106 +309,86 @@ var topologyInfoCommand = &cobra.Command{
 	},
 }
 
+// NOTE: the output here previously mixed tabs and spaces when
+// using a series of printf calls. This mixing is preserved in
+// the template and is intentional. Deciding to change formatting
+// is left as a future exercise if desired.
+var clusterTemplate = `
+Cluster Id: {{.Id}}
+
+    File:  {{.File}}
+    Block: {{.Block}}
+
+    Volumes:
+{{range .Volumes}}
+	Name: {{.Name}}
+	Size: {{.Size}}
+	Id: {{.Id}}
+	Cluster Id: {{.Cluster}}
+	Mount: {{.Mount.GlusterFS.MountPoint}}
+	Mount Options: {{ range $k, $v := .Mount.GlusterFS.Options }}{{$k}}={{$v}}{{end}}
+	Durability Type: {{.Durability.Type}}
+{{- if eq .Durability.Type "replicate" }}
+	Replica: {{.Durability.Replicate.Replica}}
+{{- else if eq .Durability.Type "disperse" }}
+	Disperse Data: {{.Durability.Disperse.Data}}
+	Disperse Redundancy: {{.Durability.Disperse.Redundancy}}
+{{- end}}
+{{- if .Snapshot.Enable }}
+	Snapshot: Enabled
+	Snapshot Factor: {{.Snapshot.Factor | printf "%.2f"}}
+{{else}}
+	Snapshot: Disabled
+{{end}}
+		Bricks:
+{{- range .Bricks}}
+			Id: {{.Id}}
+			Path: {{.Path}}
+			Size (GiB): {{kibToGib .Size}}
+			Node: {{.NodeId}}
+			Device: {{.DeviceId}}
+{{end}}
+{{end}}
+
+    Nodes:
+{{range .Nodes}}
+	Node Id: {{.Id}}
+	State: {{.State}}
+	Cluster Id: {{.ClusterId}}
+	Zone: {{.Zone}}
+	Management Hostnames: {{join .Hostnames.Manage ", "}}
+	Storage Hostnames: {{join .Hostnames.Storage ", "}}
+	Devices:
+{{- range .DevicesInfo}}
+		Id:{{.Id | printf "%-35v" -}}
+		Name:{{.Name | printf "%-20v" -}}
+		State:{{.State | printf "%-10v" -}}
+		Size (GiB):{{kibToGib .Storage.Total | printf "%-8v" -}}
+		Used (GiB):{{kibToGib .Storage.Used | printf "%-8v" -}}
+		Free (GiB):{{kibToGib .Storage.Free | printf "%-8v"}}
+			Bricks:
+{{- range .Bricks}}
+				Id:{{.Id | printf "%-35v" -}}
+				Size (GiB):{{kibToGib .Size | printf "%-8v" -}}
+				Path: {{.Path}}
+{{- end}}
+{{- end}}
+{{end}}
+`
+
 func printClusterInfo(cluster api.Cluster) {
-	fmt.Fprintf(stdout, "\nCluster Id: %v\n", cluster.Id)
-	fmt.Fprintf(stdout, "\n    File:  %v\n", cluster.File)
-	fmt.Fprintf(stdout, "    Block: %v\n", cluster.Block)
-	fmt.Fprintf(stdout, "\n    %s\n", "Volumes:")
-	for k := range cluster.Volumes {
-
-		// Format and print volumeinfo  on this cluster
-		v := cluster.Volumes[k]
-		s := fmt.Sprintf("\n\tName: %v\n"+
-			"\tSize: %v\n"+
-			"\tId: %v\n"+
-			"\tCluster Id: %v\n"+
-			"\tMount: %v\n"+
-			"\tMount Options: backup-volfile-servers=%v\n"+
-			"\tDurability Type: %v\n",
-			v.Name,
-			v.Size,
-			v.Id,
-			v.Cluster,
-			v.Mount.GlusterFS.MountPoint,
-			v.Mount.GlusterFS.Options["backup-volfile-servers"],
-			v.Durability.Type)
-
-		switch v.Durability.Type {
-		case api.DurabilityEC:
-			s += fmt.Sprintf("\tDisperse Data: %v\n"+
-				"\tDisperse Redundancy: %v\n",
-				v.Durability.Disperse.Data,
-				v.Durability.Disperse.Redundancy)
-		case api.DurabilityReplicate:
-			s += fmt.Sprintf("\tReplica: %v\n",
-				v.Durability.Replicate.Replica)
-		}
-		if v.Snapshot.Enable {
-			s += fmt.Sprintf("\tSnapshot: Enabled\n"+
-				"\tSnapshot Factor: %.2f\n",
-				v.Snapshot.Factor)
-		} else {
-			s += "\tSnapshot: Disabled\n"
-		}
-		s += "\n\t\tBricks:\n"
-		for _, b := range v.Bricks {
-			s += fmt.Sprintf("\t\t\tId: %v\n"+
-				"\t\t\tPath: %v\n"+
-				"\t\t\tSize (GiB): %v\n"+
-				"\t\t\tNode: %v\n"+
-				"\t\t\tDevice: %v\n\n",
-				b.Id,
-				b.Path,
-				b.Size/(1024*1024),
-				b.NodeId,
-				b.DeviceId)
-		}
-		fmt.Fprintf(stdout, "%s", s)
+	fm := template.FuncMap{
+		"join": strings.Join,
+		"kibToGib": func(i uint64) string {
+			return fmt.Sprintf("%d", i/(1024*1024))
+		},
 	}
-
-	// format and print each Node information on this cluster
-	fmt.Fprintf(stdout, "\n    %s\n", "Nodes:")
-	for j := range cluster.Nodes {
-		info := cluster.Nodes[j]
-		fmt.Fprintf(stdout, "\n\tNode Id: %v\n"+
-			"\tState: %v\n"+
-			"\tCluster Id: %v\n"+
-			"\tZone: %v\n"+
-			"\tManagement Hostnames: %v\n"+
-			"\tStorage Hostnames: %v\n",
-			info.Id,
-			info.State,
-			info.ClusterId,
-			info.Zone,
-			strings.Join(info.Hostnames.Manage, ", "),
-			strings.Join(info.Hostnames.Storage, ", "))
-		fmt.Fprintf(stdout, "\tDevices:\n")
-
-		// format and print the device info
-		for j, d := range info.DevicesInfo {
-			fmt.Fprintf(stdout, "\t\tId:%-35v"+
-				"Name:%-20v"+
-				"State:%-10v"+
-				"Size (GiB):%-8v"+
-				"Used (GiB):%-8v"+
-				"Free (GiB):%-8v\n",
-				d.Id,
-				d.Name,
-				d.State,
-				d.Storage.Total/(1024*1024),
-				d.Storage.Used/(1024*1024),
-				d.Storage.Free/(1024*1024))
-
-			// format and print the brick information
-			fmt.Fprintf(stdout, "\t\t\tBricks:\n")
-			for _, d := range info.DevicesInfo[j].Bricks {
-				fmt.Fprintf(stdout, "\t\t\t\tId:%-35v"+
-					"Size (GiB):%-8v"+
-					"Path: %v\n",
-					d.Id,
-					d.Size/(1024*1024),
-					d.Path)
-			}
-		}
+	t, err := template.New("cluster").Funcs(fm).Parse(clusterTemplate)
+	if err != nil {
+		panic(err)
+	}
+	err = t.Execute(os.Stdout, cluster)
+	if err != nil {
+		panic(err)
 	}
 }


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

These changes switch topology info from using a bunch of printf-style calls to a "text/template" based templated output. The template ought to be easier to maintain that the printfs. After converting to a template, lines for tags on nodes and devices are added.

### Does this PR fix issues?

Enhances output of topology info, fixing [rhbz#1572579](https://bugzilla.redhat.com/show_bug.cgi?id=1572579)


