### PR TITLE
docker/centos: container files get installed by 'make install'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,8 @@ bindir:=$(prefix)/bin
 datarootdir:=$(prefix)/share
 hekdir:=$(datarootdir)/heketi
 mandir:=$(datarootdir)/man
+heketi_start_path:=$(hekdir)/container/heketi-start.sh
+heketi_config_path:=$(hekdir)/container/heketi.json
 
 INSTALL:=install -D -p
 INSTALL_PROGRAM:=$(INSTALL) -m 0755
@@ -179,9 +181,9 @@ install:
 	$(INSTALL_DATA) docs/man/heketi-cli.8 \
 		$(DESTDIR)$(mandir)/man8/heketi-cli.8
 	$(INSTALL_PROGRAM) extras/container/heketi-start.sh \
-		$(DESTDIR)$(hekdir)/container/heketi-start.sh
+		$(DESTDIR)$(heketi_start_path)
 	$(INSTALL_DATA) extras/container/heketi.json \
-		$(DESTDIR)$(hekdir)/container/heketi.json
+		$(DESTDIR)$(heketi_config_path)
 
 
 .PHONY: server client test clean name run version release \

--- a/extras/docker/centos/.gitignore
+++ b/extras/docker/centos/.gitignore
@@ -1,3 +1,0 @@
-# artifacts copied from elsewere (see prepare-build.sh)
-heketi.json
-heketi-start.sh

--- a/extras/docker/centos/Dockerfile
+++ b/extras/docker/centos/Dockerfile
@@ -16,5 +16,5 @@ VOLUME /etc/heketi
 VOLUME /var/lib/heketi
 
 # expose port, set user and set entrypoint with config option
-ENTRYPOINT ["/usr/bin/heketi-start.sh"]
+ENTRYPOINT ["/usr/share/heketi/container/heketi-start.sh"]
 EXPOSE 8080

--- a/extras/docker/centos/Dockerfile
+++ b/extras/docker/centos/Dockerfile
@@ -9,9 +9,8 @@ RUN yum -y install centos-release-gluster && \
     yum -y install heketi heketi-client && \
     yum -y clean all
 
-# post install config and volume setup
-ADD heketi.json /etc/heketi/heketi.json
-ADD heketi-start.sh /usr/bin/heketi-start.sh
+# post install config from example file
+RUN install -m 0600 -D /usr/share/heketi/container/heketi.json /etc/heketi/heketi.json
 
 VOLUME /etc/heketi
 VOLUME /var/lib/heketi

--- a/extras/docker/centos/Dockerfile.testing
+++ b/extras/docker/centos/Dockerfile.testing
@@ -16,5 +16,5 @@ VOLUME /etc/heketi
 VOLUME /var/lib/heketi
 
 # expose port, set user and set entrypoint with config option
-ENTRYPOINT ["/usr/bin/heketi-start.sh"]
+ENTRYPOINT ["/usr/share/heketi/container/heketi-start.sh"]
 EXPOSE 8080

--- a/extras/docker/centos/Dockerfile.testing
+++ b/extras/docker/centos/Dockerfile.testing
@@ -9,9 +9,8 @@ RUN yum -y install centos-release-gluster && \
     yum -y --enablerepo=centos-gluster*-test install heketi heketi-client && \
     yum -y --enablerepo=* clean all
 
-# post install config and volume setup
-ADD heketi.json /etc/heketi/heketi.json
-ADD heketi-start.sh /usr/bin/heketi-start.sh
+# post install config from example file
+RUN install -m 0600 -D /usr/share/heketi/container/heketi.json /etc/heketi/heketi.json
 
 VOLUME /etc/heketi
 VOLUME /var/lib/heketi

--- a/extras/docker/centos/prepare-build.sh
+++ b/extras/docker/centos/prepare-build.sh
@@ -1,15 +1,11 @@
 #!/bin/sh
 #
-# Preparation for building container images.
+# This script is now deprecated and should get removed once the CentOS
+# Community Container Pipeline does not point to it anymore.
 #
