### PR TITLE
Perform consistency checks on db

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -580,6 +580,11 @@ func (a *App) SetRoutes(router *mux.Router) error {
 			Method:      "GET",
 			Pattern:     "/db/dump",
 			HandlerFunc: a.DbDump},
+		rest.Route{
+			Name:        "DbCheck",
+			Method:      "GET",
+			Pattern:     "/db/check",
+			HandlerFunc: a.DbCheck},
 
 		// Logging
 		rest.Route{

--- a/apps/glusterfs/app_db.go
+++ b/apps/glusterfs/app_db.go
@@ -30,3 +30,21 @@ func (a *App) DbDump(w http.ResponseWriter, r *http.Request) {
 		panic(err)
 	}
 }
+
+// DbCheck ... Checks the DB for inconsistencies.
+// It returns a JSON summary of the check.
+// This is the variant to be called via the API and running in the App
+func (a *App) DbCheck(w http.ResponseWriter, r *http.Request) {
+	checkResponse, err := dbCheckConsistency(a.db)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Write msg
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(checkResponse); err != nil {
+		panic(err)
+	}
+}

--- a/apps/glusterfs/app_db.go
+++ b/apps/glusterfs/app_db.go
@@ -44,7 +44,9 @@ func (a *App) DbCheck(w http.ResponseWriter, r *http.Request) {
 	// Write msg
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(checkResponse); err != nil {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "    ")
+	if err := encoder.Encode(checkResponse); err != nil {
 		panic(err)
 	}
 }

