### PR TITLE
auto cleanup pt2

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -664,6 +664,18 @@ func (a *App) ServerReset() error {
 	})
 }
 
+// OfflineCleaner returns an operations cleaner based on the current
+// app object that can be used to perform an offline cleanup.
+// An offline cleanup assumes that the binary is only doing cleanups
+// and nothing else.
+func (a *App) OfflineCleaner() OperationCleaner {
+	return OperationCleaner{
+		db:       a.db,
+		executor: a.executor,
+		sel:      CleanAll,
+	}
+}
+
 // currentNodeHealthStatus returns a map of node ids to the most
 // recently known health status (true is up, false is not up).
 // If a node is not found in the map its status is unknown.

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -297,8 +297,15 @@ func (v *BlockVolumeEntry) deleteBlockVolumeExec(db wdb.RODB,
 	}
 
 	logger.Debug("Using executor host [%v]", executorhost)
+	return v.destroyFromHost(executor, hvname, executorhost)
+}
 
-	err = executor.BlockVolumeDestroy(executorhost, hvname, v.Info.Name)
+// destroyFromHost removes the block volume using the provided
+// executor, block hosting volume name, and host.
+func (v *BlockVolumeEntry) destroyFromHost(
+	executor executors.Executor, hvname, h string) error {
+
+	err := executor.BlockVolumeDestroy(h, hvname, v.Info.Name)
 	if _, ok := err.(*executors.VolumeDoesNotExistErr); ok {
 		logger.Warning(
 			"Block volume %v (%v) does not exist: assuming already deleted",

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -404,6 +404,21 @@ func (v *BlockVolumeEntry) updateHosts(hosts []string) {
 	v.Info.BlockVolume.Hosts = hosts
 }
 
+// hosts returns a node-to-host mapping for all nodes suitable
+// for running commands related to this block volume
+func (v *BlockVolumeEntry) hosts(db wdb.RODB) (nodeHosts, error) {
+	var hosts nodeHosts
+	err := db.View(func(tx *bolt.Tx) error {
+		cluster, err := NewClusterEntryFromId(tx, v.Info.Cluster)
+		if err != nil {
+			return err
+		}
+		hosts, err = cluster.hosts(wdb.WrapTx(tx))
+		return err
+	})
+	return hosts, err
+}
+
 // hasPendingBlockHostingVolume returns true if the db contains pending
 // block hosting volumes.
 func hasPendingBlockHostingVolume(tx *bolt.Tx) (bool, error) {

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -225,22 +225,6 @@ func (v *BlockVolumeEntry) eligibleClustersAndVolumes(db wdb.RODB) (
 	return
 }
 
-func (v *BlockVolumeEntry) cleanupBlockVolumeCreate(db wdb.DB,
-	executor executors.Executor) error {
-
-	hvname, err := v.blockHostingVolumeName(db)
-	if err != nil {
-		return err
-	}
-
-	err = v.deleteBlockVolumeExec(db, hvname, executor)
-	if err != nil {
-		return err
-	}
-
-	return v.removeComponents(db, false)
-}
-
 func (v *BlockVolumeEntry) Create(db wdb.DB,
 	executor executors.Executor) (e error) {
 

--- a/apps/glusterfs/brick_create.go
+++ b/apps/glusterfs/brick_create.go
@@ -23,45 +23,74 @@ import (
 // in the key freed underlying storage and false if not.
 type ReclaimMap map[string]bool
 
-func CreateBricks(db wdb.RODB, executor executors.Executor, brick_entries []*BrickEntry) error {
-	sg := utils.NewStatusGroup()
+// brickHostMap maps brick entries to hostnames.
+// The host names are generally used for execution of brick commands.
+// A brick host map gathers all the information needed to execute
+// commands from the db prior to execution.
+type brickHostMap map[*BrickEntry]string
 
+// newBrickHostMap creates a mapping of brick entries to the hosts
+// that commands for that brick can be executed on.
+func newBrickHostMap(
+	db wdb.RODB, bricks []*BrickEntry) (brickHostMap, error) {
+
+	bmap := brickHostMap{}
+	for _, brick := range bricks {
+		var err error
+		bmap[brick], err = brick.host(db)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return bmap, nil
+}
+
+// create executes commands to create every brick in the map using
+// the mapped host. If a brick fails to create the function
+// tries to automatically clean up the other created bricks.
+func (bmap brickHostMap) create(executor executors.Executor) error {
+	sg := utils.NewStatusGroup()
 	// Create a goroutine for each brick
-	for _, brick := range brick_entries {
+	for brick, host := range bmap {
 		sg.Add(1)
-		go func(b *BrickEntry) {
+		go func(b *BrickEntry, host string) {
 			defer sg.Done()
-			sg.Err(b.Create(db, executor))
-		}(brick)
+			logger.Info("Creating brick %v", b.Info.Id)
+			_, err := executor.BrickCreate(host, b.createReq())
+			sg.Err(err)
+		}(brick, host)
 	}
 
-	// Wait here until all goroutines have returned.  If
-	// any of errored, it would be cought here
 	err := sg.Result()
 	if err != nil {
 		logger.Err(err)
-
 		// Destroy all bricks and cleanup
-		DestroyBricks(db, executor, brick_entries)
+		if _, err := bmap.destroy(executor); err != nil {
+			logger.LogError(
+				"error destroying bricks after create failure: %v", err)
+		}
 	}
 
 	return err
 }
 
-func DestroyBricks(db wdb.RODB, executor executors.Executor, brick_entries []*BrickEntry) (ReclaimMap, error) {
-	sg := utils.NewStatusGroup()
+// destroy executes commands to destroy/delete every brick in the map
+// using the mapped host.
+func (bmap brickHostMap) destroy(
+	executor executors.Executor) (ReclaimMap, error) {
 
+	sg := utils.NewStatusGroup()
 	// return a map with the deviceId as key, and a bool if the space has been free'd
 	reclaimed := map[string]bool{}
 	// the mutex is used to prevent "fatal error: concurrent map writes"
 	mutex := sync.Mutex{}
 
 	// Create a goroutine for each brick
-	for _, brick := range brick_entries {
+	for brick, host := range bmap {
 		sg.Add(1)
-		go func(b *BrickEntry, r map[string]bool, m *sync.Mutex) {
+		go func(b *BrickEntry, host string, r map[string]bool, m *sync.Mutex) {
 			defer sg.Done()
-			spaceReclaimed, err := b.Destroy(db, executor)
+			spaceReclaimed, err := executor.BrickDestroy(host, b.destroyReq())
 			if err != nil {
 				logger.LogError("error destroying brick %v: %v",
 					b.Info.Id, err)
@@ -73,15 +102,31 @@ func DestroyBricks(db wdb.RODB, executor executors.Executor, brick_entries []*Br
 			}
 
 			sg.Err(err)
-		}(brick, reclaimed, &mutex)
+		}(brick, host, reclaimed, &mutex)
 	}
 
-	// Wait here until all goroutines have returned.  If
-	// any of errored, it would be cought here
 	err := sg.Result()
 	if err != nil {
 		logger.Err(err)
 	}
 
 	return reclaimed, err
+}
+
+// CreateBricks is a deprecated wrapper for creating multiple bricks.
+func CreateBricks(db wdb.RODB, executor executors.Executor, brick_entries []*BrickEntry) error {
+	bmap, err := newBrickHostMap(db, brick_entries)
+	if err != nil {
+		return err
+	}
+	return bmap.create(executor)
+}
+
+// DestroyBricks is a deprecated wrapper for destroying multiple bricks.
+func DestroyBricks(db wdb.RODB, executor executors.Executor, brick_entries []*BrickEntry) (ReclaimMap, error) {
+	bmap, err := newBrickHostMap(db, brick_entries)
+	if err != nil {
+		return nil, err
+	}
+	return bmap.destroy(executor)
 }

--- a/apps/glusterfs/brick_entry.go
+++ b/apps/glusterfs/brick_entry.go
@@ -259,28 +259,6 @@ func (b *BrickEntry) Destroy(db wdb.RODB, executor executors.Executor) (bool, er
 	return spaceReclaimed, nil
 }
 
-func (b *BrickEntry) DestroyCheck(db wdb.RODB, executor executors.Executor) error {
-	godbc.Require(db != nil)
-	godbc.Require(b.TpSize > 0)
-	godbc.Require(b.Info.Size > 0)
-
-	// Get node hostname
-	var host string
-	err := db.View(func(tx *bolt.Tx) error {
-		node, err := NewNodeEntryFromId(tx, b.Info.NodeId)
-		if err != nil {
-			return err
-		}
-
-		host = node.ManageHostName()
-		godbc.Check(host != "")
-		return nil
-	})
-
-	// TODO: any additional checks in the DB? The detection of the VG/LV and its users is done in cmdexec.BrickDestroy()
-	return err
-}
-
 // Size consumed on device
 func (b *BrickEntry) TotalSize() uint64 {
 	return b.TpSize + b.PoolMetadataSize

--- a/apps/glusterfs/brick_entry.go
+++ b/apps/glusterfs/brick_entry.go
@@ -373,3 +373,27 @@ func (b *BrickEntry) LvName() string {
 func (b *BrickEntry) BrickType() BrickSubType {
 	return b.SubType
 }
+
+// remove deletes a brick and the links to that brick in the db.
+func (b *BrickEntry) remove(tx *bolt.Tx, v *VolumeEntry) error {
+	err := b.RemoveFromDevice(tx)
+	if err != nil {
+		logger.Err(err)
+		return err
+	}
+
+	// Delete brick from volume entry
+	v.BrickDelete(b.Info.Id)
+	if err != nil {
+		logger.Err(err)
+		return err
+	}
+
+	// Delete brick entry from db
+	err = b.Delete(tx)
+	if err != nil {
+		logger.Err(err)
+		return err
+	}
+	return nil
+}

--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -154,21 +154,21 @@ func bricksFromOp(db wdb.RODB,
 func volumesFromOp(db wdb.RODB,
 	op *PendingOperationEntry) ([]*VolumeEntry, error) {
 
-	volume_entries := []*VolumeEntry{}
+	volumeEntries := []*VolumeEntry{}
 	err := db.View(func(tx *bolt.Tx) error {
 		for _, a := range op.Actions {
 			switch a.Change {
 			case OpAddVolume, OpDeleteVolume, OpExpandVolume:
-				brick, err := NewVolumeEntryFromId(tx, a.Id)
+				v, err := NewVolumeEntryFromId(tx, a.Id)
 				if err != nil {
 					return err
 				}
-				volume_entries = append(volume_entries, brick)
+				volumeEntries = append(volumeEntries, v)
 			}
 		}
 		return nil
 	})
-	return volume_entries, err
+	return volumeEntries, err
 }
 
 // expandSizeFromOp returns the size of a volume expand operation assuming

--- a/apps/glusterfs/operations.go
+++ b/apps/glusterfs/operations.go
@@ -157,7 +157,8 @@ func volumesFromOp(db wdb.RODB,
 	volume_entries := []*VolumeEntry{}
 	err := db.View(func(tx *bolt.Tx) error {
 		for _, a := range op.Actions {
-			if a.Change == OpAddVolume {
+			switch a.Change {
+			case OpAddVolume, OpDeleteVolume, OpExpandVolume:
 				brick, err := NewVolumeEntryFromId(tx, a.Id)
 				if err != nil {
 					return err

--- a/apps/glusterfs/operations_block_volume.go
+++ b/apps/glusterfs/operations_block_volume.go
@@ -24,7 +24,6 @@ type BlockVolumeCreateOperation struct {
 	OperationManager
 	noRetriesOperation
 	bvol *BlockVolumeEntry
-	//vol *VolumeEntry
 }
 
 // NewBlockVolumeCreateOperation  returns a new BlockVolumeCreateOperation  populated
@@ -242,7 +241,15 @@ func (bvc *BlockVolumeCreateOperation) Rollback(executor executors.Executor) err
 	if err != nil {
 		return err
 	}
-	if e := bvc.bvol.cleanupBlockVolumeCreate(bvc.db, executor); e != nil {
+	hvname, err := bvc.bvol.blockHostingVolumeName(bvc.db)
+	if err != nil {
+		return err
+	}
+	err = bvc.bvol.deleteBlockVolumeExec(bvc.db, hvname, executor)
+	if err != nil {
+		return err
+	}
+	if e := bvc.bvol.removeComponents(bvc.db, false); e != nil {
 		return e
 	}
 	if vol != nil {

--- a/apps/glusterfs/operations_block_volume.go
+++ b/apps/glusterfs/operations_block_volume.go
@@ -386,6 +386,30 @@ func NewBlockVolumeDeleteOperation(
 	}
 }
 
+// loadBlockVolumeDeleteOperation returns a BlockVolumeDeleteOperation populated
+// from an existing pending operation entry in the db.
+func loadBlockVolumeDeleteOperation(
+	db wdb.DB, p *PendingOperationEntry) (*BlockVolumeDeleteOperation, error) {
+
+	bvs, err := blockVolumesFromOp(db, p)
+	if err != nil {
+		return nil, err
+	}
+	if len(bvs) != 1 {
+		return nil, fmt.Errorf(
+			"Incorrect number of block volumes (%v) for create operation: %v",
+			len(bvs), p.Id)
+	}
+
+	return &BlockVolumeDeleteOperation{
+		OperationManager: OperationManager{
+			db: db,
+			op: p,
+		},
+		bvol: bvs[0],
+	}, nil
+}
+
 func (vdel *BlockVolumeDeleteOperation) Label() string {
 	return "Delete Block Volume"
 }

--- a/apps/glusterfs/operations_cleanup.go
+++ b/apps/glusterfs/operations_cleanup.go
@@ -40,6 +40,12 @@ func (oc OperationCleaner) Clean() error {
 		if _, ok := err.(ErrNotLoadable); ok {
 			logger.Err(err)
 			continue
+		} else if err == ErrNotFound {
+			// TODO: flag/process pending ops with bad references more sanely
+			// for now, just skip over them
+			logger.LogError("unable to load operation [%v]: %v",
+				pop.Id, err)
+			continue
 		} else if err != nil {
 			return err
 		}

--- a/apps/glusterfs/operations_cleanup_test.go
+++ b/apps/glusterfs/operations_cleanup_test.go
@@ -70,3 +70,80 @@ func TestBasicOperationsCleanup(t *testing.T) {
 		return nil
 	})
 }
+
+func TestOperationsCleanupThreeOps(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	req := &api.VolumeCreateRequest{}
+	req.Size = 1024
+	req.Durability.Type = api.DurabilityReplicate
+	req.Durability.Replicate.Replica = 3
+
+	// create a volume we can delete later
+	vol := NewVolumeEntryFromRequest(req)
+	vc := NewVolumeCreateOperation(vol, app.db)
+	e := RunOperation(vc, app.executor)
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	app.db.Update(func(tx *bolt.Tx) error {
+		l, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(l) == 0, "expected len(l) == 0, got:", len(l))
+		return nil
+	})
+	dvol := vol
+
+	// create 1st pending op
+	vol = NewVolumeEntryFromRequest(req)
+	vc = NewVolumeCreateOperation(vol, app.db)
+	e = vc.Build()
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	// create 2nd pending op
+	vol = NewVolumeEntryFromRequest(req)
+	vc = NewVolumeCreateOperation(vol, app.db)
+	e = vc.Build()
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	// create 3rd pending op
+	vdel := NewVolumeDeleteOperation(dvol, app.db)
+	e = vdel.Build()
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	app.db.Update(func(tx *bolt.Tx) error {
+		l, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(l) == 3, "expected len(l) == 3, got:", len(l))
+		e = MarkPendingOperationsStale(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		return nil
+	})
+
+	oc := OperationCleaner{
+		db:       app.db,
+		executor: app.executor,
+		sel:      CleanAll,
+	}
+	e = oc.Clean()
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	app.db.View(func(tx *bolt.Tx) error {
+		l, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(l) == 0, "expected len(l) == 0, got:", len(l))
+		return nil
+	})
+}

--- a/apps/glusterfs/operations_cleanup_test.go
+++ b/apps/glusterfs/operations_cleanup_test.go
@@ -294,3 +294,105 @@ func TestOperationsCleanupVolumeExpand(t *testing.T) {
 		return nil
 	})
 }
+
+func TestOperationsCleanupBlockVolumeCreate(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	req := &api.BlockVolumeCreateRequest{}
+	req.Size = 1024
+
+	vol := NewBlockVolumeEntryFromRequest(req)
+	vc := NewBlockVolumeCreateOperation(vol, app.db)
+	e := vc.Build()
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	app.db.Update(func(tx *bolt.Tx) error {
+		l, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(l) == 1, "expected len(l) == 1, got:", len(l))
+		e = MarkPendingOperationsStale(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		return nil
+	})
+
+	oc := OperationCleaner{
+		db:       app.db,
+		executor: app.executor,
+		sel:      CleanAll,
+	}
+	e = oc.Clean()
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	app.db.View(func(tx *bolt.Tx) error {
+		l, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(l) == 0, "expected len(l) == 0, got:", len(l))
+		return nil
+	})
+}
+
+func TestOperationsCleanupBlockVolumeDelete(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	req := &api.BlockVolumeCreateRequest{}
+	req.Size = 1024
+
+	vol := NewBlockVolumeEntryFromRequest(req)
+	vc := NewBlockVolumeCreateOperation(vol, app.db)
+	e := RunOperation(vc, app.executor)
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+
+	vdel := NewBlockVolumeDeleteOperation(vol, app.db)
+	e = vdel.Build()
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+
+	app.db.Update(func(tx *bolt.Tx) error {
+		l, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(l) == 1, "expected len(l) == 1, got:", len(l))
+		e = MarkPendingOperationsStale(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		return nil
+	})
+
+	oc := OperationCleaner{
+		db:       app.db,
+		executor: app.executor,
+		sel:      CleanAll,
+	}
+	e = oc.Clean()
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	app.db.View(func(tx *bolt.Tx) error {
+		l, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(l) == 0, "expected len(l) == 0, got:", len(l))
+		return nil
+	})
+}

--- a/apps/glusterfs/operations_cleanup_test.go
+++ b/apps/glusterfs/operations_cleanup_test.go
@@ -62,12 +62,11 @@ func TestBasicOperationsCleanup(t *testing.T) {
 	e = oc.Clean()
 	tests.Assert(t, e == nil, "expected e == nil, got", e)
 
-	// currently no operations are actually cleanable.
-	// we must assert that the operations count is the same as before
+	// assert that pending volume create got cleaned up
 	app.db.View(func(tx *bolt.Tx) error {
 		l, e := PendingOperationList(tx)
 		tests.Assert(t, e == nil, "expected e == nil, got", e)
-		tests.Assert(t, len(l) == 1, "expected len(l) == 1, got:", len(l))
+		tests.Assert(t, len(l) == 0, "expected len(l) == 0, got:", len(l))
 		return nil
 	})
 }

--- a/apps/glusterfs/operations_cleanup_test.go
+++ b/apps/glusterfs/operations_cleanup_test.go
@@ -147,3 +147,80 @@ func TestOperationsCleanupThreeOps(t *testing.T) {
 		return nil
 	})
 }
+
+func TestOperationsCleanupSkipNonLoadable(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// create a dummy volume so there's at least one brick on a device
+	req := &api.VolumeCreateRequest{}
+	req.Size = 1024
+	req.Durability.Type = api.DurabilityReplicate
+	req.Durability.Replicate.Replica = 3
+
+	// create a volume we can delete later
+	vol := NewVolumeEntryFromRequest(req)
+	vc := NewVolumeCreateOperation(vol, app.db)
+	e := RunOperation(vc, app.executor)
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	var deviceId string
+	app.db.Update(func(tx *bolt.Tx) error {
+		l, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(l) == 0, "expected len(l) == 0, got:", len(l))
+		dl, e := DeviceList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(dl) > 1, "expected len(dl) > 1, got:", len(dl))
+		for _, d := range dl {
+			dev, e := NewDeviceEntryFromId(tx, d)
+			tests.Assert(t, e == nil, "expected e == nil, got", e)
+			if len(dev.Bricks) >= 1 {
+				deviceId = d
+			}
+		}
+		tests.Assert(t, deviceId != "")
+		return nil
+	})
+
+	dro := NewDeviceRemoveOperation(deviceId, app.db)
+	e = dro.Build()
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	app.db.Update(func(tx *bolt.Tx) error {
+		l, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(l) == 1, "expected len(l) == 1, got:", len(l))
+		e = MarkPendingOperationsStale(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		return nil
+	})
+
+	oc := OperationCleaner{
+		db:       app.db,
+		executor: app.executor,
+		sel:      CleanAll,
+	}
+	e = oc.Clean()
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	// the non cleanable device remove operation remains
+	app.db.View(func(tx *bolt.Tx) error {
+		l, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(l) == 1, "expected len(l) == 1, got:", len(l))
+		return nil
+	})
+}

--- a/apps/glusterfs/operations_cleanup_test.go
+++ b/apps/glusterfs/operations_cleanup_test.go
@@ -224,3 +224,73 @@ func TestOperationsCleanupSkipNonLoadable(t *testing.T) {
 		return nil
 	})
 }
+
+func TestOperationsCleanupVolumeExpand(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	req := &api.VolumeCreateRequest{}
+	req.Size = 1024
+	req.Durability.Type = api.DurabilityReplicate
+	req.Durability.Replicate.Replica = 3
+
+	// create a volume we can delete later
+	vol := NewVolumeEntryFromRequest(req)
+	vc := NewVolumeCreateOperation(vol, app.db)
+	e := RunOperation(vc, app.executor)
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	app.db.Update(func(tx *bolt.Tx) error {
+		l, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(l) == 0, "expected len(l) == 0, got:", len(l))
+		return nil
+	})
+
+	ve := NewVolumeExpandOperation(vol, app.db, 50)
+	e = ve.Build()
+	tests.Assert(t, e == nil, "expected e == nil, got:", e)
+
+	app.db.Update(func(tx *bolt.Tx) error {
+		po, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(po) == 1, "expected len(po) == 1, got:", len(po))
+		e = MarkPendingOperationsStale(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		return nil
+	})
+
+	oc := OperationCleaner{
+		db:       app.db,
+		executor: app.executor,
+		sel:      CleanAll,
+	}
+	e = oc.Clean()
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	app.db.View(func(tx *bolt.Tx) error {
+		l, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(l) == 0, "expected len(l) == 0, got:", len(l))
+		vl, e := VolumeList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(vl) == 1, "expected len(vl) == 1, got:", len(l))
+		vol, e := NewVolumeEntryFromId(tx, vl[0])
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, vol.Info.Size == 1024,
+			"expected vol.Info.Size == 1024, got:", vol.Info.Size)
+		return nil
+	})
+}

--- a/apps/glusterfs/operations_cleanup_test.go
+++ b/apps/glusterfs/operations_cleanup_test.go
@@ -455,3 +455,77 @@ func TestOperationsCleanupCleanFail(t *testing.T) {
 		return nil
 	})
 }
+
+func TestOperationsCleanupBrokenOp(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	req := &api.VolumeCreateRequest{}
+	req.Size = 1024
+	req.Durability.Type = api.DurabilityReplicate
+	req.Durability.Replicate.Replica = 3
+
+	vol := NewVolumeEntryFromRequest(req)
+	vc := NewVolumeCreateOperation(vol, app.db)
+	e := vc.Build()
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	app.db.Update(func(tx *bolt.Tx) error {
+		l, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(l) == 1, "expected len(l) == 1, got:", len(l))
+		e = MarkPendingOperationsStale(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		// we delete the volume from the db to purposefully
+		// "break" the pending operation load
+		pop, e := NewPendingOperationEntryFromId(tx, l[0])
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		var volId string
+		for _, action := range pop.Actions {
+			if action.Change == OpAddVolume {
+				volId = action.Id
+				break
+			}
+		}
+		tests.Assert(t, volId != "", "expected volId != \"\"")
+		v, e := NewVolumeEntryFromId(tx, volId)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		e = v.Delete(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		return nil
+	})
+
+	app.xo.MockVolumeDestroy = func(host string, volume string) error {
+		return fmt.Errorf("fake error")
+	}
+
+	oc := OperationCleaner{
+		db:       app.db,
+		executor: app.executor,
+		sel:      CleanAll,
+	}
+	e = oc.Clean()
+	// even if an individual clean fails, the overall clean succeeds
+	// unless some really horribly goes wrong
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	// the pending op should remain because the Clean failed
+	app.db.View(func(tx *bolt.Tx) error {
+		l, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(l) == 1, "expected len(l) == 1, got:", len(l))
+		return nil
+	})
+}

--- a/apps/glusterfs/operations_cleanup_test.go
+++ b/apps/glusterfs/operations_cleanup_test.go
@@ -10,6 +10,7 @@
 package glusterfs
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -393,6 +394,64 @@ func TestOperationsCleanupBlockVolumeDelete(t *testing.T) {
 		l, e := PendingOperationList(tx)
 		tests.Assert(t, e == nil, "expected e == nil, got", e)
 		tests.Assert(t, len(l) == 0, "expected len(l) == 0, got:", len(l))
+		return nil
+	})
+}
+
+func TestOperationsCleanupCleanFail(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	req := &api.VolumeCreateRequest{}
+	req.Size = 1024
+	req.Durability.Type = api.DurabilityReplicate
+	req.Durability.Replicate.Replica = 3
+
+	vol := NewVolumeEntryFromRequest(req)
+	vc := NewVolumeCreateOperation(vol, app.db)
+	e := vc.Build()
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	app.db.Update(func(tx *bolt.Tx) error {
+		l, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(l) == 1, "expected len(l) == 1, got:", len(l))
+		e = MarkPendingOperationsStale(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		return nil
+	})
+
+	app.xo.MockVolumeDestroy = func(host string, volume string) error {
+		return fmt.Errorf("fake error")
+	}
+
+	oc := OperationCleaner{
+		db:       app.db,
+		executor: app.executor,
+		sel:      CleanAll,
+	}
+	e = oc.Clean()
+	// even if an individual clean fails, the overall clean succeeds
+	// unless some really horribly goes wrong
+	tests.Assert(t, e == nil, "expected e == nil, got", e)
+
+	// the pending op should remain because the Clean failed
+	app.db.View(func(tx *bolt.Tx) error {
+		l, e := PendingOperationList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(l) == 1, "expected len(l) == 1, got:", len(l))
 		return nil
 	})
 }