-# - artifacts need to be in this WORKDIR, symlinks won't work
-#
+# Once the :testing container builds successfully again, the prebuild-script
+# can be dropped from
+# https://github.com/CentOS/container-index/blob/master/index.d/gluster.yaml
+# and after that has been merged, this script can be deleted.
 
-# error out if anything fails
-set -e
-
-# the local directory where the Dockerfile is located
-WORKDIR=$(dirname "${0}")
-
-cp -f "${WORKDIR}"/../fromsource/heketi.json "${WORKDIR}"
-cp -f "${WORKDIR}"/../fromsource/heketi-start.sh "${WORKDIR}"
+true

--- a/extras/docker/fromsource/Dockerfile
+++ b/extras/docker/fromsource/Dockerfile
@@ -27,8 +27,6 @@ RUN mkdir $BUILD_HOME $GOPATH && \
     make && \
     mkdir -p /etc/heketi /var/lib/heketi && \
     make install prefix=/usr && \
-    cp /usr/share/heketi/container/heketi-start.sh /usr/bin/heketi-start.sh && \
-    cp /usr/share/heketi/container/heketi.json /etc/heketi/heketi.json && \
     glide cc && \
     cd && rm -rf $BUILD_HOME && \
     dnf -y remove git glide golang mercurial && \
@@ -38,5 +36,5 @@ RUN mkdir $BUILD_HOME $GOPATH && \
 VOLUME /etc/heketi /var/lib/heketi
 
 # expose port, set user and set entrypoint with config option
-ENTRYPOINT ["/usr/bin/heketi-start.sh"]
+ENTRYPOINT ["/usr/share/heketi/container/heketi-start.sh"]
 EXPOSE 8080

--- a/extras/docker/rpi/Dockerfile
+++ b/extras/docker/rpi/Dockerfile
@@ -8,7 +8,7 @@ LABEL description="Heketi Container for Raspberry Pi"
 ADD ./heketi /usr/bin/heketi
 ADD ./heketi-cli /usr/bin/heketi-cli
 ADD ../../container/heketi.json /etc/heketi/heketi.json
-ADD ../../conatiner/heketi-start.sh /usr/bin/heketi-start.sh
+ADD ../../container/heketi-start.sh /usr/bin/heketi-start.sh
 VOLUME /etc/heketi
 
 VOLUME /var/lib/heketi

--- a/extras/docker/rpi/Dockerfile
+++ b/extras/docker/rpi/Dockerfile
@@ -7,8 +7,8 @@ LABEL description="Heketi Container for Raspberry Pi"
 
 ADD ./heketi /usr/bin/heketi
 ADD ./heketi-cli /usr/bin/heketi-cli
-ADD ../../container/heketi.json /etc/heketi/heketi.json
-ADD ../../container/heketi-start.sh /usr/bin/heketi-start.sh
+ADD ./heketi.json /etc/heketi/heketi.json
+ADD ./heketi-start.sh /usr/bin/heketi-start.sh
 VOLUME /etc/heketi
 
 VOLUME /var/lib/heketi

--- a/extras/docker/rpi/build-rpi-dockerfile.sh
+++ b/extras/docker/rpi/build-rpi-dockerfile.sh
@@ -13,6 +13,8 @@ compile() {
     env GOOS=linux GOARCH=arm make || fail "Unable to create build"
     cp heketi "$DOCKERFILEDIR"
     cp client/cli/go/heketi-cli "$DOCKERFILEDIR"
+    cp extras/container/heketi.json "$DOCKERFILEDIR"
+    cp extras/container/heketi-start.sh "$DOCKERFILEDIR"
     make clean
     cd "$DOCKERFILEDIR" || fail "Unable to 'cd $DOCKERFILEDIR'."
 }


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

There is no need to manually provide the `heketi.json` configuration and
`heketi-start.sh` script. These are installed with `make install` since
commit 0c12c6abf3.

The container image builds for the CentOS Container Registry call
`prepare-build.sh` which used to copy the files to the container build
root. Now these files do not exist anymore, the preparation fails and
the (:testing) container does not get updated anymore.

### Does this PR fix issues?

Fixes: #1432

