### PR TITLE
build: fix path issue in prepare.sh

### DIFF
--- a/extras/docker/centos/prepare-build.sh
+++ b/extras/docker/centos/prepare-build.sh
@@ -11,5 +11,5 @@ set -e
 # the local directory where the Dockerfile is located
 WORKDIR=$(dirname "${0}")
 
-cp -f "${WORKDIR}"/../fromsource/heketi.json "${WORKDIR}"
-cp -f "${WORKDIR}"/../fromsource/heketi-start.sh "${WORKDIR}"
+cp -f "${WORKDIR}"/../../container/heketi.json "${WORKDIR}"
+cp -f "${WORKDIR}"/../../container/heketi-start.sh "${WORKDIR}"


### PR DESCRIPTION
update heketi.json and  heketi-start.sh path

Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>

<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?
[commit](https://github.com/heketi/heketi/commit/0c12c6abf34255d026ad5d6aae316901814b8024) has moved `heketi.josn` and `heketi-start.sh` from  `extras/docker/fromsource`  to `extras/container`

### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #1432


