### PR TITLE
systemd: provide a heketi.env file with possible variables

### DIFF
--- a/extras/systemd/heketi.env
+++ b/extras/systemd/heketi.env
@@ -1,0 +1,60 @@
+#
+# These environment variables will be loaded by systemd in case heketi is
+# started as a service (as opposed to running in a container).
+#
+# See the actual /etc/heketi/heketi.json configuration file for more options.
+#
+# The variables commented out show the default values. Variables not set here
+# might be set in the /etc/heketi/heketi.json configuration file.
+#
+
+# Database file name
+#HEKETI_DB_PATH=/var/lib/heketi/heketi.db
+
+# fstab file on nodes
+#HEKETI_FSTAB=/etc/fstab
+
+# Set log level. Choices are:
+#   none, critical, error, warning, info, debug
+#HEKETI_GLUSTERAPP_LOGLEVEL=warning
+
+# Heketi Server Port Number
+#HEKETI_HTTP_PORT=8080
+
+# Allow starting heketi when there are stale pending ops being in the db.
+#HEKETI_IGNORE_STALE_OPERATIONS=0
+
+# The maximum limit of snapshots. If no limit has been specified, then Heketi
+# will not set a limit and GlusterFS will use its default value.
+#HEKETI_SNAPSHOT_LIMIT=
+
+# Volume options that will be applied for all volumes created. Can be
+# overridden by volume options in volume create request.
+#HEKETI_PRE_REQUEST_VOLUME_OPTIONS=""
+
+# Volume options that will be applied for all volumes created. To be used to
+# override volume options in volume create request.
+#HEKETI_POST_REQUEST_VOLUME_OPTIONS=""
+
+# Creates Block Hosting volumes automatically if not found or exsisting volume
+# exhausted.
+#HEKETI_AUTO_CREATE_BLOCK_HOSTING_VOLUME=1
+
+# New block hosting volume will be created in size mentioned, This is
+# considered only if auto-create is enabled.
+#HEKETI_BLOCK_HOSTING_VOLUME_SIZE=500
+
+# New block hosting volume will be created with the following set of options.
+# Removing the group gluster-block option is NOT recommended. Additional
+# options can be added next to it separated by a comma.
+#HEKETI_BLOCK_HOSTING_VOLUME_OPTIONS="group gluster-block"
+
+
+# SSH username and private key file information.
+# Note: make sure to configure "executor" to "ssh" in /etc/heketi/heketi.json.
+#HEKETI_SSH_KEYFILE="path/to/private_key"
+#HEKETI_SSH_PORT=22
+#HEKETI_SSH_USER=sshuser
+
+# Rebalance on expansion is done by default, but it can be disabled if needed.
+#HEKETI_GLUSTERAPP_REBALANCE_ON_EXPANSION=1


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

The environment variables that can be set to influence the behaviour of
Heketi are not well documented. This is an attempt to capture the
variables that can be changed for the benefit of the heketi.service
systemd unit.

The systemd unit already tries to read variables from
/etc/heketi/heketi.env, but this file is not provided anywhere. If users
have a need to change the environment, they will need to create the file
and not mistype the name of the variable. Providing a file with the
defaults makes it less error prone.

### Notes for the reviewer

Some of the variables have been left out intentionally:

- admin and user keys: these should be set in the heketi.json config file. Passing them as an environment variable to non-containerized processes seems insecure (thanks @raghavendra-talur)
- heketi as a service started by systemd does not interact with kubernetes, these variables are not used