### PR TITLE
Add a configurable timeout to gluster cli, defaulting to 10 minutes

### DIFF
--- a/etc/heketi.json
+++ b/etc/heketi.json
@@ -49,7 +49,8 @@
       "user": "sshuser",
       "port": "Optional: ssh port.  Default is 22",
       "fstab": "Optional: Specify fstab file on node.  Default is /etc/fstab",
-      "backup_lvm_metadata": false
+      "backup_lvm_metadata": false,
+      "gluster_cli_timeout": "Optional: Timeout, in seconds, passed to the gluster cli invocations"
     },
 
     "_kubeexec_comment": "Kubernetes configuration",
@@ -61,7 +62,8 @@
       "password": "password for kubernetes user",
       "namespace": "OpenShift project or Kubernetes namespace",
       "fstab": "Optional: Specify fstab file on node.  Default is /etc/fstab",
-      "backup_lvm_metadata": false
+      "backup_lvm_metadata": false,
+      "gluster_cli_timeout": "Optional: Timeout, in seconds, passed to the gluster cli invocations"
     },
 
     "_db_comment": "Database file name",

--- a/executors/cmdexec/cmdexec.go
+++ b/executors/cmdexec/cmdexec.go
@@ -35,6 +35,10 @@ type CmdExecutor struct {
 	BackupLVM      bool
 }
 
