### PR TITLE
apps: fix gofmt error found by go 1.11

### DIFF
--- a/apps/glusterfs/app_test.go
+++ b/apps/glusterfs/app_test.go
@@ -183,6 +183,7 @@ func TestAppBlockSettings(t *testing.T) {
 		Executor:  "crazyexec",
 		Allocator: "simple",
 		DBfile:    "/path/to/nonexistent/heketi.db",
+		// this comment should make gofmt happy in versions >= 1.11 and <= 1.10
 		CreateBlockHostingVolumes: true,
 		BlockHostingVolumeSize:    500,
 	}


### PR DESCRIPTION
Go 1.11 (on fedora 29) found this formatting error.