### PR TITLE
reintroduce rest framework into source tree

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/gorilla/mux"
-	"github.com/heketi/rest"
 	"github.com/lpabon/godbc"
 
 	"github.com/heketi/heketi/executors"
@@ -28,6 +27,7 @@ import (
 	"github.com/heketi/heketi/executors/mockexec"
 	"github.com/heketi/heketi/executors/sshexec"
 	"github.com/heketi/heketi/pkg/logging"
+	"github.com/heketi/heketi/server/rest"
 )
 
 const (

--- a/server/rest/README.md
+++ b/server/rest/README.md
@@ -1,0 +1,6 @@
+# Heketi RESTful Functions
+
+The Heketi server's rest-framework utility functions.
+This includes the source for a helper struct to create rest endpoints
+and the async http helper library.
+

--- a/server/rest/asynchttp.go
+++ b/server/rest/asynchttp.go
@@ -1,0 +1,297 @@
+//
+// Copyright (c) 2015 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package rest
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/heketi/heketi/pkg/idgen"
+	"github.com/heketi/heketi/pkg/logging"
+	"github.com/lpabon/godbc"
+)
+
+var (
+	logger = logging.NewLogger("[asynchttp]", logging.LEVEL_INFO)
+)
+
+// Contains information about the asynchronous operation
+type AsyncHttpHandler struct {
+	err          error
+	completed    bool
+	manager      *AsyncHttpManager
+	location, id string
+}
+
+// Manager of asynchronous operations
+type AsyncHttpManager struct {
+	IdGen    func() string
+	lock     sync.RWMutex
+	route    string
+	handlers map[string]*AsyncHttpHandler
+}
+
+// Creates a new manager
+func NewAsyncHttpManager(route string) *AsyncHttpManager {
+	return &AsyncHttpManager{
+		route:    route,
+		handlers: make(map[string]*AsyncHttpHandler),
+		IdGen:    idgen.GenUUID,
+	}
+}
+
+// Use to create a new asynchronous operation handler.
+// Only use this function if you need to do every step by hand.
+// It is recommended to use AsyncHttpRedirectFunc() instead
+func (a *AsyncHttpManager) NewHandler() *AsyncHttpHandler {
+	return a.NewHandlerWithId(a.NewId())
+}
+
+// NewHandlerWithId constructs and returns an AsyncHttpHandler with the
+// given ID. Compare to NewHandler() which automatically generates its
+// own ID.
+func (a *AsyncHttpManager) NewHandlerWithId(id string) *AsyncHttpHandler {
+	handler := &AsyncHttpHandler{
+		manager: a,
+		id:      id,
+	}
+
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	_, idPresent := a.handlers[handler.id]
+	godbc.Require(!idPresent)
+	a.handlers[handler.id] = handler
+
+	return handler
+}
+
+// NewId returns a new string id for a handler. This string is not preserved
+// internally and must be passed to another function to be used.
+func (a *AsyncHttpManager) NewId() string {
+	return a.IdGen()
+}
+
+// Create an asynchronous operation handler and return the appropiate
+// information the caller.
+// This function will call handlerfunc() in a new go routine, then
+// return to the caller a HTTP status 202 setting up the `Location` header
+// to point to the new asynchronous handler.
+//
+// If handlerfunc() returns failure, the asynchronous handler will return
+// an http status of 500 and save the error string in the body.
+// If handlerfunc() is successful and returns a location url path in "string",
+// the asynchronous handler will return 303 (See Other) with the Location
+// header set to the value returned in the string.
+// If handlerfunc() is successful and returns an empty string, then the
+// asynchronous handler will return 204 to the caller.
+//
+// Example:
+//      package rest
+//		import (
+//			"github.com/gorilla/mux"
+//          "github.com/heketi/rest"
+//			"net/http"
+//			"net/http/httptest"
+//			"time"
+//		)
+//
+//		// Setup asynchronous manager
+//		route := "/x"
+//		manager := rest.NewAsyncHttpManager(route)
+//
+//		// Setup the route
+//		router := mux.NewRouter()
+//	 	router.HandleFunc(route+"/{id}", manager.HandlerStatus).Methods("GET")
+//		router.HandleFunc("/result", func(w http.ResponseWriter, r *http.Request) {
+//			w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
+//			w.WriteHeader(http.StatusOK)
+//			fmt.Fprint(w, "HelloWorld")
+//		}).Methods("GET")
+//
+//		router.HandleFunc("/app", func(w http.ResponseWriter, r *http.Request) {
+//			manager.AsyncHttpRedirectFunc(w, r, func() (string, error) {
+//				time.Sleep(100 * time.Millisecond)
+//				return "/result", nil
+//			})
+//		}).Methods("GET")
+//
+//		// Setup the server
+//		ts := httptest.NewServer(router)
+//		defer ts.Close()
+//
+func (a *AsyncHttpManager) AsyncHttpRedirectFunc(w http.ResponseWriter,
+	r *http.Request,
+	handlerfunc func() (string, error)) {
+
+	handler := a.NewHandler()
+	handler.handle(handlerfunc)
+	http.Redirect(w, r, handler.Url(), http.StatusAccepted)
+}
+
+func (a *AsyncHttpManager) AsyncHttpRedirectUsing(w http.ResponseWriter,
+	r *http.Request,
+	id string,
+	handlerfunc func() (string, error)) {
+
+	handler := a.NewHandlerWithId(id)
+	handler.handle(handlerfunc)
+	http.Redirect(w, r, handler.Url(), http.StatusAccepted)
+}
+
+// Handler for asynchronous operation status
+// Register this handler with a router like Gorilla Mux
+//
+// Returns the following HTTP status codes
+// 		200 Operation is still pending
+//		404 Id requested does not exist
+//		500 Operation finished and has failed.  Body will be filled in with the
+//			error in plain text.
+//		303 Operation finished and has setup a new location to retreive data.
+//		204 Operation finished and has no data to return
+//
+// Example:
+//      package rest
+//		import (
+//			"github.com/gorilla/mux"
+//          "github.com/heketi/rest"
+//			"net/http"
+//			"net/http/httptest"
+//			"time"
+//		)
+//
+//		// Setup asynchronous manager
+//		route := "/x"
+//		manager := rest.NewAsyncHttpManager(route)
+//
+//		// Setup the route
+//		router := mux.NewRouter()
+//	 	router.HandleFunc(route+"/{id:[A-Fa-f0-9]+}", manager.HandlerStatus).Methods("GET")
+//
+//		// Setup the server
+//		ts := httptest.NewServer(router)
+//		defer ts.Close()
+//
+func (a *AsyncHttpManager) HandlerStatus(w http.ResponseWriter, r *http.Request) {
+	// Get the id from the URL
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	// Check the id is in the map
+	if handler, ok := a.handlers[id]; ok {
+
+		if handler.completed {
+			if handler.err != nil {
+
+				// Return 500 status
+				http.Error(w, handler.err.Error(), http.StatusInternalServerError)
+			} else {
+				if handler.location != "" {
+
+					// Redirect to new location
+					http.Redirect(w, r, handler.location, http.StatusSeeOther)
+				} else {
+
+					// Return 204 status
+					w.WriteHeader(http.StatusNoContent)
+				}
+			}
+
+			// It has been completed, we can now remove it from the map
+			delete(a.handlers, id)
+		} else {
+			// Still pending
+			// Could add a JSON body here later
+			w.Header().Add("X-Pending", "true")
+			w.WriteHeader(http.StatusOK)
+		}
+
+	} else {
+		http.Error(w, "Id not found", http.StatusNotFound)
+	}
+}
+
+// Returns the url for the specified asynchronous handler
+func (h *AsyncHttpHandler) Url() string {
+	h.manager.lock.RLock()
+	defer h.manager.lock.RUnlock()
+
+	return h.manager.route + "/" + h.id
+}
+
+// Registers that the handler has completed with an error
+func (h *AsyncHttpHandler) CompletedWithError(err error) {
+
+	h.manager.lock.RLock()
+	defer h.manager.lock.RUnlock()
+
+	godbc.Require(h.completed == false)
+
+	h.err = err
+	h.completed = true
+
+	godbc.Ensure(h.completed == true)
+}
+
+// Registers that the handler has completed and has provided a location
+// where information can be retreived
+func (h *AsyncHttpHandler) CompletedWithLocation(location string) {
+
+	h.manager.lock.RLock()
+	defer h.manager.lock.RUnlock()
+
+	godbc.Require(h.completed == false)
+
+	h.location = location
+	h.completed = true
+
+	godbc.Ensure(h.completed == true)
+	godbc.Ensure(h.location == location)
+	godbc.Ensure(h.err == nil)
+}
+
+// Registers that the handler has completed and no data needs to be returned
+func (h *AsyncHttpHandler) Completed() {
+
+	h.manager.lock.RLock()
+	defer h.manager.lock.RUnlock()
+
+	godbc.Require(h.completed == false)
+
+	h.completed = true
+
+	godbc.Ensure(h.completed == true)
+	godbc.Ensure(h.location == "")
+	godbc.Ensure(h.err == nil)
+}
+
+// handle starts running the given function in the background (goroutine).
+func (h *AsyncHttpHandler) handle(f func() (string, error)) {
+	go func() {
+		logger.Info("Started job %v", h.id)
+
+		ts := time.Now()
+		url, err := f()
+		logger.Info("Completed job %v in %v", h.id, time.Since(ts))
+
+		if err != nil {
+			h.CompletedWithError(err)
+		} else if url != "" {
+			h.CompletedWithLocation(url)
+		} else {
+			h.Completed()
+		}
+	}()
+}