+func (c *CmdExecutor) Init(config *CmdConfig) {
+	c.Throttlemap = make(map[string]chan bool)
+}
+
 func (s *CmdExecutor) AccessConnection(host string) {
 	var (
 		c  chan bool

--- a/executors/cmdexec/cmdexec.go
+++ b/executors/cmdexec/cmdexec.go
@@ -36,9 +36,14 @@ type CmdExecutor struct {
 	BackupLVM      bool
 }
 
+func setWithEnvVariables(config *CmdConfig) {
+}
+
 func (c *CmdExecutor) Init(config *CmdConfig) {
 	c.Throttlemap = make(map[string]chan bool)
 	c.config = config
+
+	setWithEnvVariables(config)
 }
 
 func (s *CmdExecutor) AccessConnection(host string) {

--- a/executors/cmdexec/cmdexec.go
+++ b/executors/cmdexec/cmdexec.go
@@ -10,6 +10,7 @@
 package cmdexec
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"sync"
@@ -40,7 +41,7 @@ type CmdExecutor struct {
 }
 
 func (c *CmdExecutor) glusterCommand() string {
-	return "gluster --mode=script"
+	return fmt.Sprintf("gluster --mode=script --timeout=%v", c.GlusterCliTimeout())
 }
 
 func setWithEnvVariables(config *CmdConfig) {

--- a/executors/cmdexec/cmdexec.go
+++ b/executors/cmdexec/cmdexec.go
@@ -36,6 +36,10 @@ type CmdExecutor struct {
 	BackupLVM      bool
 }
 
+func (c *CmdExecutor) glusterCommand() string {
+	return "gluster --mode=script"
+}
+
 func setWithEnvVariables(config *CmdConfig) {
 }
 

--- a/executors/cmdexec/cmdexec.go
+++ b/executors/cmdexec/cmdexec.go
@@ -120,3 +120,17 @@ func (c *CmdExecutor) GlusterCliTimeout() uint32 {
 
 	return c.config.GlusterCliTimeout
 }
+
+// The timeout, in minutes, for the command execution.
+// It used to be 10 minutes (or sometimes 5, for some simple commands),
+// but now it needs to be longer than the gluster cli timeout at
+// least where calling the gluster cli.
+func (c *CmdExecutor) GlusterCliExecTimeout() int {
+	timeout := 1 + (int(c.GlusterCliTimeout())+1)/60
+
+	if timeout < 10 {
+		timeout = 10
+	}
+
+	return timeout
+}

--- a/executors/cmdexec/cmdexec.go
+++ b/executors/cmdexec/cmdexec.go
@@ -27,6 +27,7 @@ type RemoteCommandTransport interface {
 }
 
 type CmdExecutor struct {
+	config      *CmdConfig
 	Throttlemap map[string]chan bool
 	Lock        sync.Mutex
 
@@ -37,6 +38,7 @@ type CmdExecutor struct {
 
 func (c *CmdExecutor) Init(config *CmdConfig) {
 	c.Throttlemap = make(map[string]chan bool)
+	c.config = config
 }
 
 func (s *CmdExecutor) AccessConnection(host string) {

--- a/executors/cmdexec/config.go
+++ b/executors/cmdexec/config.go
@@ -15,4 +15,5 @@ type CmdConfig struct {
 	SnapShotLimit        int    `json:"snapshot_limit"`
 	RebalanceOnExpansion bool   `json:"rebalance_on_expansion"`
 	BackupLVM            bool   `json:"backup_lvm_metadata"`
+	GlusterCliTimeout    uint32 `json:"gluster_cli_timeout"`
 }

--- a/executors/cmdexec/fakeexec_test.go
+++ b/executors/cmdexec/fakeexec_test.go
@@ -43,6 +43,7 @@ func NewFakeExecutor(f *CommandFaker) (*FakeExecutor, error) {
 	t := &FakeExecutor{}
 	t.RemoteExecutor = t
 	config := &CmdConfig{}
+	config.GlusterCliTimeout = 42
 	t.CmdExecutor.Init(config)
 	t.fake = f
 	t.Fstab = "/my/fstab"

--- a/executors/cmdexec/fakeexec_test.go
+++ b/executors/cmdexec/fakeexec_test.go
@@ -42,7 +42,8 @@ type FakeExecutor struct {
 func NewFakeExecutor(f *CommandFaker) (*FakeExecutor, error) {
 	t := &FakeExecutor{}
 	t.RemoteExecutor = t
-	t.Throttlemap = make(map[string]chan bool)
+	config := &CmdConfig{}
+	t.CmdExecutor.Init(config)
 	t.fake = f
 	t.Fstab = "/my/fstab"
 	t.portStr = "22"

--- a/executors/cmdexec/peer.go
+++ b/executors/cmdexec/peer.go
@@ -28,7 +28,8 @@ func (s *CmdExecutor) PeerProbe(host, newnode string) error {
 	commands := []string{
 		fmt.Sprintf("%v peer probe %v", s.glusterCommand(), newnode),
 	}
-	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 10))
+	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands,
+		s.GlusterCliExecTimeout()))
 	if err != nil {
 		return err
 	}
@@ -40,7 +41,8 @@ func (s *CmdExecutor) PeerProbe(host, newnode string) error {
 			fmt.Sprintf("%v snapshot config snap-max-hard-limit %v",
 				s.glusterCommand(), s.RemoteExecutor.SnapShotLimit()),
 		}
-		err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 10))
+		err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands,
+			s.GlusterCliExecTimeout()))
 		if err != nil {
 			return err
 		}
@@ -58,7 +60,8 @@ func (s *CmdExecutor) PeerDetach(host, detachnode string) error {
 	commands := []string{
 		fmt.Sprintf("%v peer detach %v", s.glusterCommand(), detachnode),
 	}
-	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 10))
+	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands,
+		s.GlusterCliExecTimeout()))
 	if err != nil {
 		logger.Err(err)
 	}

