### PR TITLE
remoteexec: use error output for error contents

### DIFF
--- a/pkg/remoteexec/result.go
+++ b/pkg/remoteexec/result.go
@@ -29,6 +29,21 @@ func (r Result) Ok() bool {
 	return r.Completed && r.Err == nil && r.ExitStatus == 0
 }
 
+// Error allows an error result to be treated like an error type.
+// Do not assume all results are true errors.
+func (r Result) Error() string {
+	// to be more compatible with older versions of heketi we use
+	// the error output (stderr) of commands unless that
+	// string is empty
+	if r.ErrOutput != "" {
+		return r.ErrOutput
+	}
+	if r.Err != nil {
+		return r.Err.Error()
+	}
+	return ""
+}
+
 // Results is used for a grouping of Result items.
 type Results []Result
 
@@ -73,7 +88,7 @@ func (rs Results) FirstErrorIndexed() (int, error) {
 			continue
 		}
 		if r.Err != nil {
-			return i, r.Err
+			return i, r
 		}
 	}
 	return -1, nil

--- a/pkg/remoteexec/result.go
+++ b/pkg/remoteexec/result.go
@@ -87,7 +87,7 @@ func (rs Results) FirstErrorIndexed() (int, error) {
 		if !r.Completed {
 			continue
 		}
-		if r.Err != nil {
+		if !r.Ok() {
 			return i, r
 		}
 	}

--- a/pkg/remoteexec/result_test.go
+++ b/pkg/remoteexec/result_test.go
@@ -1,0 +1,348 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package remoteexec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/heketi/tests"
+)
+
+func TestResultOk(t *testing.T) {
+	var r Result
+
+	// a command that ran successfully
+	r = Result{
+		Completed:  true,
+		Output:     "Foo",
+		ExitStatus: 0,
+	}
+	tests.Assert(t, r.Ok(), "expected r.Ok() to be true")
+
+	// an incomplete result
+	r = Result{}
+	tests.Assert(t, !r.Ok(), "expected r.Ok() to be false")
+
+	// a command that ran & completed with error
+	r = Result{
+		Completed:  true,
+		ErrOutput:  "Bar bar bar",
+		Err:        fmt.Errorf("command exited 1"),
+		ExitStatus: 1,
+	}
+	tests.Assert(t, !r.Ok(), "expected r.Ok() to be false")
+
+	// only error set. possibly indicating a conn error
+	r = Result{
+		Completed: true,
+		Err:       fmt.Errorf("something broke"),
+	}
+	tests.Assert(t, !r.Ok(), "expected r.Ok() to be false")
+}
+
+func TestResultError(t *testing.T) {
+	var r Result
+
+	// a command that ran successfully
+	r = Result{
+		Completed:  true,
+		Output:     "Foo",
+		ExitStatus: 0,
+	}
+	tests.Assert(t, r.Error() == "", "expected \"\" got:", r.Error())
+
+	// an incomplete result
+	r = Result{}
+	tests.Assert(t, r.Error() == "", "expected \"\" got:", r.Error())
+
+	// a command that ran & completed with error
+	r = Result{
+		Completed:  true,
+		ErrOutput:  "Bar bar bar",
+		Err:        fmt.Errorf("command exited 1"),
+		ExitStatus: 1,
+	}
+	tests.Assert(t, r.Error() == "Bar bar bar",
+		"expected \"Bar bar bar\" got:", r.Error())
+
+	// only error set. possibly indicating a conn error
+	r = Result{
+		Completed: true,
+		Err:       fmt.Errorf("something broke"),
+	}
+	tests.Assert(t, r.Error() == "something broke",
+		"expected \"something broke\" got:", r.Error())
+}
+
+func TestSquashErrors(t *testing.T) {
+	var rs Results
+
+	rs = append(rs, Result{
+		Completed:  true,
+		Output:     "Foo",
+		ExitStatus: 0,
+	})
+	o, e := rs.SquashErrors()
+	tests.Assert(t, e == nil, "expected e == nil")
+	tests.Assert(t, len(o) == 1, "expected len(o) == 1, got:", len(o))
+	tests.Assert(t, o[0] == "Foo", `expected o[0] == "Foo", got:`, o[0])
+
+	rs = append(rs, Result{
+		Completed:  true,
+		Output:     "Flup",
+		ExitStatus: 0,
+	})
+	o, e = rs.SquashErrors()
+	tests.Assert(t, e == nil, "expected e == nil")
+	tests.Assert(t, len(o) == 2, "expected len(o) == 2, got:", len(o))
+	tests.Assert(t, o[1] == "Flup", `expected o[1] == "Flup", got:`, o[1])
+
+	rs = append(rs, Result{
+		Completed:  true,
+		ErrOutput:  "Bar bar bar",
+		Err:        fmt.Errorf("command exited 1"),
+		ExitStatus: 1,
+	})
+	o, e = rs.SquashErrors()
+	tests.Assert(t, e != nil, "expected e != nil")
+	tests.Assert(t, e.Error() == "Bar bar bar",
+		"expected \"Bar bar bar\" got:", e.Error())
+
+	// check empty array behavior
+	rs = Results{}
+	o, e = rs.SquashErrors()
+	tests.Assert(t, e == nil, "expected e == nil")
+	tests.Assert(t, len(o) == 0, "expected len(o) == 0, got:", len(o))
+
+	// check short array
+	rs = make(Results, 2)
+	rs[0] = Result{
+		Completed:  true,
+		Output:     "Foo",
+		ExitStatus: 0,
+	}
+	o, e = rs.SquashErrors()
+	tests.Assert(t, e == nil, "expected e == nil")
+	tests.Assert(t, len(o) == 2, "expected len(o) == 2, got:", len(o))
+	tests.Assert(t, o[0] == "Foo", `expected o[0] == "Foo", got:`, o[0])
+	tests.Assert(t, o[1] == "", `expected o[0] == "", got:`, o[0])
+}
+
+func TestResultsOk(t *testing.T) {
+	var rs Results
+
+	// empty is always Ok
+	tests.Assert(t, rs.Ok(), "expected r.Ok() to be true")
+
+	rs = make(Results, 5)
+	rs[0] = Result{
+		Completed:  true,
+		Output:     "Foo",
+		ExitStatus: 0,
+	}
+
+	// its short, but no errors, thus true
+	tests.Assert(t, rs.Ok(), "expected r.Ok() to be true")
+
+	rs[1] = Result{
+		Completed:  true,
+		Output:     "Flup",
+		ExitStatus: 0,
+	}
+
+	// its short, but no errors, thus true
+	tests.Assert(t, rs.Ok(), "expected r.Ok() to be true")
+
+	rs[2] = Result{
+		Completed:  true,
+		ErrOutput:  "Bar bar bar",
+		Err:        fmt.Errorf("command exited 1"),
+		ExitStatus: 1,
+	}
+
+	// now an error is present, its false
+	tests.Assert(t, !rs.Ok(), "expected rs.Ok() to be false")
+}
+
+func TestResultsFirstErrorIndexed(t *testing.T) {
+	var rs Results
+
+	// empty is always Ok
+	ei, e := rs.FirstErrorIndexed()
+	tests.Assert(t, ei == -1, "expected ei == -1, got:", ei)
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+
+	rs = make(Results, 5)
+	rs[0] = Result{
+		Completed:  true,
+		Output:     "Foo",
+		ExitStatus: 0,
+	}
+
+	ei, e = rs.FirstErrorIndexed()
+	tests.Assert(t, ei == -1, "expected ei == -1, got:", ei)
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+
+	rs[1] = Result{
+		Completed:  true,
+		Output:     "Flup",
+		ExitStatus: 0,
+	}
+
+	ei, e = rs.FirstErrorIndexed()
+	tests.Assert(t, ei == -1, "expected ei == -1, got:", ei)
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+
+	rs[2] = Result{
+		Completed:  true,
+		ErrOutput:  "Bar bar bar",
+		Err:        fmt.Errorf("command exited 1"),
+		ExitStatus: 1,
+	}
+
+	ei, e = rs.FirstErrorIndexed()
+	tests.Assert(t, ei == 2, "expected ei == 2, got:", ei)
+	tests.Assert(t, e != nil, "expected e != nil, got:", e)
+	tests.Assert(t, e.Error() == "Bar bar bar",
+		"expected \"Bar bar bar\" got:", e.Error())
+
+	// it ignores "holes"
+	rs[1] = Result{}
+
+	ei, e = rs.FirstErrorIndexed()
+	tests.Assert(t, ei == 2, "expected ei == 2, got:", ei)
+	tests.Assert(t, e != nil, "expected e != nil, got:", e)
+	tests.Assert(t, e.Error() == "Bar bar bar",
+		"expected \"Bar bar bar\" got:", e.Error())
+
+	// put error earlier
+	rs[1] = Result{
+		Completed:  true,
+		ErrOutput:  "Robble robble",
+		Err:        fmt.Errorf("command exited 1"),
+		ExitStatus: 1,
+	}
+
+	ei, e = rs.FirstErrorIndexed()
+	tests.Assert(t, ei == 1, "expected ei == 1, got:", ei)
+	tests.Assert(t, e != nil, "expected e != nil, got:", e)
+	tests.Assert(t, e.Error() == "Robble robble",
+		"expected \"Robble robble\" got:", e.Error())
+}
+
+func TestResultsFirstError(t *testing.T) {
+	var rs Results
+
+	// empty is always Ok
+	e := rs.FirstError()
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+
+	rs = make(Results, 5)
+	rs[0] = Result{
+		Completed:  true,
+		Output:     "Foo",
+		ExitStatus: 0,
+	}
+
+	e = rs.FirstError()
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+
+	rs[1] = Result{
+		Completed:  true,
+		Output:     "Flup",
+		ExitStatus: 0,
+	}
+
+	e = rs.FirstError()
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+
+	rs[2] = Result{
+		Completed:  true,
+		ErrOutput:  "Bar bar bar",
+		Err:        fmt.Errorf("command exited 1"),
+		ExitStatus: 1,
+	}
+
+	e = rs.FirstError()
+	tests.Assert(t, e != nil, "expected e != nil, got:", e)
+	tests.Assert(t, e.Error() == "Bar bar bar",
+		"expected \"Bar bar bar\" got:", e.Error())
+
+	// it ignores "holes"
+	rs[1] = Result{}
+
+	e = rs.FirstError()
+	tests.Assert(t, e != nil, "expected e != nil, got:", e)
+	tests.Assert(t, e.Error() == "Bar bar bar",
+		"expected \"Bar bar bar\" got:", e.Error())
+
+	// put error earlier
+	rs[1] = Result{
+		Completed:  true,
+		ErrOutput:  "Robble robble",
+		Err:        fmt.Errorf("command exited 1"),
+		ExitStatus: 1,
+	}
+
+	e = rs.FirstError()
+	tests.Assert(t, e != nil, "expected e != nil, got:", e)
+	tests.Assert(t, e.Error() == "Robble robble",
+		"expected \"Robble robble\" got:", e.Error())
+}
+
+func TestAnyError(t *testing.T) {
+	var rs Results
+
+	// empty is always Ok
+	e := AnyError(rs, nil)
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+
+	rs = make(Results, 5)
+	rs[0] = Result{
+		Completed:  true,
+		Output:     "Foo",
+		ExitStatus: 0,
+	}
+
+	e = AnyError(rs, nil)
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+
+	rs[1] = Result{
+		Completed:  true,
+		Output:     "Flup",
+		ExitStatus: 0,
+	}
+
+	e = AnyError(rs, nil)
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+
+	e = AnyError(rs, fmt.Errorf("Robble robble"))
+	tests.Assert(t, e != nil, "expected e != nil, got:", e)
+	tests.Assert(t, e.Error() == "Robble robble",
+		"expected \"Robble robble\" got:", e.Error())
+
+	rs[2] = Result{
+		Completed:  true,
+		ErrOutput:  "Bar bar bar",
+		Err:        fmt.Errorf("command exited 1"),
+		ExitStatus: 1,
+	}
+
+	e = AnyError(rs, nil)
+	tests.Assert(t, e != nil, "expected e != nil, got:", e)
+	tests.Assert(t, e.Error() == "Bar bar bar",
+		"expected \"Bar bar bar\" got:", e.Error())
+
+	e = AnyError(rs, fmt.Errorf("Robble robble"))
+	tests.Assert(t, e != nil, "expected e != nil, got:", e)
+	tests.Assert(t, e.Error() == "Robble robble",
+		"expected \"Robble robble\" got:", e.Error())
+}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Historically, heketi used to convert the stderr of commands to go error
type and discard the originating error. The remoteexec library however
goes to lengths to retain all the information about a command including
the error output (stderr) and originating error. But most of the
preexisting heketi code wants to check the error output not the
originating error.

This change allows treating a Result type as an error, looking for error
output if it exists and then falling back to the content of the
originating error. When the adapter functions FirstErrorIndexed,
FirstError, and AnyError were added the important ErrorOutput was
forgotten and the originating error was used. Now it returns the
result-as-error. This change fixes at least one regression where the
error response of "gluster volume delete" was being scraped.


### Notes for the reviewer

Currently, there's no test for this because the error handling that was failing happens in the executor layers which don't get executed with the unit tests in app/glusterfs, so there's no value in trying to write a unit test for this. As for functional tests, .... we do have tests for the volume-already-deleted case but this goes through a check for snapshots first, and this code already uses the "new api" rather than the AnyError adapter function. The problem shows up in the cleanup path which skips checking for snapshots and immediately tries to destroy the volume. This was revealed when adding new tests with the new support for error injection. I wanted to get the PR out there to cut down on the chances for regressions on master sooner than those PRs will be ready.