--- a/apps/glusterfs/operations_load.go
+++ b/apps/glusterfs/operations_load.go
@@ -41,6 +41,8 @@ func LoadOperation(
 	switch p.Type {
 	case OperationCreateVolume:
 		op, err = loadVolumeCreateOperation(db, p)
+	case OperationDeleteVolume:
+		op, err = loadVolumeDeleteOperation(db, p)
 	default:
 		err = NewErrNotLoadable(p.Id, p.Type)
 	}

--- a/apps/glusterfs/operations_load.go
+++ b/apps/glusterfs/operations_load.go
@@ -45,6 +45,8 @@ func LoadOperation(
 		op, err = loadVolumeDeleteOperation(db, p)
 	case OperationExpandVolume:
 		op, err = loadVolumeExpandOperation(db, p)
+	case OperationCreateBlockVolume:
+		op, err = loadBlockVolumeCreateOperation(db, p)
 	default:
 		err = NewErrNotLoadable(p.Id, p.Type)
 	}

--- a/apps/glusterfs/operations_load.go
+++ b/apps/glusterfs/operations_load.go
@@ -39,14 +39,18 @@ func LoadOperation(
 		err error
 	)
 	switch p.Type {
+	// file volume operations
 	case OperationCreateVolume:
 		op, err = loadVolumeCreateOperation(db, p)
 	case OperationDeleteVolume:
 		op, err = loadVolumeDeleteOperation(db, p)
 	case OperationExpandVolume:
 		op, err = loadVolumeExpandOperation(db, p)
+	// block volume operations
 	case OperationCreateBlockVolume:
 		op, err = loadBlockVolumeCreateOperation(db, p)
+	case OperationDeleteBlockVolume:
+		op, err = loadBlockVolumeDeleteOperation(db, p)
 	default:
 		err = NewErrNotLoadable(p.Id, p.Type)
 	}

--- a/apps/glusterfs/operations_load.go
+++ b/apps/glusterfs/operations_load.go
@@ -43,6 +43,8 @@ func LoadOperation(
 		op, err = loadVolumeCreateOperation(db, p)
 	case OperationDeleteVolume:
 		op, err = loadVolumeDeleteOperation(db, p)
+	case OperationExpandVolume:
+		op, err = loadVolumeExpandOperation(db, p)
 	default:
 		err = NewErrNotLoadable(p.Id, p.Type)
 	}

--- a/apps/glusterfs/operations_load_test.go
+++ b/apps/glusterfs/operations_load_test.go
@@ -1,0 +1,155 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/heketi/tests"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+)
+
+func TestLoadOperation(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		2,    // clusters
+		3,    // nodes_per_cluster
+		4,    // devices_per_node,
+		6*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	t.Run("invalidOp", func(t *testing.T) {
+		p := NewPendingOperationEntry("invalid")
+		_, e := LoadOperation(app.db, p)
+		tests.Assert(t, e != nil, "expected e != nil, got:", e)
+		_, ok := e.(ErrNotLoadable)
+		tests.Assert(t, ok, "expected e to be NewErrNotLoadable")
+		tests.Assert(t, strings.Contains(e.Error(), "invalid"),
+			`expected strings.Contains(e.Error(), "invalid"), got:`,
+			e.Error())
+	})
+	t.Run("volume create", func(t *testing.T) {
+		req := &api.VolumeCreateRequest{}
+		req.Size = 1024
+		req.Durability.Type = api.DurabilityReplicate
+		req.Durability.Replicate.Replica = 3
+		vol := NewVolumeEntryFromRequest(req)
+		vc := NewVolumeCreateOperation(vol, app.db)
+		e := vc.Build()
+		tests.Assert(t, e == nil, "expected e == nil, got:", e)
+		o, e := LoadOperation(app.db, vc.op)
+		tests.Assert(t, e == nil, "expected e == nil, got:", e)
+		vc2, ok := o.(*VolumeCreateOperation)
+		tests.Assert(t, ok, "expected e to be VolumeCreateOperation")
+		tests.Assert(t, vc2.op.Id == vc.op.Id,
+			"expected vc2.op.Id == vc.op.Id, got:", vc2.op.Id, vc.op.Id)
+		tests.Assert(t, vc2.vol.Info.Id == vc.vol.Info.Id,
+			"expected vc2.vol.Info.Id == vc.vol.Info.Id")
+		tests.Assert(t, vc2.vol != vc.vol,
+			"expected vc2.vol != vc.vol")
+	})
+	t.Run("volume delete", func(t *testing.T) {
+		req := &api.VolumeCreateRequest{}
+		req.Size = 1024
+		req.Durability.Type = api.DurabilityReplicate
+		req.Durability.Replicate.Replica = 3
+		vol := NewVolumeEntryFromRequest(req)
+		vc := NewVolumeCreateOperation(vol, app.db)
+		e := RunOperation(vc, app.executor)
+		tests.Assert(t, e == nil, "expected e == nil, got:", e)
+		vdel := NewVolumeDeleteOperation(vol, app.db)
+		e = vdel.Build()
+		tests.Assert(t, e == nil, "expected e == nil, got:", e)
+		o, e := LoadOperation(app.db, vdel.op)
+		tests.Assert(t, e == nil, "expected e == nil, got:", e)
+		vdel2, ok := o.(*VolumeDeleteOperation)
+		tests.Assert(t, ok, "expected e to be VolumeDeleteOperation")
+		tests.Assert(t, vdel2.op.Id == vdel.op.Id,
+			"expected vdel2.op.Id == vdel.op.Id, got", vdel2.op.Id, vdel2.op.Id)
+		tests.Assert(t, vol.Info.Id == vdel2.vol.Info.Id,
+			"expected vol.Info.Id == vdel2.vol.Info.Id")
+		tests.Assert(t, vdel2.vol != vdel.vol,
+			"expected vdel2.vol != vdel.vol")
+	})
+	t.Run("volume expand", func(t *testing.T) {
+		req := &api.VolumeCreateRequest{}
+		req.Size = 1024
+		req.Durability.Type = api.DurabilityReplicate
+		req.Durability.Replicate.Replica = 3
+		vol := NewVolumeEntryFromRequest(req)
+		vc := NewVolumeCreateOperation(vol, app.db)
+		e := RunOperation(vc, app.executor)
+		tests.Assert(t, e == nil, "expected e == nil, got:", e)
+		ve := NewVolumeExpandOperation(vol, app.db, 6)
+		e = ve.Build()
+		tests.Assert(t, e == nil, "expected e == nil, got:", e)
+		o, e := LoadOperation(app.db, ve.op)
+		tests.Assert(t, e == nil, "expected e == nil, got:", e)
+		ve2, ok := o.(*VolumeExpandOperation)
+		tests.Assert(t, ok, "expected e to be VolumExpandOperation")
+		tests.Assert(t, ve2.op.Id == ve.op.Id,
+			"expected ve2.op.Id == ve.op.Id, got", ve2.op.Id, ve2.op.Id)
+		tests.Assert(t, vol.Info.Id == ve2.vol.Info.Id,
+			"expected vol.Info.Id == ve2.vol.Info.Id")
+		tests.Assert(t, ve2.vol != ve.vol,
+			"expected ve2.vol != ve.vol")
+	})
+	t.Run("block volume create", func(t *testing.T) {
+		req := &api.BlockVolumeCreateRequest{}
+		req.Size = 1024
+		vol := NewBlockVolumeEntryFromRequest(req)
+		vc := NewBlockVolumeCreateOperation(vol, app.db)
+		e := vc.Build()
+		// need to roll back the bhv create in order to test other ops later
+		defer vc.Rollback(app.executor)
+		tests.Assert(t, e == nil, "expected e == nil, got:", e)
+		o, e := LoadOperation(app.db, vc.op)
+		tests.Assert(t, e == nil, "expected e == nil, got:", e)
+		vc2, ok := o.(*BlockVolumeCreateOperation)
+		tests.Assert(t, ok, "expected e to be BlockVolumeCreateOperation")
+		tests.Assert(t, vc2.op.Id == vc.op.Id,
+			"expected vc2.op.Id == vc.op.Id, got:", vc2.op.Id, vc.op.Id)
+		tests.Assert(t, vc2.bvol.Info.Id == vc.bvol.Info.Id,
+			"expected vc2.vol.Info.Id == vc.vol.Info.Id")
+		tests.Assert(t, vc2.bvol != vc.bvol,
+			"expected vc2.vol != vc.vol")
+	})
+	t.Run("block volume delete", func(t *testing.T) {
+		req := &api.BlockVolumeCreateRequest{}
+		req.Size = 1024
+		vol := NewBlockVolumeEntryFromRequest(req)
+		vc := NewBlockVolumeCreateOperation(vol, app.db)
+		e := RunOperation(vc, app.executor)
+		tests.Assert(t, e == nil, "expected e == nil, got:", e)
+		vdel := NewBlockVolumeDeleteOperation(vol, app.db)
+		e = vdel.Build()
+		tests.Assert(t, e == nil, "expected e == nil, got:", e)
+		o, e := LoadOperation(app.db, vdel.op)
+		tests.Assert(t, e == nil, "expected e == nil, got:", e)
+		vdel2, ok := o.(*BlockVolumeDeleteOperation)
+		tests.Assert(t, ok, "expected e to be BlockVolumeDeleteOperation")
+		tests.Assert(t, vdel2.op.Id == vdel.op.Id,
+			"expected vdel2.op.Id == vdel.op.Id, got", vdel2.op.Id, vdel2.op.Id)
+		tests.Assert(t, vol.Info.Id == vdel2.bvol.Info.Id,
+			"expected vol.Info.Id == vdel2.vol.Info.Id")
+		tests.Assert(t, vdel2.bvol != vdel.bvol,
+			"expected vdel2.vol != vdel.vol")
+	})
+}

--- a/apps/glusterfs/operations_manage.go
+++ b/apps/glusterfs/operations_manage.go
@@ -208,6 +208,26 @@ func RunOperation(o Operation,
 	return nil
 }
 
+// rollbackViaClean runs a CleanableOperation's clean methods as
+// needed to perform operation rollback. Any operation that
+// implements clean methods ought to be able to use
+// rollbackViaClean as the core of its rollback action.
+func rollbackViaClean(o CleanableOperation, executor executors.Executor) error {
+	if err := o.Clean(executor); err != nil {
+		logger.LogError(
+			"error running Clean in rollback for %v: %v",
+			o.Label(), err)
+		return err
+	}
+	if err := o.CleanDone(); err != nil {
+		logger.LogError(
+			"error running CleanDone in rollback for %v: %v",
+			o.Label(), err)
+		return err
+	}
+	return nil
+}
+
 func retryOperation(o Operation,
 	executor executors.Executor) (err error) {
 

--- a/apps/glusterfs/operations_volume.go
+++ b/apps/glusterfs/operations_volume.go
@@ -195,6 +195,30 @@ func NewVolumeExpandOperation(
 	}
 }
 
+// loadVolumeExpandOperation returns a VolumeExpandOperation populated
+// from an existing pending operation entry in the db.
+func loadVolumeExpandOperation(
+	db wdb.DB, p *PendingOperationEntry) (*VolumeExpandOperation, error) {
+
+	vols, err := volumesFromOp(db, p)
+	if err != nil {
+		return nil, err
+	}
+	if len(vols) != 1 {
+		return nil, fmt.Errorf(
+			"Incorrect number of volumes (%v) for create operation: %v",
+			len(vols), p.Id)
+	}
+
+	return &VolumeExpandOperation{
+		OperationManager: OperationManager{
+			db: db,
+			op: p,
+		},
+		vol: vols[0],
+	}, nil
+}
+
 func (ve *VolumeExpandOperation) Label() string {
 	return "Expand Volume"
 }

--- a/apps/glusterfs/operations_volume.go
+++ b/apps/glusterfs/operations_volume.go
@@ -317,6 +317,30 @@ func NewVolumeDeleteOperation(
 	}
 }
 