--- a/executors/cmdexec/peer.go
+++ b/executors/cmdexec/peer.go
@@ -26,7 +26,7 @@ func (s *CmdExecutor) PeerProbe(host, newnode string) error {
 	logger.Info("Probing: %v -> %v", host, newnode)
 	// create the commands
 	commands := []string{
-		fmt.Sprintf("gluster peer probe %v", newnode),
+		fmt.Sprintf("gluster --mode=script peer probe %v", newnode),
 	}
 	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 10))
 	if err != nil {
@@ -56,7 +56,7 @@ func (s *CmdExecutor) PeerDetach(host, detachnode string) error {
 	// create the commands
 	logger.Info("Detaching node %v", detachnode)
 	commands := []string{
-		fmt.Sprintf("gluster peer detach %v", detachnode),
+		fmt.Sprintf("gluster --mode=script peer detach %v", detachnode),
 	}
 	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 10))
 	if err != nil {

--- a/executors/cmdexec/peer.go
+++ b/executors/cmdexec/peer.go
@@ -26,7 +26,7 @@ func (s *CmdExecutor) PeerProbe(host, newnode string) error {
 	logger.Info("Probing: %v -> %v", host, newnode)
 	// create the commands
 	commands := []string{
-		fmt.Sprintf("gluster --mode=script peer probe %v", newnode),
+		fmt.Sprintf("%v peer probe %v", s.glusterCommand(), newnode),
 	}
 	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 10))
 	if err != nil {
@@ -37,8 +37,8 @@ func (s *CmdExecutor) PeerProbe(host, newnode string) error {
 	if s.RemoteExecutor.SnapShotLimit() > 0 {
 		logger.Info("Setting snapshot limit")
 		commands = []string{
-			fmt.Sprintf("gluster --mode=script snapshot config snap-max-hard-limit %v",
-				s.RemoteExecutor.SnapShotLimit()),
+			fmt.Sprintf("%v snapshot config snap-max-hard-limit %v",
+				s.glusterCommand(), s.RemoteExecutor.SnapShotLimit()),
 		}
 		err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 10))
 		if err != nil {
@@ -56,7 +56,7 @@ func (s *CmdExecutor) PeerDetach(host, detachnode string) error {
 	// create the commands
 	logger.Info("Detaching node %v", detachnode)
 	commands := []string{
-		fmt.Sprintf("gluster --mode=script peer detach %v", detachnode),
+		fmt.Sprintf("%v peer detach %v", s.glusterCommand(), detachnode),
 	}
 	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 10))
 	if err != nil {

--- a/executors/cmdexec/peer_test.go
+++ b/executors/cmdexec/peer_test.go
@@ -30,7 +30,7 @@ func TestSshExecPeerProbe(t *testing.T) {
 
 		tests.Assert(t, host == "host:22", host)
 		tests.Assert(t, len(commands) == 1)
-		tests.Assert(t, commands[0] == "gluster peer probe newnode", commands)
+		tests.Assert(t, commands[0] == "gluster --mode=script peer probe newnode", commands)
 
 		return nil, nil
 	}
@@ -56,7 +56,7 @@ func TestSshExecPeerProbe(t *testing.T) {
 		case 0:
 			tests.Assert(t, host == "host:22", host)
 			tests.Assert(t, len(commands) == 1)
-			tests.Assert(t, commands[0] == "gluster peer probe newnode", commands)
+			tests.Assert(t, commands[0] == "gluster --mode=script peer probe newnode", commands)
 
 		case 1:
 			tests.Assert(t, host == "host:22", host)

--- a/executors/cmdexec/peer_test.go
+++ b/executors/cmdexec/peer_test.go
@@ -30,7 +30,7 @@ func TestSshExecPeerProbe(t *testing.T) {
 
 		tests.Assert(t, host == "host:22", host)
 		tests.Assert(t, len(commands) == 1)
-		tests.Assert(t, commands[0] == "gluster --mode=script peer probe newnode", commands)
+		tests.Assert(t, commands[0] == "gluster --mode=script --timeout=42 peer probe newnode", commands)
 
 		return nil, nil
 	}
@@ -56,12 +56,12 @@ func TestSshExecPeerProbe(t *testing.T) {
 		case 0:
 			tests.Assert(t, host == "host:22", host)
 			tests.Assert(t, len(commands) == 1)
-			tests.Assert(t, commands[0] == "gluster --mode=script peer probe newnode", commands)
+			tests.Assert(t, commands[0] == "gluster --mode=script --timeout=42 peer probe newnode", commands)
 
 		case 1:
 			tests.Assert(t, host == "host:22", host)
 			tests.Assert(t, len(commands) == 1)
-			tests.Assert(t, commands[0] == "gluster --mode=script snapshot config snap-max-hard-limit 14", commands)
+			tests.Assert(t, commands[0] == "gluster --mode=script --timeout=42 snapshot config snap-max-hard-limit 14", commands)
 
 		default:
 			tests.Assert(t, false, "Should not be reached")

--- a/executors/cmdexec/snapshot.go
+++ b/executors/cmdexec/snapshot.go
@@ -31,7 +31,7 @@ func (s *CmdExecutor) snapshotActivate(host string, snapshot string) error {
 	}
 
 	command := []string{
-		fmt.Sprintf("gluster --mode=script --xml snapshot activate %v", snapshot),
+		fmt.Sprintf("%v --xml snapshot activate %v", s.glusterCommand(), snapshot),
 	}
 
 	results, err := s.RemoteExecutor.ExecCommands(host, command, 10)
@@ -64,7 +64,7 @@ func (s *CmdExecutor) snapshotDeactivate(host string, snapshot string) error {
 	}
 
 	command := []string{
-		fmt.Sprintf("gluster --mode=script --xml snapshot deactivate %v", snapshot),
+		fmt.Sprintf("%v --xml snapshot deactivate %v", s.glusterCommand(), snapshot),
 	}
 
 	results, err := s.RemoteExecutor.ExecCommands(host, command, 10)
@@ -106,7 +106,7 @@ func (s *CmdExecutor) SnapshotCloneVolume(host string, vcr *executors.SnapshotCl
 	}
 
 	command := []string{
-		fmt.Sprintf("gluster --mode=script --xml snapshot clone %v %v", vcr.Volume, vcr.Snapshot),
+		fmt.Sprintf("%v --xml snapshot clone %v %v", s.glusterCommand(), vcr.Volume, vcr.Snapshot),
 	}
 
 	results, err := s.RemoteExecutor.ExecCommands(host, command, 10)
@@ -126,7 +126,7 @@ func (s *CmdExecutor) SnapshotCloneVolume(host string, vcr *executors.SnapshotCl
 
 	// start the newly cloned volume
 	command = []string{
-		fmt.Sprintf("gluster --mode=script --xml volume start %v", vcr.Volume),
+		fmt.Sprintf("%v --xml volume start %v", s.glusterCommand(), vcr.Volume),
 	}
 
 	err = rex.AnyError(s.RemoteExecutor.ExecCommands(host, command, 10))
@@ -155,7 +155,7 @@ func (s *CmdExecutor) SnapshotDestroy(host string, snapshot string) error {
 	}
 
 	command := []string{
-		fmt.Sprintf("gluster --mode=script --xml snapshot delete %v", snapshot),
+		fmt.Sprintf("%v --xml snapshot delete %v", s.glusterCommand(), snapshot),
 	}
 
 	results, err := s.RemoteExecutor.ExecCommands(host, command, 10)

--- a/executors/cmdexec/snapshot.go
+++ b/executors/cmdexec/snapshot.go
@@ -34,7 +34,8 @@ func (s *CmdExecutor) snapshotActivate(host string, snapshot string) error {
 		fmt.Sprintf("%v --xml snapshot activate %v", s.glusterCommand(), snapshot),
 	}
 
-	results, err := s.RemoteExecutor.ExecCommands(host, command, 10)
+	results, err := s.RemoteExecutor.ExecCommands(host, command,
+		s.GlusterCliExecTimeout())
 	if err := rex.AnyError(results, err); err != nil {
 		return fmt.Errorf("Unable to activate snapshot %v: %v", snapshot, err)
 	}
@@ -67,7 +68,8 @@ func (s *CmdExecutor) snapshotDeactivate(host string, snapshot string) error {
 		fmt.Sprintf("%v --xml snapshot deactivate %v", s.glusterCommand(), snapshot),
 	}
 
-	results, err := s.RemoteExecutor.ExecCommands(host, command, 10)
+	results, err := s.RemoteExecutor.ExecCommands(host, command,
+		s.GlusterCliExecTimeout())
 	if err := rex.AnyError(results, err); err != nil {
 		return fmt.Errorf("Unable to deactivate snapshot %v: %v", snapshot, err)
 	}
@@ -109,7 +111,8 @@ func (s *CmdExecutor) SnapshotCloneVolume(host string, vcr *executors.SnapshotCl
 		fmt.Sprintf("%v --xml snapshot clone %v %v", s.glusterCommand(), vcr.Volume, vcr.Snapshot),
 	}
 
-	results, err := s.RemoteExecutor.ExecCommands(host, command, 10)
+	results, err := s.RemoteExecutor.ExecCommands(host, command,
+		s.GlusterCliExecTimeout())
 	if err := rex.AnyError(results, err); err != nil {
 		return nil, fmt.Errorf("Unable to clone snapshot %v: %v", vcr.Snapshot, err)
 	}
@@ -129,7 +132,8 @@ func (s *CmdExecutor) SnapshotCloneVolume(host string, vcr *executors.SnapshotCl
 		fmt.Sprintf("%v --xml volume start %v", s.glusterCommand(), vcr.Volume),
 	}
 
-	err = rex.AnyError(s.RemoteExecutor.ExecCommands(host, command, 10))
+	err = rex.AnyError(s.RemoteExecutor.ExecCommands(host, command,
+		s.GlusterCliExecTimeout()))
 	if err != nil {
 		s.VolumeDestroy(host, vcr.Volume)
 		return nil, fmt.Errorf("Unable to start volume %v, clone of snapshot %v: %v", vcr.Volume, vcr.Snapshot, err)
@@ -158,7 +162,8 @@ func (s *CmdExecutor) SnapshotDestroy(host string, snapshot string) error {
 		fmt.Sprintf("%v --xml snapshot delete %v", s.glusterCommand(), snapshot),
 	}
 
-	results, err := s.RemoteExecutor.ExecCommands(host, command, 10)
+	results, err := s.RemoteExecutor.ExecCommands(host, command,
+		s.GlusterCliExecTimeout())
 	if err := rex.AnyError(results, err); err != nil {
 		return fmt.Errorf("Unable to delete snapshot %v: %v", snapshot, err)
 	}

--- a/executors/cmdexec/volume.go
+++ b/executors/cmdexec/volume.go
@@ -29,7 +29,7 @@ func (s *CmdExecutor) VolumeCreate(host string,
 	godbc.Require(len(volume.Bricks) > 0)
 	godbc.Require(volume.Name != "")
 
-	cmd := fmt.Sprintf("gluster --mode=script volume create %v ", volume.Name)
+	cmd := fmt.Sprintf("%v volume create %v ", s.glusterCommand(), volume.Name)
 
 	var (
 		inSet     int
@@ -71,7 +71,7 @@ func (s *CmdExecutor) VolumeCreate(host string,
 
 	commands = append(commands, s.createVolumeOptionsCommand(volume)...)
 
-	commands = append(commands, fmt.Sprintf("gluster --mode=script volume start %v", volume.Name))
+	commands = append(commands, fmt.Sprintf("%v volume start %v", s.glusterCommand(), volume.Name))
 
 	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 10))
 	if err != nil {
@@ -116,7 +116,7 @@ func (s *CmdExecutor) VolumeExpand(host string,
 	}
 
 	if s.RemoteExecutor.RebalanceOnExpansion() {
-		commands = []string{fmt.Sprintf("gluster --mode=script volume rebalance %v start", volume.Name)}
+		commands = []string{fmt.Sprintf("%v volume rebalance %v start", s.glusterCommand(), volume.Name)}
 		err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 10))
 		if err != nil {
 			// This is a hack. We fake success if rebalance fails.
@@ -139,7 +139,7 @@ func (s *CmdExecutor) VolumeDestroy(host string, volume string) error {
 	// First stop the volume, then delete it
 
 	commands := []string{
-		fmt.Sprintf("gluster --mode=script volume stop %v force", volume),
+		fmt.Sprintf("%v volume stop %v force", s.glusterCommand(), volume),
 	}
 
 	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 10))
@@ -148,7 +148,7 @@ func (s *CmdExecutor) VolumeDestroy(host string, volume string) error {
 	}
 
 	commands = []string{
-		fmt.Sprintf("gluster --mode=script volume delete %v", volume),
+		fmt.Sprintf("%v volume delete %v", s.glusterCommand(), volume),
 	}
 
 	err = rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 10))
@@ -174,7 +174,7 @@ func (s *CmdExecutor) createVolumeOptionsCommand(volume *executors.VolumeRequest
 	// Go through all the Options and create volume set command
 	for _, volOption := range volume.GlusterVolumeOptions {
 		if volOption != "" {
-			cmd = fmt.Sprintf("gluster --mode=script volume set %v %v", volume.Name, volOption)
+			cmd = fmt.Sprintf("%v volume set %v %v", s.glusterCommand(), volume.Name, volOption)
 			commands = append(commands, cmd)
 		}
 
@@ -197,7 +197,7 @@ func (s *CmdExecutor) createAddBrickCommands(volume *executors.VolumeRequest,
 			}
 
 			// Create a new add-brick command
-			cmd = fmt.Sprintf("gluster --mode=script volume add-brick %v ", volume.Name)
+			cmd = fmt.Sprintf("%v volume add-brick %v ", s.glusterCommand(), volume.Name)
 		}
 
 		// Add this brick to the add-brick command
@@ -225,7 +225,7 @@ func (s *CmdExecutor) checkForSnapshots(host, volume string) error {
 	}
 
 	commands := []string{
-		fmt.Sprintf("gluster --mode=script snapshot list %v --xml", volume),
+		fmt.Sprintf("%v snapshot list %v --xml", s.glusterCommand(), volume),
 	}
 
 	results, err := s.RemoteExecutor.ExecCommands(host, commands, 10)
@@ -265,7 +265,7 @@ func (s *CmdExecutor) VolumeInfo(host string, volume string) (*executors.Volume,
 	}
 
 	command := []string{
-		fmt.Sprintf("gluster --mode=script volume info %v --xml", volume),
+		fmt.Sprintf("%v volume info %v --xml", s.glusterCommand(), volume),
 	}
 
 	//Get the xml output of volume info
@@ -290,7 +290,7 @@ func (s *CmdExecutor) VolumeReplaceBrick(host string, volume string, oldBrick *e
 
 	// Replace the brick
 	command := []string{
-		fmt.Sprintf("gluster --mode=script volume replace-brick %v %v:%v %v:%v commit force", volume, oldBrick.Host, oldBrick.Path, newBrick.Host, newBrick.Path),
+		fmt.Sprintf("%v volume replace-brick %v %v:%v %v:%v commit force", s.glusterCommand(), volume, oldBrick.Host, oldBrick.Path, newBrick.Host, newBrick.Path),
 	}
 	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, command, 10))
 	if err != nil {
@@ -343,7 +343,7 @@ func (s *CmdExecutor) VolumeSnapshot(host string, vsr *executors.VolumeSnapshotR
 	}
 
 	command := []string{
-		fmt.Sprintf("gluster --mode=script --xml snapshot create %v %v no-timestamp", vsr.Snapshot, vsr.Volume),
+		fmt.Sprintf("%v --xml snapshot create %v %v no-timestamp", s.glusterCommand(), vsr.Snapshot, vsr.Volume),
 		// TODO: set the snapshot description if vsr.Description is non-empty
 	}
 
@@ -382,7 +382,7 @@ func (s *CmdExecutor) HealInfo(host string, volume string) (*executors.HealInfo,
 	}
 
 	command := []string{
-		fmt.Sprintf("gluster --mode=script volume heal %v info --xml", volume),
+		fmt.Sprintf("%v volume heal %v info --xml", s.glusterCommand(), volume),
 	}
 
 	results, err := s.RemoteExecutor.ExecCommands(host, command, 10)

--- a/executors/cmdexec/volume.go
+++ b/executors/cmdexec/volume.go
@@ -73,7 +73,8 @@ func (s *CmdExecutor) VolumeCreate(host string,
 
 	commands = append(commands, fmt.Sprintf("%v volume start %v", s.glusterCommand(), volume.Name))
 
-	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 10))
+	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands,
+		s.GlusterCliExecTimeout()))
 	if err != nil {
 		s.VolumeDestroy(host, volume.Name)
 		return nil, err
@@ -110,14 +111,16 @@ func (s *CmdExecutor) VolumeExpand(host string,
 		0, // start at the beginning of the brick list
 		inSet,
 		maxPerSet)
-	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 10))
+	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands,
+		s.GlusterCliExecTimeout()))
 	if err != nil {
 		return nil, err
 	}
 
 	if s.RemoteExecutor.RebalanceOnExpansion() {
 		commands = []string{fmt.Sprintf("%v volume rebalance %v start", s.glusterCommand(), volume.Name)}
-		err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 10))
+		err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands,
+			s.GlusterCliExecTimeout()))
 		if err != nil {
 			// This is a hack. We fake success if rebalance fails.
 			// Mainly because rebalance may fail even if one brick is down for the given volume.
@@ -142,7 +145,8 @@ func (s *CmdExecutor) VolumeDestroy(host string, volume string) error {
 		fmt.Sprintf("%v volume stop %v force", s.glusterCommand(), volume),
 	}
 
-	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 10))
+	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands,
+		s.GlusterCliExecTimeout()))
 	if err != nil {
 		logger.LogError("Unable to stop volume %v: %v", volume, err)
 	}
