### PR TITLE
travis: try building on xenial image, to resolve hg tls issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+dist: xenial
 sudo: true
 before_install:
     - sudo apt-get update -qq

--- a/tests/020-test-shellscripts.sh
+++ b/tests/020-test-shellscripts.sh
@@ -19,7 +19,7 @@ test_shellcheck() {
 	fi
 }
 
-SHELLCHECK="$(which shellcheck 2>/dev/null)"
+SHELLCHECK="$(command -v shellcheck 2>/dev/null)"
 
 SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
 

--- a/tests/200-py-unittest.sh
+++ b/tests/200-py-unittest.sh
@@ -39,9 +39,12 @@ fi
 
 TOXENVS="py27"
 if command -v python3.5 &>/dev/null; then
-	TOXENVS="${TOXENVS},py35"
 	if command -v pyenv &>/dev/null; then
-		pyenv global system 3.5
+		if pyenv global system 3.5; then
+			TOXENVS="${TOXENVS},py35"
+		fi
+	else
+		TOXENVS="${TOXENVS},py35"
 	fi
 fi
 if command -v python3.6 &>/dev/null; then


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

On December 1st, [BitBucket disabled TLS 1.0 support](https://bitbucket.org/blog/deprecating-tlsv1-tlsv1-1-2018-12-01) which is causing problems for the old version of mercurial/python provided by the travis ci we are using.

This change bumps the distro version we request from travis to "xenial" where TLS > 1.0 does work. This also includes fixes for fallout from the version bump.

### Notes for the reviewer

All other PRs will continue to fail unless this PR is merged.

