### PR TITLE
funtional tests: run TestErrorHandling by default

### DIFF
--- a/tests/functional/run.sh
+++ b/tests/functional/run.sh
@@ -50,6 +50,7 @@ if [[ "${#TESTS[@]}" -eq 0 ]]; then
 	TESTS+=("TestManyBricksVolume")
 	TESTS+=("TestUpgrade")
 	TESTS+=("TestEnabledTLS")
+	TESTS+=("TestErrorHandling")
 fi
 
 # install glide


### PR DESCRIPTION
I found that the error handling tests were not run at all in the functional test runs... Fix this!