@@ -151,7 +155,8 @@ func (s *CmdExecutor) VolumeDestroy(host string, volume string) error {
 		fmt.Sprintf("%v volume delete %v", s.glusterCommand(), volume),
 	}
 
-	err = rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 10))
+	err = rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands,
+		s.GlusterCliExecTimeout()))
 	if err != nil {
 		return logger.Err(fmt.Errorf("Unable to delete volume %v: %v", volume, err))
 	}
@@ -228,7 +233,8 @@ func (s *CmdExecutor) checkForSnapshots(host, volume string) error {
 		fmt.Sprintf("%v snapshot list %v --xml", s.glusterCommand(), volume),
 	}
 
-	results, err := s.RemoteExecutor.ExecCommands(host, commands, 10)
+	results, err := s.RemoteExecutor.ExecCommands(host, commands,
+		s.GlusterCliExecTimeout())
 	if err := rex.AnyError(results, err); err != nil {
 		return fmt.Errorf("Unable to get snapshot information from volume %v: %v", volume, err)
 	}
@@ -269,7 +275,8 @@ func (s *CmdExecutor) VolumeInfo(host string, volume string) (*executors.Volume,
 	}
 
 	//Get the xml output of volume info
-	results, err := s.RemoteExecutor.ExecCommands(host, command, 10)
+	results, err := s.RemoteExecutor.ExecCommands(host, command,
+		s.GlusterCliExecTimeout())
 	if err := rex.AnyError(results, err); err != nil {
 		return nil, fmt.Errorf("Unable to get volume info of volume name: %v", volume)
 	}