--- a/server/rest/asynchttp_test.go
+++ b/server/rest/asynchttp_test.go
@@ -1,0 +1,538 @@
+//
+// Copyright (c) 2015 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package rest
+
+import (
+	"errors"
+	"fmt"
+	"github.com/gorilla/mux"
+	"github.com/heketi/tests"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNewManager(t *testing.T) {
+
+	manager := NewAsyncHttpManager("/x")
+
+	tests.Assert(t, len(manager.handlers) == 0)
+	tests.Assert(t, manager.route == "/x")
+
+}
+
+func TestNewHandler(t *testing.T) {
+
+	manager := NewAsyncHttpManager("/x")
+
+	handler := manager.NewHandler()
+	tests.Assert(t, handler.location == "")
+	tests.Assert(t, handler.id != "")
+	tests.Assert(t, handler.completed == false)
+	tests.Assert(t, handler.err == nil)
+	tests.Assert(t, manager.handlers[handler.id] == handler)
+}
+
+func TestHandlerUrl(t *testing.T) {
+	manager := NewAsyncHttpManager("/x")
+	handler := manager.NewHandler()
+
+	// overwrite id value
+	handler.id = "12345"
+	tests.Assert(t, handler.Url() == "/x/12345")
+}
+
+func TestHandlerNotFound(t *testing.T) {
+
+	// Setup asynchronous manager
+	route := "/x"
+	manager := NewAsyncHttpManager(route)
+
+	// Setup the route
+	router := mux.NewRouter()
+	router.HandleFunc(route+"/{id}", manager.HandlerStatus).Methods("GET")
+
+	// Setup the server
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	// Request
+	r, err := http.Get(ts.URL + route + "/12345")
+	tests.Assert(t, r.StatusCode == http.StatusNotFound)
+	tests.Assert(t, err == nil)
+}
+
+func TestHandlerCompletions(t *testing.T) {
+
+	// Setup asynchronous manager
+	route := "/x"
+	manager := NewAsyncHttpManager(route)
+	handler := manager.NewHandler()
+
+	// Setup the route
+	router := mux.NewRouter()
+	router.HandleFunc(route+"/{id}", manager.HandlerStatus).Methods("GET")
+	router.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("X-Test", "HelloWorld")
+		w.WriteHeader(http.StatusOK)
+	}).Methods("GET")
+
+	// Setup the server
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	// Request
+	r, err := http.Get(ts.URL + handler.Url())
+	tests.Assert(t, r.StatusCode == http.StatusOK)
+	tests.Assert(t, err == nil)
+
+	// Handler completion without data
+	handler.Completed()
+	r, err = http.Get(ts.URL + handler.Url())
+	tests.Assert(t, r.StatusCode == http.StatusNoContent)
+	tests.Assert(t, err == nil)
+
+	// Check that it was removed from the map
+	_, ok := manager.handlers[handler.id]
+	tests.Assert(t, ok == false)
+
+	// Create new handler
+	handler = manager.NewHandler()
+
+	// Request
+	r, err = http.Get(ts.URL + handler.Url())
+	tests.Assert(t, r.StatusCode == http.StatusOK)
+	tests.Assert(t, err == nil)
+
+	// Complete with error
+	error_string := "This is a test"
+	handler.CompletedWithError(errors.New(error_string))
+	r, err = http.Get(ts.URL + handler.Url())
+	tests.Assert(t, r.StatusCode == http.StatusInternalServerError)
+	tests.Assert(t, err == nil)
+
+	// Check body has error string
+	body, err := ioutil.ReadAll(r.Body)
+	r.Body.Close()
+	tests.Assert(t, string(body) == error_string+"\n")
+
+	// Create new handler
+	handler = manager.NewHandler()
+
+	// Request
+	r, err = http.Get(ts.URL + handler.Url())
+	tests.Assert(t, r.StatusCode == http.StatusOK)
+	tests.Assert(t, err == nil)
+
+	// Complete with SeeOther to Location
+	handler.CompletedWithLocation("/test")
+
+	// http.Get() looks at the Location header
+	// and automatically redirects to the new location
+	r, err = http.Get(ts.URL + handler.Url())
+	tests.Assert(t, r.StatusCode == http.StatusOK)
+	tests.Assert(t, r.Header.Get("X-Test") == "HelloWorld")
+	tests.Assert(t, err == nil)
+
+}
+
+func TestAsyncHttpRedirectFunc(t *testing.T) {
+	// Setup asynchronous manager
+	route := "/x"
+	manager := NewAsyncHttpManager(route)
+
+	// Setup the route
+	router := mux.NewRouter()
+	router.HandleFunc(route+"/{id}", manager.HandlerStatus).Methods("GET")
+	router.HandleFunc("/result", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "HelloWorld")
+	}).Methods("GET")
+
+	// Start testing error condition
+	handlerfunc := func() (string, error) {
+		return "", errors.New("Test Handler Function")
+	}
+
+	// The variable 'handlerfunc' can be changed outside the scope to
+	// point to a new function.  Isn't Go awesome!
+	router.HandleFunc("/app", func(w http.ResponseWriter, r *http.Request) {
+		manager.AsyncHttpRedirectFunc(w, r, handlerfunc)
+	}).Methods("GET")
+
+	// Setup the server
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	// Get /app url
+	r, err := http.Get(ts.URL + "/app")
+	tests.Assert(t, r.StatusCode == http.StatusAccepted)
+	tests.Assert(t, err == nil)
+	location, err := r.Location()
+	tests.Assert(t, err == nil)
+
+	// Expect the error
+	for {
+		r, err := http.Get(location.String())
+		tests.Assert(t, err == nil)
+		if r.Header.Get("X-Pending") != "true" {
+			tests.Assert(t, r.StatusCode == http.StatusInternalServerError)
+			body, err := ioutil.ReadAll(r.Body)
+			r.Body.Close()
+			tests.Assert(t, err == nil)
+			tests.Assert(t, string(body) == "Test Handler Function\n")
+			break
+		} else {
+			tests.Assert(t, r.StatusCode == http.StatusOK)
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	// Set handler function to return a url to /result
+	handlerfunc = func() (string, error) {
+		return "/result", nil
+	}
+
+	// Get /app url
+	r, err = http.Get(ts.URL + "/app")
+	tests.Assert(t, r.StatusCode == http.StatusAccepted)
+	tests.Assert(t, err == nil)
+	location, err = r.Location()
+	tests.Assert(t, err == nil)
+
+	// Should have the content from /result.  http.Get() automatically
+	// retreives the content when a status of SeeOther is set and the
+	// Location header has the next URL.
+	for {
+		r, err := http.Get(location.String())
+		tests.Assert(t, err == nil)
+		if r.Header.Get("X-Pending") != "true" {
+			tests.Assert(t, r.StatusCode == http.StatusOK)
+			body, err := ioutil.ReadAll(r.Body)
+			r.Body.Close()
+			tests.Assert(t, err == nil)
+			tests.Assert(t, string(body) == "HelloWorld")
+			break
+		} else {
+			tests.Assert(t, r.StatusCode == http.StatusOK)
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	// Test no redirect, simple completion
+	handlerfunc = func() (string, error) {
+		return "", nil
+	}
+
+	// Get /app url
+	r, err = http.Get(ts.URL + "/app")
+	tests.Assert(t, r.StatusCode == http.StatusAccepted)
+	tests.Assert(t, err == nil)
+	location, err = r.Location()
+	tests.Assert(t, err == nil)
+
+	// Should be success
+	for {
+		r, err := http.Get(location.String())
+		tests.Assert(t, err == nil)
+		if r.Header.Get("X-Pending") != "true" {
+			tests.Assert(t, r.StatusCode == http.StatusNoContent)
+			tests.Assert(t, r.ContentLength == 0)
+			break
+		} else {
+			tests.Assert(t, r.StatusCode == http.StatusOK)
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+}
+
+func TestHandlerConcurrency(t *testing.T) {
+
+	// Setup asynchronous manager
+	route := "/x"
+	manager := NewAsyncHttpManager(route)
+
+	// Setup the route
+	router := mux.NewRouter()
+	router.HandleFunc(route+"/{id}", manager.HandlerStatus).Methods("GET")
+	// Setup the server
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	var wg sync.WaitGroup
+	errorsch := make(chan error, 10)
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			handler := manager.NewHandler()
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				handler.Completed()
+			}()
+
+			for {
+				r, err := http.Get(ts.URL + handler.Url())
+				if err != nil {
+					errorsch <- errors.New("Unable to get data from handler")
+					return
+				}
+				if r.StatusCode == http.StatusNoContent {
+					return
+				} else if r.StatusCode == http.StatusOK {
+					time.Sleep(time.Millisecond)
+				} else {
+					errorsch <- errors.New(fmt.Sprintf("Bad status returned: %d\n", r.StatusCode))
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	tests.Assert(t, len(errorsch) == 0)
+}
+
+func TestHandlerApplication(t *testing.T) {
+
+	// Setup asynchronous manager
+	route := "/x"
+	manager := NewAsyncHttpManager(route)
+
+	// Setup the route
+	router := mux.NewRouter()
+	router.HandleFunc(route+"/{id}", manager.HandlerStatus).Methods("GET")
+	router.HandleFunc("/result", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "HelloWorld")
+	}).Methods("GET")
+	router.HandleFunc("/app", func(w http.ResponseWriter, r *http.Request) {
+		handler := manager.NewHandler()
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			handler.CompletedWithLocation("/result")
+		}()
+
+		http.Redirect(w, r, handler.Url(), http.StatusAccepted)
+	}).Methods("GET")
+
+	// Setup the server
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	// Get /app url
+	r, err := http.Get(ts.URL + "/app")
+	tests.Assert(t, r.StatusCode == http.StatusAccepted)
+	tests.Assert(t, err == nil)
+	location, err := r.Location()
+	tests.Assert(t, err == nil)
+
+	for {
+		// Since Get automatically redirects, we will
+		// just keep asking until we get a body
+		r, err := http.Get(location.String())
+		tests.Assert(t, err == nil)
+		tests.Assert(t, r.StatusCode == http.StatusOK)
+		if r.ContentLength > 0 {
+			body, err := ioutil.ReadAll(r.Body)
+			r.Body.Close()
+			tests.Assert(t, err == nil)
+			tests.Assert(t, string(body) == "HelloWorld")
+			break
+		} else {
+			tests.Assert(t, r.Header.Get("X-Pending") == "true")
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+}
+
+func TestApplicationWithRedirectFunc(t *testing.T) {
+
+	// Setup asynchronous manager
+	route := "/x"
+	manager := NewAsyncHttpManager(route)
+
+	// Setup the route
+	router := mux.NewRouter()
+	router.HandleFunc(route+"/{id}", manager.HandlerStatus).Methods("GET")
+	router.HandleFunc("/result", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "HelloWorld")
+	}).Methods("GET")
+
+	router.HandleFunc("/app", func(w http.ResponseWriter, r *http.Request) {
+		manager.AsyncHttpRedirectFunc(w, r, func() (string, error) {
+			time.Sleep(500 * time.Millisecond)
+			return "/result", nil
+		})
+	}).Methods("GET")
+
+	// Setup the server
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	// Get /app url
+	r, err := http.Get(ts.URL + "/app")
+	tests.Assert(t, r.StatusCode == http.StatusAccepted)
+	tests.Assert(t, err == nil)
+	location, err := r.Location()
+	tests.Assert(t, err == nil)
+
+	for {
+		// Since Get automatically redirects, we will
+		// just keep asking until we get a body
+		r, err := http.Get(location.String())
+		tests.Assert(t, err == nil)
+		tests.Assert(t, r.StatusCode == http.StatusOK)
+		if r.ContentLength > 0 {
+			body, err := ioutil.ReadAll(r.Body)
+			r.Body.Close()
+			tests.Assert(t, err == nil)
+			tests.Assert(t, string(body) == "HelloWorld")
+			break
+		} else {
+			tests.Assert(t, r.Header.Get("X-Pending") == "true")
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+}
+
+func TestAsyncHttpRedirectUsing(t *testing.T) {
+
+	// Setup asynchronous manager
+	route := "/x"
+	manager := NewAsyncHttpManager(route)
+
+	// Setup the route
+	router := mux.NewRouter()
+	router.HandleFunc(route+"/{id}", manager.HandlerStatus).Methods("GET")
+	router.HandleFunc("/result", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "HelloWorld")
+	}).Methods("GET")
+
+	router.HandleFunc("/app", func(w http.ResponseWriter, r *http.Request) {
+		manager.AsyncHttpRedirectUsing(w, r, "bob", func() (string, error) {
+			time.Sleep(500 * time.Millisecond)
+			return "/result", nil
+		})
+	}).Methods("GET")
+
+	// Setup the server
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	r, err := http.Get(ts.URL + "/app")
+	tests.Assert(t, r.StatusCode == http.StatusAccepted)
+	tests.Assert(t, err == nil)
+	location, err := r.Location()
+	tests.Assert(t, err == nil)
+
+	tests.Assert(t, strings.Contains(location.String(), "bob"),
+		`expected "bob" in newloc, got:`, location)
+
+	for {
+		// Since Get automatically redirects, we will
+		// just keep asking until we get a body
+		r, err := http.Get(location.String())
+		tests.Assert(t, err == nil)
+		tests.Assert(t, r.StatusCode == http.StatusOK)
+		if r.ContentLength > 0 {
+			body, err := ioutil.ReadAll(r.Body)
+			r.Body.Close()
+			tests.Assert(t, err == nil)
+			tests.Assert(t, string(body) == "HelloWorld")
+			break
+		} else {
+			tests.Assert(t, r.Header.Get("X-Pending") == "true")
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+}
+
+func TestAsyncHttpRedirectFuncCustomIds(t *testing.T) {
+
+	// Setup asynchronous manager
+	route := "/x"
+	manager := NewAsyncHttpManager(route)
+
+	i := 0
+	manager.IdGen = func() string {
+		s := fmt.Sprintf("abc-%v%v%v", i, i, i)
+		i += 1
+		return s
+	}
+
+	// Setup the route
+	router := mux.NewRouter()
+	router.HandleFunc(route+"/{id}", manager.HandlerStatus).Methods("GET")
+	router.HandleFunc("/result", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "HelloWorld")
+	}).Methods("GET")
+
+	router.HandleFunc("/app", func(w http.ResponseWriter, r *http.Request) {
+		manager.AsyncHttpRedirectFunc(w, r, func() (string, error) {
+			time.Sleep(500 * time.Millisecond)
+			return "/result", nil
+		})
+	}).Methods("GET")
+
+	// Setup the server
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	for j := 0; j < 4; j++ {
+		r, err := http.Get(ts.URL + "/app")
+		tests.Assert(t, r.StatusCode == http.StatusAccepted)
+		tests.Assert(t, err == nil)
+		location, err := r.Location()
+		tests.Assert(t, err == nil)
+
+		// test that our custom id generator generated the IDs
+		// according to our pattern
+		tests.Assert(t, strings.Contains(location.String(), "abc-"),
+			`expected "abc-" in newloc, got:`, location)
+		part := fmt.Sprintf("-%v%v%v", j, j, j)
+		tests.Assert(t, strings.Contains(location.String(), part),
+			"expected", part, "in newloc, got:", location)
+
+		for {
+			// Since Get automatically redirects, we will
+			// just keep asking until we get a body
+			r, err := http.Get(location.String())
+			tests.Assert(t, err == nil)
+			tests.Assert(t, r.StatusCode == http.StatusOK)
+			if r.ContentLength > 0 {
+				body, err := ioutil.ReadAll(r.Body)
+				r.Body.Close()
+				tests.Assert(t, err == nil)
+				tests.Assert(t, string(body) == "HelloWorld")
+				break
+			} else {
+				tests.Assert(t, r.Header.Get("X-Pending") == "true")
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}
+
+}

--- a/server/rest/routes.go
+++ b/server/rest/routes.go
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2015 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package rest
+
+import (
+	"net/http"
+)
+
+//
+// This route style comes from the tutorial on
+// http://thenewstack.io/make-a-restful-json-api-go/
+//
+type Route struct {
+	Name        string
+	Method      string
+	Pattern     string
+	HandlerFunc http.HandlerFunc
+}
+
+type Routes []Route


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

This change takes the source files for the formerly external
"heketi/rest" package and makes it a server utility library
(under "heketi/heketi/server/rest") with a license updated
to match the other server components.

The imports of the source files are adjusted to match the
internal "pkg/" utility packages, rather than the external
"heketi/utils" package.

This change is part of the effort to standardize and unify
licensing of the heketi packages as noted in issue #1279.
With this change the heketi server always uses the updated
in-tree utility functions.


### Does this PR fix issues?

Quasi-prerequisite / part of issue #1279

### Notes for the reviewer

This makes no functional change only code movement.