+// loadVolumeDeleteOperation returns a VolumeDeleteOperation populated
+// from an existing pending operation entry in the db.
+func loadVolumeDeleteOperation(
+	db wdb.DB, p *PendingOperationEntry) (*VolumeDeleteOperation, error) {
+
+	vols, err := volumesFromOp(db, p)
+	if err != nil {
+		return nil, err
+	}
+	if len(vols) != 1 {
+		return nil, fmt.Errorf(
+			"Incorrect number of volumes (%v) for delete operation: %v",
+			len(vols), p.Id)
+	}
+
+	return &VolumeDeleteOperation{
+		OperationManager: OperationManager{
+			db: db,
+			op: p,
+		},
+		vol: vols[0],
+	}, nil
+}
+
 func (vdel *VolumeDeleteOperation) Label() string {
 	return "Delete Volume"
 }

--- a/apps/glusterfs/try_on_host.go
+++ b/apps/glusterfs/try_on_host.go
@@ -26,6 +26,17 @@ func newTryOnHosts(hosts nodeHosts) *tryOnHosts {
 	return &tryOnHosts{Hosts: hosts}
 }
 
+// once returns a tryOnHosts that only tries one host known
+// to be up.
+func (c *tryOnHosts) once() *tryOnHosts {
+	return &tryOnHosts{
+		Hosts: c.Hosts,
+		done: func(err error) bool {
+			return true
+		},
+	}
+}
+
 func (c *tryOnHosts) run(f func(host string) error) error {
 	// if a custom done is not provided only stop
 	// if err == nil

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -476,9 +476,8 @@ func (v *VolumeEntry) tryAllocateBricks(
 	return
 }
 
-func (v *VolumeEntry) cleanupCreateVolume(db wdb.DB,
-	executor executors.Executor,
-	brick_entries []*BrickEntry) error {
+func (v *VolumeEntry) destroyGlusterVolume(
+	db wdb.RODB, executor executors.Executor) error {
 
 	hosts, err := v.hosts(db)
 	if err != nil {
@@ -502,6 +501,16 @@ func (v *VolumeEntry) cleanupCreateVolume(db wdb.DB,
 	if err != nil {
 		logger.LogError("failed to delete volume in cleanup: %v", err)
 		return fmt.Errorf("failed to clean up volume: %v", v.Info.Id)
+	}
+	return nil
+}
+
+func (v *VolumeEntry) cleanupCreateVolume(db wdb.DB,
+	executor executors.Executor,
+	brick_entries []*BrickEntry) error {
+
+	if err := v.destroyGlusterVolume(db, executor); err != nil {
+		return err
 	}
 
 	// from a quick read its "safe" to unconditionally try to delete

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -888,7 +888,7 @@ func eligibleClusters(db wdb.RODB, req ClusterReq,
 // volume's cluster. These hosts can be used as destinations
 // for gluster commands.
 func (v *VolumeEntry) hosts(db wdb.RODB) (nodeHosts, error) {
-	hosts := nodeHosts{}
+	var hosts nodeHosts
 	err := db.View(func(tx *bolt.Tx) error {
 		vol, err := NewVolumeEntryFromId(tx, v.Info.Id)
 		if err != nil {
@@ -899,16 +899,8 @@ func (v *VolumeEntry) hosts(db wdb.RODB) (nodeHosts, error) {
 		if err != nil {
 			return err
 		}
-
-		for _, nodeId := range cluster.Info.Nodes {
-			node, err := NewNodeEntryFromId(tx, nodeId)
-			if err != nil {
-				return err
-			}
-			hosts[nodeId] = node.ManageHostName()
-		}
-
-		return nil
+		hosts, err = cluster.hosts(wdb.WrapTx(tx))
+		return err
 	})
 	return hosts, err
 }

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -757,27 +757,6 @@ func (v *VolumeEntry) expandVolumeComponents(db wdb.DB,
 	return
 }
 
-func (v *VolumeEntry) cleanupExpandVolume(db wdb.DB,
-	executor executors.Executor,
-	brick_entries []*BrickEntry,
-	origSize int) (e error) {
-
-	logger.Debug("Error detected, cleaning up")
-	DestroyBricks(db, executor, brick_entries)
-
-	// Remove from db
-	return db.Update(func(tx *bolt.Tx) error {
-		for _, brick := range brick_entries {
-			brick.remove(tx, v)
-		}
-		v.Info.Size = origSize
-		err := v.Save(tx)
-		godbc.Check(err == nil)
-
-		return nil
-	})
-}
-
 func (v *VolumeEntry) expandVolumeExec(db wdb.DB,
 	executor executors.Executor,
 	brick_entries []*BrickEntry) (e error) {

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -663,7 +663,7 @@ func (v *VolumeEntry) teardown(
 
 	return db.Update(func(tx *bolt.Tx) error {
 		for _, brick := range brick_entries {
-			err := v.removeBrickFromDb(tx, brick)
+			err := brick.remove(tx, v)
 			if err != nil {
 				return err
 			}
@@ -784,7 +784,7 @@ func (v *VolumeEntry) cleanupExpandVolume(db wdb.DB,
 	// Remove from db
 	return db.Update(func(tx *bolt.Tx) error {
 		for _, brick := range brick_entries {
-			v.removeBrickFromDb(tx, brick)
+			brick.remove(tx, v)
 		}
 		v.Info.Size = origSize
 		err := v.Save(tx)

--- a/main.go
+++ b/main.go
@@ -72,6 +72,12 @@ var dbCmd = &cobra.Command{
 	Long:  "heketi db management",
 }
 
+var offlineCmd = &cobra.Command{
+	Use:   "offline",
+	Short: "perform offline operations",
+	Long:  "perform offline operations",
+}
+
 var importdbCmd = &cobra.Command{
 	Use:     "import",
 	Short:   "import creates a db file from JSON input",
@@ -204,6 +210,43 @@ var deletePendingEntriesCmd = &cobra.Command{
 	},
 }
 
+var cleanupOperationsCmd = &cobra.Command{
+	Use:     "cleanup-operations",
+	Short:   "clean up all pending operations stored in heketi db",
+	Long:    "clean up all pending operations stored in heketi db",
+	Example: "heketi offline cleanup-operations --config=heketi.json",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Fprintf(os.Stdout, "OFFLINE COMMAND: Clean All Pending Operations\n")
+		if configfile == "" {
+			fmt.Fprintf(os.Stderr, "Configuration file is required\n")
+			os.Exit(1)
+		}
+
+		// Read configuration
+		c, err := config.ReadConfig(configfile)
+		if err != nil {
+			os.Exit(1)
+		}
+
+		randSeed()
+		// always start if stale ops in the db
+		c.GlusterFS.IgnoreStaleOperations = true
+		// option to not start the background node monitor?
+		// FIXME, this is a hacky way to disable this background activity
+		//os.Setenv("HEKETI_DISABLE_HEALTH_MONITOR", "true")
+		app := setupApp(c)
+
+		// run the operation cleanup in the foreground (offline mode)
+		fmt.Fprintf(os.Stderr, "Starting clean now...\n")
+		err = app.OfflineCleaner().Clean()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error cleaning operations: %v\n", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	},
+}
+
 func init() {
 	RootCmd.Flags().StringVar(&configfile, "config", "", "Configuration file")
 	RootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "Show version")
@@ -239,6 +282,13 @@ func init() {
 	deletePendingEntriesCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show actions that would be performed but don't perform them")
 	deletePendingEntriesCmd.Flags().BoolVar(&force, "force", false, "Clean entries even if they don't have an owner Pending Operation, incompatible with dry-run")
 	deletePendingEntriesCmd.SilenceUsage = true
+
+	RootCmd.AddCommand(offlineCmd)
+	offlineCmd.SilenceUsage = true
+
+	offlineCmd.AddCommand(cleanupOperationsCmd)
+	cleanupOperationsCmd.SilenceUsage = true
+	cleanupOperationsCmd.Flags().StringVar(&configfile, "config", "", "Configuration file")
 }
 
 func setWithEnvVariables(options *config.Config) {


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

This PR implements a good chunk of the code needed to actually make operations cleanable. This is where the bulk of the refactorings to app/glusterfs lie as far as operations are concerned. The general gist is that you'll see:
* Various refactorings to make clean up code reasonable: including splitting out db access from executor stuff
* Making various operations loadable
* Making various operations cleanable
* Unit tests for the above
* An offline mode for cleaning: `heketi offline cleanup-operations ...` which can be run when heketi server is not running.

The latter is mainly included in this PR (as opposed to a latter PR) as a demonstration of things end-to-end.

Does this seem like a lot? There's more to come!


### Does this PR fix issues?

Part of issue #1401


### Notes for the reviewer

This looks like a lot of commits but hopefully these are small and reviewable commits that won't make your brain explode. :-)

This PR builds on top of PR #1445 please review and merge that series first.