@@ -292,7 +299,8 @@ func (s *CmdExecutor) VolumeReplaceBrick(host string, volume string, oldBrick *e
 	command := []string{
 		fmt.Sprintf("%v volume replace-brick %v %v:%v %v:%v commit force", s.glusterCommand(), volume, oldBrick.Host, oldBrick.Path, newBrick.Host, newBrick.Path),
 	}
-	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, command, 10))
+	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, command,
+		s.GlusterCliExecTimeout()))
 	if err != nil {
 		return logger.Err(fmt.Errorf("Unable to replace brick %v:%v with %v:%v for volume %v", oldBrick.Host, oldBrick.Path, newBrick.Host, newBrick.Path, volume))
 	}
@@ -347,7 +355,8 @@ func (s *CmdExecutor) VolumeSnapshot(host string, vsr *executors.VolumeSnapshotR
 		// TODO: set the snapshot description if vsr.Description is non-empty
 	}
 
-	results, err := s.RemoteExecutor.ExecCommands(host, command, 10)
+	results, err := s.RemoteExecutor.ExecCommands(host, command,
+		s.GlusterCliExecTimeout())
 	if err := rex.AnyError(results, err); err != nil {
 		return nil, fmt.Errorf("Unable to create snapshot of volume %v: %v", vsr.Volume, err)
 	}
