### PR TITLE
pkg/utils: relicense to dual Apache2 and LGPLv3+

### DIFF
--- a/pkg/utils/bodystring.go
+++ b/pkg/utils/bodystring.go
@@ -3,8 +3,11 @@
 //
 // This file is licensed to you under your choice of the GNU Lesser
 // General Public License, version 3 or any later version (LGPLv3 or
-// later), or the GNU General Public License, version 2 (GPLv2), in all
-// cases as published by the Free Software Foundation.
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
 //
 
 package utils

--- a/pkg/utils/bodystring_test.go
+++ b/pkg/utils/bodystring_test.go
@@ -3,8 +3,11 @@
 //
 // This file is licensed to you under your choice of the GNU Lesser
 // General Public License, version 3 or any later version (LGPLv3 or
-// later), or the GNU General Public License, version 2 (GPLv2), in all
-// cases as published by the Free Software Foundation.
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
 //
 
 package utils

--- a/pkg/utils/jsonutils.go
+++ b/pkg/utils/jsonutils.go
@@ -3,8 +3,11 @@
 //
 // This file is licensed to you under your choice of the GNU Lesser
 // General Public License, version 3 or any later version (LGPLv3 or
-// later), or the GNU General Public License, version 2 (GPLv2), in all
-// cases as published by the Free Software Foundation.
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
 //
 
 package utils

--- a/pkg/utils/jsonutils_test.go
+++ b/pkg/utils/jsonutils_test.go
@@ -3,8 +3,11 @@
 //
 // This file is licensed to you under your choice of the GNU Lesser
 // General Public License, version 3 or any later version (LGPLv3 or
-// later), or the GNU General Public License, version 2 (GPLv2), in all
-// cases as published by the Free Software Foundation.
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
 //
 
 package utils

--- a/pkg/utils/statusgroup.go
+++ b/pkg/utils/statusgroup.go
@@ -3,8 +3,11 @@
 //
 // This file is licensed to you under your choice of the GNU Lesser
 // General Public License, version 3 or any later version (LGPLv3 or
-// later), or the GNU General Public License, version 2 (GPLv2), in all
-// cases as published by the Free Software Foundation.
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
 //
 
 package utils

--- a/pkg/utils/statusgroup_test.go
+++ b/pkg/utils/statusgroup_test.go
@@ -3,8 +3,11 @@
 //
 // This file is licensed to you under your choice of the GNU Lesser
 // General Public License, version 3 or any later version (LGPLv3 or
-// later), or the GNU General Public License, version 2 (GPLv2), in all
-// cases as published by the Free Software Foundation.
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
 //
 
 package utils


### PR DESCRIPTION
In a sequence of commits

fc8e4c5fa19d11afb4d9ebed8a94082b7d9459ae
31b83a82a22956349d0df178d5a0d212af237871
7c3cd4c1e0be107195558059c604ebf1dc765d53

Heketi was relicensed from Apache to the following model:

- the rest api client code is under dual Apache2 or LGPLv3+
- all other parts (server, cli, tests, ...) are under dual LGPLv3+ or GPLv2

Now an oversight/mistake was made in that parts of the pkg/utils are
used in the client and hence apache-licensed projects that compile
in heketi client, like kubernetes, have a license problem since they
pull GPL code in. See:

https://github.com/heketi/heketi/issues/1279
https://github.com/kubernetes/kubernetes/issues/35557
https://github.com/kubernetes/kubernetes/issues/70802

This patch fixes the oversight by relicensing the remaining
pieces of pkg/utils to the same dual Apache2 or LGPLv3+ license
after those parts that are only used in the server have been
moved out of pkg/utils.

Fixes #1279

Signed-off-by: Michael Adam <obnox@redhat.com>
Signed-off-by: John Mulligan <jmulligan@redhat.com>
