### PR TITLE
apps: protect against old state in volume delete ops

### DIFF
--- a/apps/glusterfs/operations_test.go
+++ b/apps/glusterfs/operations_test.go
@@ -718,6 +718,11 @@ func TestVolumeDeleteOperationTwice(t *testing.T) {
 		po, e := PendingOperationList(tx)
 		tests.Assert(t, e == nil, "expected e == nil, got", e)
 		tests.Assert(t, len(po) == 1, "expected len(po) == 1, got:", len(po))
+
+		// check that the volume is pending in the db
+		v, e := NewVolumeEntryFromId(tx, vol.Info.Id)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, v.Pending.Id != "", "expected v to be pending")
 		return nil
 	})
 


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Unlike volume creates, volume deletes require the system to check
the state of the pre-existing objects in the db. Thus the Build
step of the delete operations must update the state of the volume
in the db and not trust the state of the block volume entries
initially passed to the operation are up-to-date.

This probably should have been caught when I worked
on PR #1398, but unfortunately it must have slipped my mind. :-(

### Does this PR fix issues?

Fixes [rhbz#1647223](https://bugzilla.redhat.com/show_bug.cgi?id=1647223)


### Notes for the reviewer