--- a/apps/glusterfs/cluster_entry.go
+++ b/apps/glusterfs/cluster_entry.go
@@ -259,9 +259,7 @@ func (c *ClusterEntry) hosts(db wdb.RODB) (nodeHosts, error) {
 
 // consistencyCheck ... verifies that a clusterEntry is consistent with rest of the database.
 // It is a method on clusterEntry and needs rest of the database as its input.
-func (c *ClusterEntry) consistencyCheck(db Db) (consistent bool, inconsistencies []string) {
-
-	consistent = true
+func (c *ClusterEntry) consistencyCheck(db Db) (response DbEntryCheckResponse) {
 
 	// No consistency check required for following attributes
 	// Id
@@ -270,12 +268,10 @@ func (c *ClusterEntry) consistencyCheck(db Db) (consistent bool, inconsistencies
 	// Nodes
 	for _, node := range c.Info.Nodes {
 		if nodeEntry, found := db.Nodes[node]; !found {
-			inconsistencies = append(inconsistencies, fmt.Sprintf("Cluster %v unknown node %v", c.Info.Id, node))
-			consistent = false
+			response.Inconsistencies = append(response.Inconsistencies, fmt.Sprintf("Cluster %v unknown node %v", c.Info.Id, node))
 		} else {
 			if nodeEntry.Info.ClusterId != c.Info.Id {
-				inconsistencies = append(inconsistencies, fmt.Sprintf("Cluster %v no link back to cluster from node %v", c.Info.Id, node))
-				consistent = false
+				response.Inconsistencies = append(response.Inconsistencies, fmt.Sprintf("Cluster %v no link back to cluster from node %v", c.Info.Id, node))
 			}
 		}
 	}
@@ -283,12 +279,10 @@ func (c *ClusterEntry) consistencyCheck(db Db) (consistent bool, inconsistencies
 	// Volumes
 	for _, volume := range c.Info.Volumes {
 		if volumeEntry, found := db.Volumes[volume]; !found {
-			inconsistencies = append(inconsistencies, fmt.Sprintf("Cluster %v unknown volume %v", c.Info.Id, volume))
-			consistent = false
+			response.Inconsistencies = append(response.Inconsistencies, fmt.Sprintf("Cluster %v unknown volume %v", c.Info.Id, volume))
 		} else {
 			if volumeEntry.Info.Cluster != c.Info.Id {
-				inconsistencies = append(inconsistencies, fmt.Sprintf("Cluster %v no link back to cluster from volume %v", c.Info.Id, volume))
-				consistent = false
+				response.Inconsistencies = append(response.Inconsistencies, fmt.Sprintf("Cluster %v no link back to cluster from volume %v", c.Info.Id, volume))
 			}
 		}
 	}
@@ -296,12 +290,10 @@ func (c *ClusterEntry) consistencyCheck(db Db) (consistent bool, inconsistencies
 	// BlockVolumes
 	for _, blockvolume := range c.Info.BlockVolumes {
 		if blockvolumeEntry, found := db.BlockVolumes[blockvolume]; !found {
-			inconsistencies = append(inconsistencies, fmt.Sprintf("Cluster %v unknown blockvolume %v", c.Info.Id, blockvolume))
-			consistent = false
+			response.Inconsistencies = append(response.Inconsistencies, fmt.Sprintf("Cluster %v unknown blockvolume %v", c.Info.Id, blockvolume))
 		} else {
 			if blockvolumeEntry.Info.Cluster != c.Info.Id {
-				inconsistencies = append(inconsistencies, fmt.Sprintf("Cluster %v no link back to cluster from blockvolume %v", c.Info.Id, blockvolume))
-				consistent = false
+				response.Inconsistencies = append(response.Inconsistencies, fmt.Sprintf("Cluster %v no link back to cluster from blockvolume %v", c.Info.Id, blockvolume))
 			}
 		}
 	}

--- a/apps/glusterfs/cluster_entry.go
+++ b/apps/glusterfs/cluster_entry.go
@@ -256,3 +256,56 @@ func (c *ClusterEntry) hosts(db wdb.RODB) (nodeHosts, error) {
 	})
 	return hosts, err
 }
+
+// consistencyCheck ... verifies that a clusterEntry is consistent with rest of the database.
+// It is a method on clusterEntry and needs rest of the database as its input.
+func (c *ClusterEntry) consistencyCheck(db Db) (consistent bool, inconsistencies []string) {
+
+	consistent = true
+
+	// No consistency check required for following attributes
+	// Id
+	// ClusterFlags
+
+	// Nodes
+	for _, node := range c.Info.Nodes {
+		if nodeEntry, found := db.Nodes[node]; !found {
+			inconsistencies = append(inconsistencies, fmt.Sprintf("Cluster %v unknown node %v", c.Info.Id, node))
+			consistent = false
+		} else {
+			if nodeEntry.Info.ClusterId != c.Info.Id {
+				inconsistencies = append(inconsistencies, fmt.Sprintf("Cluster %v no link back to cluster from node %v", c.Info.Id, node))
+				consistent = false
+			}
+		}
+	}
+
+	// Volumes
+	for _, volume := range c.Info.Volumes {
+		if volumeEntry, found := db.Volumes[volume]; !found {
+			inconsistencies = append(inconsistencies, fmt.Sprintf("Cluster %v unknown volume %v", c.Info.Id, volume))
+			consistent = false
+		} else {
+			if volumeEntry.Info.Cluster != c.Info.Id {
+				inconsistencies = append(inconsistencies, fmt.Sprintf("Cluster %v no link back to cluster from volume %v", c.Info.Id, volume))
+				consistent = false
+			}
+		}
+	}
+
+	// BlockVolumes
+	for _, blockvolume := range c.Info.BlockVolumes {
+		if blockvolumeEntry, found := db.BlockVolumes[blockvolume]; !found {
+			inconsistencies = append(inconsistencies, fmt.Sprintf("Cluster %v unknown blockvolume %v", c.Info.Id, blockvolume))
+			consistent = false
+		} else {
+			if blockvolumeEntry.Info.Cluster != c.Info.Id {
+				inconsistencies = append(inconsistencies, fmt.Sprintf("Cluster %v no link back to cluster from blockvolume %v", c.Info.Id, blockvolume))
+				consistent = false
+			}
+		}
+	}
+
+	return
+
+}

--- a/apps/glusterfs/db_operations.go
+++ b/apps/glusterfs/db_operations.go
@@ -517,20 +517,17 @@ func dbCheckVolumes(dump Db) (volumesCheckResponse DbBucketCheckResponse) {
 	for _, volumeEntry := range dump.Volumes {
 
 		volumesCheckResponse.Total++
-		if volumeEntry.Pending.Id != "" {
+
+		volumeCheckResponse := volumeEntry.consistencyCheck(dump)
+		if volumeCheckResponse.Pending {
 			volumesCheckResponse.Pending++
 		}
 
-		volConsistent, volCheckInconsistencies := volumeEntry.consistencyCheck(dump)
-
-		if volConsistent == true {
-			volumesCheckResponse.Ok++
-		} else {
+		if len(volumeCheckResponse.Inconsistencies) > 0 {
+			volumesCheckResponse.Inconsistencies = append(volumesCheckResponse.Inconsistencies, volumeCheckResponse.Inconsistencies...)
 			volumesCheckResponse.NotOk++
-		}
-
-		if len(volCheckInconsistencies) > 0 {
-			volumesCheckResponse.Inconsistencies = append(volumesCheckResponse.Inconsistencies, volCheckInconsistencies...)
+		} else {
+			volumesCheckResponse.Ok++
 		}
 	}
 
@@ -543,16 +540,13 @@ func dbCheckClusters(dump Db) (clustersCheckResponse DbBucketCheckResponse) {
 		clustersCheckResponse.Total++
 		// Cluster Entries don't have pending operations
 
-		clusterConsistent, clusterInconsistencies := clusterEntry.consistencyCheck(dump)
+		clusterCheckResponse := clusterEntry.consistencyCheck(dump)
 
-		if clusterConsistent == true {
-			clustersCheckResponse.Ok++
-		} else {
+		if len(clusterCheckResponse.Inconsistencies) > 0 {
+			clustersCheckResponse.Inconsistencies = append(clustersCheckResponse.Inconsistencies, clusterCheckResponse.Inconsistencies...)
 			clustersCheckResponse.NotOk++
-		}
-
-		if len(clusterInconsistencies) > 0 {
-			clustersCheckResponse.Inconsistencies = append(clustersCheckResponse.Inconsistencies, clusterInconsistencies...)
+		} else {
+			clustersCheckResponse.Ok++
 		}
 	}
 
@@ -565,16 +559,13 @@ func dbCheckNodes(dump Db) (nodesCheckResponse DbBucketCheckResponse) {
 		nodesCheckResponse.Total++
 		// Node Entries don't have pending operations
 
-		nodeConsistent, nodeInconsistencies := nodeEntry.consistencyCheck(dump)
+		nodeCheckResponse := nodeEntry.consistencyCheck(dump)
 
-		if nodeConsistent == true {
-			nodesCheckResponse.Ok++
-		} else {
+		if len(nodeCheckResponse.Inconsistencies) > 0 {
+			nodesCheckResponse.Inconsistencies = append(nodesCheckResponse.Inconsistencies, nodeCheckResponse.Inconsistencies...)
 			nodesCheckResponse.NotOk++
-		}
-
-		if len(nodeInconsistencies) > 0 {
-			nodesCheckResponse.Inconsistencies = append(nodesCheckResponse.Inconsistencies, nodeInconsistencies...)
+		} else {
+			nodesCheckResponse.Ok++
 		}
 	}
 
@@ -587,16 +578,13 @@ func dbCheckDevices(dump Db) (devicesCheckResponse DbBucketCheckResponse) {
 		devicesCheckResponse.Total++
 		// Device Entries don't have pending operations
 
-		deviceConsistent, deviceInconsistencies := deviceEntry.consistencyCheck(dump)
+		deviceCheckResponse := deviceEntry.consistencyCheck(dump)
 
-		if deviceConsistent == true {
-			devicesCheckResponse.Ok++
-		} else {
+		if len(deviceCheckResponse.Inconsistencies) > 0 {
+			devicesCheckResponse.Inconsistencies = append(devicesCheckResponse.Inconsistencies, deviceCheckResponse.Inconsistencies...)
 			devicesCheckResponse.NotOk++
-		}
-
-		if len(deviceInconsistencies) > 0 {
-			devicesCheckResponse.Inconsistencies = append(devicesCheckResponse.Inconsistencies, deviceInconsistencies...)
+		} else {
+			devicesCheckResponse.Ok++
 		}
 	}
 
@@ -607,20 +595,16 @@ func dbCheckBlockVolumes(dump Db) (blockVolumesCheckResponse DbBucketCheckRespon
 	for _, blockVolumeEntry := range dump.BlockVolumes {
 
 		blockVolumesCheckResponse.Total++
-		if blockVolumeEntry.Pending.Id != "" {
+
+		blockVolumeCheckResponse := blockVolumeEntry.consistencyCheck(dump)
+		if blockVolumeCheckResponse.Pending {
 			blockVolumesCheckResponse.Pending++
 		}
-
-		blockVolumeConsistent, blockVolumeInconsistencies := blockVolumeEntry.consistencyCheck(dump)
-
-		if blockVolumeConsistent == true {
-			blockVolumesCheckResponse.Ok++
-		} else {
+		if len(blockVolumeCheckResponse.Inconsistencies) > 0 {
+			blockVolumesCheckResponse.Inconsistencies = append(blockVolumesCheckResponse.Inconsistencies, blockVolumeCheckResponse.Inconsistencies...)
 			blockVolumesCheckResponse.NotOk++
-		}
-
-		if len(blockVolumeInconsistencies) > 0 {
-			blockVolumesCheckResponse.Inconsistencies = append(blockVolumesCheckResponse.Inconsistencies, blockVolumeInconsistencies...)
+		} else {
+			blockVolumesCheckResponse.Ok++
 		}
 	}
 
@@ -631,20 +615,17 @@ func dbCheckBricks(dump Db) (bricksCheckResponse DbBucketCheckResponse) {
 	for _, brickEntry := range dump.Bricks {
 
 		bricksCheckResponse.Total++
-		if brickEntry.Pending.Id != "" {
+
+		brickCheckResponse := brickEntry.consistencyCheck(dump)
+		if brickCheckResponse.Pending {
 			bricksCheckResponse.Pending++
 		}
 
-		brickConsistent, brickInconsistencies := brickEntry.consistencyCheck(dump)
-
-		if brickConsistent == true {
-			bricksCheckResponse.Ok++
-		} else {
+		if len(brickCheckResponse.Inconsistencies) > 0 {
+			bricksCheckResponse.Inconsistencies = append(bricksCheckResponse.Inconsistencies, brickCheckResponse.Inconsistencies...)
 			bricksCheckResponse.NotOk++
-		}
-
-		if len(brickInconsistencies) > 0 {
-			bricksCheckResponse.Inconsistencies = append(bricksCheckResponse.Inconsistencies, brickInconsistencies...)
+		} else {
+			bricksCheckResponse.Ok++
 		}
 	}
 
@@ -654,16 +635,13 @@ func dbCheckBricks(dump Db) (bricksCheckResponse DbBucketCheckResponse) {
 func dbCheckPendingOps(dump Db) (pendingOpsCheckResponse DbBucketCheckResponse) {
 	for _, pendingOpEntry := range dump.PendingOperations {
 
-		pendingOpConsistent, pendingOpInconsistencies := pendingOpEntry.consistencyCheck(dump)
+		pendingOpCheckResponse := pendingOpEntry.consistencyCheck(dump)
 
-		if pendingOpConsistent == true {
-			pendingOpsCheckResponse.Ok++
-		} else {
+		if len(pendingOpCheckResponse.Inconsistencies) > 0 {
+			pendingOpsCheckResponse.Inconsistencies = append(pendingOpsCheckResponse.Inconsistencies, pendingOpCheckResponse.Inconsistencies...)
 			pendingOpsCheckResponse.NotOk++
-		}
-
-		if len(pendingOpInconsistencies) > 0 {
-			pendingOpsCheckResponse.Inconsistencies = append(pendingOpsCheckResponse.Inconsistencies, pendingOpInconsistencies...)
+		} else {
+			pendingOpsCheckResponse.Ok++
 		}
 	}
 

--- a/apps/glusterfs/db_operations.go
+++ b/apps/glusterfs/db_operations.go
@@ -461,3 +461,46 @@ func DeleteBricksWithEmptyPath(db *bolt.DB, all bool, clusterIDs []string, nodeI
 	}
 	return nil
 }
+
+// DbCheck ... is the offline version
+func DbCheck(dbfile string) error {
+
+	db, err := OpenDB(dbfile, false)
+	if err != nil {
+		return fmt.Errorf("Unable to open database: %v", err)
+	}
+
+	checkresponse, err := dbCheckConsistency(db)
+	if err != nil {
+		return fmt.Errorf("Unable to check the database: %v", err)
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "    ")
+
+	if err := encoder.Encode(checkresponse); err != nil {
+		return fmt.Errorf("Unable to encode the response into json: %v", err)
+	}
+
+	return nil
+}
+
+// dbCheckConsistency ... checks the current db state to determine if contents
+// of all the buckets represent a consistent view.
+func dbCheckConsistency(db *bolt.DB) (DbCheckResponse, error) {
+
+	var response DbCheckResponse
+
+	dump, err := dbDumpInternal(db)
+	if err != nil {
+		return response, fmt.Errorf("Could not construct dump from DB: %v", err.Error())
+	}
+
+	// TODO: Check the db here and remove the print statement.
+	// Implement check function for each bucket and call them here.
+	// Lastly, set the consistent bool to true/false based on len(inconsistencies)
+	// of all bucket checks.
+	fmt.Fprintf(os.Stderr, "%v", dump)
+
+	return response, nil
+}

--- a/apps/glusterfs/db_operations.go
+++ b/apps/glusterfs/db_operations.go
@@ -502,6 +502,8 @@ func dbCheckConsistency(db *bolt.DB) (response DbCheckResponse, err error) {
 
 	response.Volumes = dbCheckVolumes(dump)
 	response.TotalInconsistencies += len(response.Volumes.Inconsistencies)
+	response.Clusters = dbCheckClusters(dump)
+	response.TotalInconsistencies += len(response.Clusters.Inconsistencies)
 
 	if response.TotalInconsistencies > 0 {
 		response.Inconsistent = true
@@ -529,6 +531,29 @@ func dbCheckVolumes(dump Db) (volumesCheckResponse DbBucketCheckResponse) {
 
 		if len(volCheckInconsistencies) > 0 {
 			volumesCheckResponse.Inconsistencies = append(volumesCheckResponse.Inconsistencies, volCheckInconsistencies...)
+		}
+	}
+
+	return
+}
+
+func dbCheckClusters(dump Db) (clustersCheckResponse DbBucketCheckResponse) {
+
+	for _, clusterEntry := range dump.Clusters {
+
+		clustersCheckResponse.Total++
+		// Cluster Entries don't have pending operations
+
+		clusterConsistent, clusterInconsistencies := clusterEntry.consistencyCheck(dump)
+
+		if clusterConsistent == true {
+			clustersCheckResponse.Ok++
+		} else {
+			clustersCheckResponse.NotOk++
+		}
+
+		if len(clusterInconsistencies) > 0 {
+			clustersCheckResponse.Inconsistencies = append(clustersCheckResponse.Inconsistencies, clusterInconsistencies...)
 		}
 	}
 

--- a/apps/glusterfs/db_operations.go
+++ b/apps/glusterfs/db_operations.go
@@ -504,6 +504,8 @@ func dbCheckConsistency(db *bolt.DB) (response DbCheckResponse, err error) {
 	response.TotalInconsistencies += len(response.Volumes.Inconsistencies)
 	response.Clusters = dbCheckClusters(dump)
 	response.TotalInconsistencies += len(response.Clusters.Inconsistencies)
+	response.Nodes = dbCheckNodes(dump)
+	response.TotalInconsistencies += len(response.Nodes.Inconsistencies)
 
 	if response.TotalInconsistencies > 0 {
 		response.Inconsistent = true
@@ -538,7 +540,6 @@ func dbCheckVolumes(dump Db) (volumesCheckResponse DbBucketCheckResponse) {
 }
 
 func dbCheckClusters(dump Db) (clustersCheckResponse DbBucketCheckResponse) {
-
 	for _, clusterEntry := range dump.Clusters {
 
 		clustersCheckResponse.Total++
@@ -554,6 +555,28 @@ func dbCheckClusters(dump Db) (clustersCheckResponse DbBucketCheckResponse) {
 
 		if len(clusterInconsistencies) > 0 {
 			clustersCheckResponse.Inconsistencies = append(clustersCheckResponse.Inconsistencies, clusterInconsistencies...)
+		}
+	}
+
+	return
+}
+
+func dbCheckNodes(dump Db) (nodesCheckResponse DbBucketCheckResponse) {
+	for _, nodeEntry := range dump.Nodes {
+
+		nodesCheckResponse.Total++
+		// Node Entries don't have pending operations
+
+		nodeConsistent, nodeInconsistencies := nodeEntry.consistencyCheck(dump)
+
+		if nodeConsistent == true {
+			nodesCheckResponse.Ok++
+		} else {
+			nodesCheckResponse.NotOk++
+		}
+
+		if len(nodeInconsistencies) > 0 {
+			nodesCheckResponse.Inconsistencies = append(nodesCheckResponse.Inconsistencies, nodeInconsistencies...)
 		}
 	}
 

--- a/apps/glusterfs/db_operations.go
+++ b/apps/glusterfs/db_operations.go
@@ -509,10 +509,6 @@ func dbCheckConsistency(db *bolt.DB) (response DbCheckResponse, err error) {
 	response.PendingOperations = dbCheckPendingOps(dump)
 	response.TotalInconsistencies += len(response.PendingOperations.Inconsistencies)
 
-	if response.TotalInconsistencies > 0 {
-		response.Inconsistent = true
-	}
-
 	return
 }
 

--- a/apps/glusterfs/db_operations.go
+++ b/apps/glusterfs/db_operations.go
@@ -506,6 +506,8 @@ func dbCheckConsistency(db *bolt.DB) (response DbCheckResponse, err error) {
 	response.TotalInconsistencies += len(response.Clusters.Inconsistencies)
 	response.Nodes = dbCheckNodes(dump)
 	response.TotalInconsistencies += len(response.Nodes.Inconsistencies)
+	response.Devices = dbCheckDevices(dump)
+	response.TotalInconsistencies += len(response.Devices.Inconsistencies)
 
 	if response.TotalInconsistencies > 0 {
 		response.Inconsistent = true
@@ -577,6 +579,28 @@ func dbCheckNodes(dump Db) (nodesCheckResponse DbBucketCheckResponse) {
 
 		if len(nodeInconsistencies) > 0 {
 			nodesCheckResponse.Inconsistencies = append(nodesCheckResponse.Inconsistencies, nodeInconsistencies...)
+		}
+	}
+
+	return
+}
+
+func dbCheckDevices(dump Db) (devicesCheckResponse DbBucketCheckResponse) {
+	for _, deviceEntry := range dump.Devices {
+
+		devicesCheckResponse.Total++
+		// Device Entries don't have pending operations
+
+		deviceConsistent, deviceInconsistencies := deviceEntry.consistencyCheck(dump)
+
+		if deviceConsistent == true {
+			devicesCheckResponse.Ok++
+		} else {
+			devicesCheckResponse.NotOk++
+		}
+
+		if len(deviceInconsistencies) > 0 {
+			devicesCheckResponse.Inconsistencies = append(devicesCheckResponse.Inconsistencies, deviceInconsistencies...)
 		}
 	}
 

--- a/apps/glusterfs/dbcommon.go
+++ b/apps/glusterfs/dbcommon.go
@@ -33,6 +33,30 @@ type Db struct {
 	PendingOperations map[string]PendingOperationEntry `json:"pendingoperations"`
 }
 
+//DbBucketCheckResponse ... is summary of check on a db bucket.
+type DbBucketCheckResponse struct {
+	Total           int      `json:"total"`
+	Pending         int      `json:"pending"`
+	Ok              int      `json:"ok"`
+	NotOk           int      `json:"notok"`
+	Inconsistencies []string `json:"inconsistencies"`
+}
+
+//DbCheckResponse ... is the output of db check. It lists a summary of db state
+//and inconsistencies related to each bucket, if any.
+type DbCheckResponse struct {
+	Clusters             DbBucketCheckResponse `json:"clusters"`
+	Volumes              DbBucketCheckResponse `json:"volumes"`
+	Bricks               DbBucketCheckResponse `json:"bricks"`
+	Nodes                DbBucketCheckResponse `json:"nodes"`
+	Devices              DbBucketCheckResponse `json:"devices"`
+	BlockVolumes         DbBucketCheckResponse `json:"blockvolumes"`
+	DbAttributes         DbBucketCheckResponse `json:"dbattributes"`
+	PendingOperations    DbBucketCheckResponse `json:"pendingoperations"`
+	TotalInconsistencies int                   `json:"totalinconsistencies"`
+	Inconsistent         bool                  `json:"inconsistent"`
+}
+
 func initializeBuckets(tx *bolt.Tx) error {
 	// Create Cluster Bucket
 	_, err := tx.CreateBucketIfNotExists([]byte(BOLTDB_BUCKET_CLUSTER))

--- a/apps/glusterfs/dbcommon.go
+++ b/apps/glusterfs/dbcommon.go
@@ -33,6 +33,12 @@ type Db struct {
 	PendingOperations map[string]PendingOperationEntry `json:"pendingoperations"`
 }
 
+//DbEntryCheckResponse ... is summary of check on a db entry.
+type DbEntryCheckResponse struct {
+	Pending         bool     `json:"pending"`
+	Inconsistencies []string `json:"inconsistencies"`
+}
+
 //DbBucketCheckResponse ... is summary of check on a db bucket.
 type DbBucketCheckResponse struct {
 	Total           int      `json:"total"`

--- a/apps/glusterfs/dbcommon.go
+++ b/apps/glusterfs/dbcommon.go
@@ -54,7 +54,6 @@ type DbCheckResponse struct {
 	DbAttributes         DbBucketCheckResponse `json:"dbattributes"`
 	PendingOperations    DbBucketCheckResponse `json:"pendingoperations"`
 	TotalInconsistencies int                   `json:"totalinconsistencies"`
-	Inconsistent         bool                  `json:"inconsistent"`
 }
 
 func initializeBuckets(tx *bolt.Tx) error {

--- a/apps/glusterfs/node_entry.go
+++ b/apps/glusterfs/node_entry.go
@@ -497,9 +497,7 @@ func (n *NodeEntry) SetTags(t map[string]string) error {
 
 // consistencyCheck ... verifies that a nodeEntry is consistent with rest of the database.
 // It is a method on nodeEntry and needs rest of the database as its input.
-func (n *NodeEntry) consistencyCheck(db Db) (consistent bool, inconsistencies []string) {
-
-	consistent = true
+func (n *NodeEntry) consistencyCheck(db Db) (response DbEntryCheckResponse) {
 
 	// No consistency check required for following attributes
 	// Id
@@ -510,24 +508,20 @@ func (n *NodeEntry) consistencyCheck(db Db) (consistent bool, inconsistencies []
 	// Devices
 	for _, device := range n.Devices {
 		if deviceEntry, found := db.Devices[device]; !found {
-			inconsistencies = append(inconsistencies, fmt.Sprintf("Node %v unknown device %v", n.Info.Id, device))
-			consistent = false
+			response.Inconsistencies = append(response.Inconsistencies, fmt.Sprintf("Node %v unknown device %v", n.Info.Id, device))
 		} else {
 			if deviceEntry.NodeId != n.Info.Id {
-				inconsistencies = append(inconsistencies, fmt.Sprintf("Node %v no link back to node from device %v", n.Info.Id, device))
-				consistent = false
+				response.Inconsistencies = append(response.Inconsistencies, fmt.Sprintf("Node %v no link back to node from device %v", n.Info.Id, device))
 			}
 		}
 	}
 
 	// Cluster
 	if clusterEntry, found := db.Clusters[n.Info.ClusterId]; !found {
-		inconsistencies = append(inconsistencies, fmt.Sprintf("Node %v unknown cluster %v", n.Info.Id, n.Info.ClusterId))
-		consistent = false
+		response.Inconsistencies = append(response.Inconsistencies, fmt.Sprintf("Node %v unknown cluster %v", n.Info.Id, n.Info.ClusterId))
 	} else {
 		if !sortedstrings.Has(clusterEntry.Info.Nodes, n.Info.Id) {
-			inconsistencies = append(inconsistencies, fmt.Sprintf("Node %v no link back to node from cluster %v", n.Info.Id, n.Info.ClusterId))
-			consistent = false
+			response.Inconsistencies = append(response.Inconsistencies, fmt.Sprintf("Node %v no link back to node from cluster %v", n.Info.Id, n.Info.ClusterId))
 		}
 	}
 

--- a/apps/glusterfs/node_entry.go
+++ b/apps/glusterfs/node_entry.go
@@ -494,3 +494,43 @@ func (n *NodeEntry) SetTags(t map[string]string) error {
 	n.Info.Tags = t
 	return nil
 }
+
+// consistencyCheck ... verifies that a nodeEntry is consistent with rest of the database.
+// It is a method on nodeEntry and needs rest of the database as its input.
+func (n *NodeEntry) consistencyCheck(db Db) (consistent bool, inconsistencies []string) {
+
+	consistent = true
+
+	// No consistency check required for following attributes
+	// Id
+	// NodeTags
+	// Zone
+	// EntryState
+
+	// Devices
+	for _, device := range n.Devices {
+		if deviceEntry, found := db.Devices[device]; !found {
+			inconsistencies = append(inconsistencies, fmt.Sprintf("Node %v unknown device %v", n.Info.Id, device))
+			consistent = false
+		} else {
+			if deviceEntry.NodeId != n.Info.Id {
+				inconsistencies = append(inconsistencies, fmt.Sprintf("Node %v no link back to node from device %v", n.Info.Id, device))
+				consistent = false
+			}
+		}
+	}
+
+	// Cluster
+	if clusterEntry, found := db.Clusters[n.Info.ClusterId]; !found {
+		inconsistencies = append(inconsistencies, fmt.Sprintf("Node %v unknown cluster %v", n.Info.Id, n.Info.ClusterId))
+		consistent = false
+	} else {
+		if !sortedstrings.Has(clusterEntry.Info.Nodes, n.Info.Id) {
+			inconsistencies = append(inconsistencies, fmt.Sprintf("Node %v no link back to node from cluster %v", n.Info.Id, n.Info.ClusterId))
+			consistent = false
+		}
+	}
+
+	return
+
+}

--- a/apps/glusterfs/pendingop_entry.go
+++ b/apps/glusterfs/pendingop_entry.go
@@ -12,6 +12,7 @@ package glusterfs
 import (
 	"bytes"
 	"encoding/gob"
+	"fmt"
 	"time"
 
 	"github.com/boltdb/bolt"
@@ -379,4 +380,35 @@ func PendingOperationEntrySelection(
 		}
 	}
 	return selection, nil
+}
+
+func (p *PendingOperationEntry) consistencyCheck(db Db) (consistent bool, inconsistencies []string) {
+
+	consistent = true
+
+	for _, action := range p.Actions {
+		switch action.Change {
+		case OpAddBrick, OpDeleteBrick:
+			if p.Id != db.Bricks[action.Id].Pending.Id {
+				inconsistencies = append(inconsistencies, fmt.Sprintf("pending op %v id in change missing %v not found in bricks", p.Id, action.Id))
+				consistent = false
+			}
+		case OpAddVolume, OpDeleteVolume, OpExpandVolume, OpCloneVolume, OpSnapshotVolume, OpAddVolumeClone:
+			if p.Id != db.Volumes[action.Id].Pending.Id {
+				inconsistencies = append(inconsistencies, fmt.Sprintf("pending op %v id in change missing %v not found in volumes", p.Id, action.Id))
+				consistent = false
+			}
+		case OpAddBlockVolume, OpDeleteBlockVolume:
+			if p.Id != db.BlockVolumes[action.Id].Pending.Id {
+				inconsistencies = append(inconsistencies, fmt.Sprintf("pending op %v id in change missing %v not found in blockvolumes", p.Id, action.Id))
+				consistent = false
+			}
+		case OpRemoveDevice:
+			// This is a noop
+		default:
+			inconsistencies = append(inconsistencies, fmt.Sprintf("Pending Op %v unexpected change type %v", p.Id, action.Change))
+			consistent = false
+		}
+	}
+	return
 }

--- a/apps/glusterfs/pendingop_entry.go
+++ b/apps/glusterfs/pendingop_entry.go
@@ -382,32 +382,26 @@ func PendingOperationEntrySelection(
 	return selection, nil
 }
 
-func (p *PendingOperationEntry) consistencyCheck(db Db) (consistent bool, inconsistencies []string) {
-
-	consistent = true
+func (p *PendingOperationEntry) consistencyCheck(db Db) (response DbEntryCheckResponse) {
 
 	for _, action := range p.Actions {
 		switch action.Change {
 		case OpAddBrick, OpDeleteBrick:
 			if p.Id != db.Bricks[action.Id].Pending.Id {
-				inconsistencies = append(inconsistencies, fmt.Sprintf("pending op %v id in change missing %v not found in bricks", p.Id, action.Id))
-				consistent = false
+				response.Inconsistencies = append(response.Inconsistencies, fmt.Sprintf("pending op %v id in change missing %v not found in bricks", p.Id, action.Id))
 			}
 		case OpAddVolume, OpDeleteVolume, OpExpandVolume, OpCloneVolume, OpSnapshotVolume, OpAddVolumeClone:
 			if p.Id != db.Volumes[action.Id].Pending.Id {
-				inconsistencies = append(inconsistencies, fmt.Sprintf("pending op %v id in change missing %v not found in volumes", p.Id, action.Id))
-				consistent = false
+				response.Inconsistencies = append(response.Inconsistencies, fmt.Sprintf("pending op %v id in change missing %v not found in volumes", p.Id, action.Id))
 			}
 		case OpAddBlockVolume, OpDeleteBlockVolume:
 			if p.Id != db.BlockVolumes[action.Id].Pending.Id {
-				inconsistencies = append(inconsistencies, fmt.Sprintf("pending op %v id in change missing %v not found in blockvolumes", p.Id, action.Id))
-				consistent = false
+				response.Inconsistencies = append(response.Inconsistencies, fmt.Sprintf("pending op %v id in change missing %v not found in blockvolumes", p.Id, action.Id))
 			}
 		case OpRemoveDevice:
 			// This is a noop
 		default:
-			inconsistencies = append(inconsistencies, fmt.Sprintf("Pending Op %v unexpected change type %v", p.Id, action.Change))
-			consistent = false
+			response.Inconsistencies = append(response.Inconsistencies, fmt.Sprintf("Pending Op %v unexpected change type %v", p.Id, action.Change))
 		}
 	}
 	return

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -1010,3 +1010,85 @@ func (v *VolumeEntry) cloneVolumeRequest(db wdb.RODB, clonename string) (*execut
 
 	return vcr, sshhost, nil
 }
+
+// consistencyCheck ... verifies that a volumeEntry is consistent with rest of the database.
+// It is a method on volumeEntry and needs rest of the database as its input.
+func (v *VolumeEntry) consistencyCheck(db Db) (consistent bool, inconsistencies []string) {
+
+	consistent = true
+	var aggregateBlockVolumesSize = 0
+
+	// No consistency check required for following attributes
+	// Id
+	// Name
+	// Durability
+	// GlusterVolumeOptions
+	// Gid
+
+	// PendingId
+	if v.Pending.Id != "" {
+		if _, found := db.PendingOperations[v.Pending.Id]; !found {
+			inconsistencies = append(inconsistencies, fmt.Sprintf("Volume %v marked pending but no pending op %v", v.Info.Id, v.Pending.Id))
+			consistent = false
+		}
+		// TODO: Validate back the pending operations' relationship to the volume
+		// This is skipped because some of it is handled in auto cleanup code.
+	}
+
+	// Cluster and mount hosts
+	if clusterEntry, found := db.Clusters[v.Info.Cluster]; !found {
+		inconsistencies = append(inconsistencies, fmt.Sprintf("Volume %v unknown cluster %v", v.Info.Id, v.Info.Cluster))
+		consistent = false
+	} else {
+		if !sortedstrings.Has(clusterEntry.Info.Volumes, v.Info.Id) {
+			inconsistencies = append(inconsistencies, fmt.Sprintf("Volume %v no link back to volume from cluster %v", v.Info.Id, v.Info.Cluster))
+			consistent = false
+		}
+		if len(v.Info.Mount.GlusterFS.Hosts) != len(clusterEntry.Info.Nodes) {
+			inconsistencies = append(inconsistencies, fmt.Sprintf("Volume %v mount hosts list(%v) is not same as list of all nodes of the cluster(%v)", v.Info.Id, v.Info.Mount.GlusterFS.Hosts, clusterEntry.Info.Nodes))
+			consistent = false
+		}
+		// TODO: I should probably match the IPs of the mount hosts to that of storage hostnames but not sure if it is worth it.
+	}
+
+	// Bricks
+	for _, brick := range v.Bricks {
+		if brickEntry, found := db.Bricks[brick]; !found {
+			inconsistencies = append(inconsistencies, fmt.Sprintf("Volume %v unknown brick %v", v.Info.Id, brick))
+			consistent = false
+		} else {
+			if brickEntry.Info.VolumeId != v.Info.Id {
+				inconsistencies = append(inconsistencies, fmt.Sprintf("Volume %v no link back to volume from brick %v", v.Info.Id, brick))
+				consistent = false
+			}
+		}
+	}
+
+	// BlockVolumes and sizes
+	for _, blockVolume := range v.Info.BlockInfo.BlockVolumes {
+		if blockVolumeEntry, found := db.BlockVolumes[blockVolume]; !found {
+			inconsistencies = append(inconsistencies, fmt.Sprintf("Volume %v unknown blockvolume %v", v.Info.Id, blockVolume))
+			consistent = false
+		} else {
+			if blockVolumeEntry.Info.BlockHostingVolume != v.Info.Id {
+				inconsistencies = append(inconsistencies, fmt.Sprintf("Volume %v no link back to volume from blockvolume %v", v.Info.Id, blockVolume))
+				consistent = false
+			}
+			aggregateBlockVolumesSize += blockVolumeEntry.Info.Size
+		}
+	}
+	if v.Info.Block == true {
+		if aggregateBlockVolumesSize != v.Info.Size-v.Info.BlockInfo.FreeSize-v.Info.BlockInfo.ReservedSize {
+			inconsistencies = append(inconsistencies,
+				fmt.Sprintf("Volume %v blocksize differs aggregateSize %v != volumeSize %v - freeSize %v - reservedSize %v",
+					v.Info.Id, aggregateBlockVolumesSize, v.Info.Size, v.Info.BlockInfo.FreeSize, v.Info.BlockInfo.ReservedSize))
+			consistent = false
+		}
+	} else if aggregateBlockVolumesSize != 0 {
+		inconsistencies = append(inconsistencies, fmt.Sprintf("Volume %v has blockvolumes but not block flag", v.Info.Id))
+		consistent = false
+	}
+
+	return
+
+}

--- a/client/api/go-client/db.go
+++ b/client/api/go-client/db.go
@@ -50,3 +50,35 @@ func (c *Client) DbDump() (string, error) {
 	respJSON := string(respBytes)
 	return respJSON, nil
 }
+
+// DbCheck provides a JSON summary of the DB check operation
+func (c *Client) DbCheck() (string, error) {
+	req, err := http.NewRequest("GET", c.host+"/db/check", nil)
+	if err != nil {
+		return "", err
+	}
+
+	// Set token
+	err = c.setToken(req)
+	if err != nil {
+		return "", err
+	}
+
+	// Send request
+	r, err := c.do(req)
+	if err != nil {
+		return "", err
+	}
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		return "", utils.GetErrorFromResponse(r)
+	}
+
+	respBytes, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return "", err
+	}
+
+	respJSON := string(respBytes)
+	return respJSON, nil
+}

--- a/client/cli/go/cmds/db.go
+++ b/client/cli/go/cmds/db.go
@@ -19,6 +19,8 @@ func init() {
 	RootCmd.AddCommand(dbCommand)
 	dbCommand.AddCommand(dumpDbCommand)
 	dumpDbCommand.SilenceUsage = true
+	dbCommand.AddCommand(checkDbCommand)
+	checkDbCommand.SilenceUsage = true
 }
 
 var dbCommand = &cobra.Command{
@@ -44,6 +46,28 @@ var dumpDbCommand = &cobra.Command{
 		}
 
 		fmt.Fprintf(stdout, dump)
+
+		return nil
+	},
+}
+
+var checkDbCommand = &cobra.Command{
+	Use:     "check",
+	Short:   "checks the db and provides a summary in json format",
+	Long:    "checks the db and provides a summary in json format",
+	Example: "  $ heketi-cli db check",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
+
+		checkResponse, err := heketi.DbCheck()
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(stdout, checkResponse)
 
 		return nil
 	},

--- a/main.go
+++ b/main.go
@@ -132,6 +132,28 @@ var exportdbCmd = &cobra.Command{
 	},
 }
 
+var checkdbCmd = &cobra.Command{
+	Use:     "consistency-check",
+	Short:   "checks the db for inconsistencies",
+	Long:    "checks the db for inconsistencies",
+	Example: "heketi db consistency-check --dbfile=/db/file/path/",
+	Run: func(cmd *cobra.Command, args []string) {
+		if dbFile == "" {
+			fmt.Fprintln(os.Stderr, "Please provide path for db file")
+			os.Exit(1)
+		}
+		if debugOutput {
+			glusterfs.SetLogLevel("debug")
+		}
+		err := glusterfs.DbCheck(dbFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to check db: %v\n", err.Error())
+			os.Exit(1)
+		}
+		os.Exit(0)
+	},
+}
+
 var deleteBricksWithEmptyPath = &cobra.Command{
 	Use:     "delete-bricks-with-empty-path",
 	Short:   "removes brick entries from db that have empty path",
@@ -240,6 +262,11 @@ func init() {
 	exportdbCmd.Flags().StringVar(&jsonFile, "jsonfile", "", "File path for JSON file to be created")
 	exportdbCmd.Flags().BoolVar(&debugOutput, "debug", false, "Show debug logs on stdout")
 	exportdbCmd.SilenceUsage = true
+
+	dbCmd.AddCommand(checkdbCmd)
+	checkdbCmd.Flags().StringVar(&dbFile, "dbfile", "", "File path for db to be exported")
+	checkdbCmd.Flags().BoolVar(&debugOutput, "debug", false, "Show debug logs on stdout")
+	checkdbCmd.SilenceUsage = true
 
 	dbCmd.AddCommand(deleteBricksWithEmptyPath)
 	deleteBricksWithEmptyPath.Flags().StringVar(&dbFile, "dbfile", "", "File path for db to operate on")


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
This PR implements consistency check for heketi db. The check can be performed in both offline and online mode. In online mode, a cli command or a REST call can be made to a heketi server. In offline version, `db check` subcommand is to be invoked for heketi binary with path to heketi.db. 

Consistency check only validates the information provided in the database and does not validate it against *real* state on the Gluster nodes and/or Kubernetes/Openshift.

### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->


### Notes for the reviewer
I did not find any value in making a version of this which takes a JSON file representing heketi database as input. Such scenarios can be handled by using the `db import` command first and then invoking a `db check` command later.