@@ -385,7 +394,8 @@ func (s *CmdExecutor) HealInfo(host string, volume string) (*executors.HealInfo,
 		fmt.Sprintf("%v volume heal %v info --xml", s.glusterCommand(), volume),
 	}
 
-	results, err := s.RemoteExecutor.ExecCommands(host, command, 10)
+	results, err := s.RemoteExecutor.ExecCommands(host, command,
+		s.GlusterCliExecTimeout())
 	if err := rex.AnyError(results, err); err != nil {
 		return nil, fmt.Errorf("Unable to get heal info of volume : %v", volume)
 	}

--- a/executors/kubeexec/kubeexec.go
+++ b/executors/kubeexec/kubeexec.go
@@ -96,7 +96,7 @@ func NewKubeExecutor(config *KubeConfig) (*KubeExecutor, error) {
 	// Initialize
 	k := &KubeExecutor{}
 	k.config = config
-	k.Throttlemap = make(map[string]chan bool)
+	k.CmdExecutor.Init(&config.CmdConfig)
 	k.RemoteExecutor = k
 
 	if k.config.Fstab == "" {

--- a/executors/sshexec/sshexec.go
+++ b/executors/sshexec/sshexec.go
@@ -87,8 +87,8 @@ func NewSshExecutor(config *SshConfig) (*SshExecutor, error) {
 	setWithEnvVariables(config)
 
 	s := &SshExecutor{}
+	s.CmdExecutor.Init(&config.CmdConfig)
 	s.RemoteExecutor = s
-	s.Throttlemap = make(map[string]chan bool)
 
 	// Set configuration
 	if config.PrivateKeyFile == "" {


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

This PR adds a configurable timeout to invocations of the Gluster CLI, set to 10 minutes by default. The reason for this is that in a very busy system, with many volumes, some gluster cli commands can take longer than the default timeout of 2 minutes.

This adds a config setting of `gluster_cli_timeout` that can be overridden by the env variable `HEKETI_GLUSTER_CLI_TIMEOUT` and defaults to 10 minutes. This seemed to have been a good default value from the observations. This value is passed to the gluster cli commandline with the `--timeout` parameter.

### Does this PR fix issues?

Fixes #1426 

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1651041

### Notes for the reviewer

In order to not run into the `ExecCommands` timeout which is currently set to 10 minutes in the invocations, the timeout for the ExecCommands invocations is also made dynamic in that it is set to the maximum of 10 and the configured cli timeout (in minutes) +1, so that we will always wait for the gluster cli to time out rather than timing out the ssh connection first.

Only a very minimal amount of refactoring / reconsiliation has been done to the executor code as part of this PR, to avoid code duplication. More refactoring could be done as follow-up PRs.
