### PR TITLE
IO Alignment improvements

### DIFF
--- a/etc/heketi.json
+++ b/etc/heketi.json
@@ -52,6 +52,7 @@
       "user": "sshuser",
       "port": "Optional: ssh port.  Default is 22",
       "fstab": "Optional: Specify fstab file on node.  Default is /etc/fstab",
+      "pv_data_alignment": "Optional: Specify PV data alignment size. Default is 256K",
       "backup_lvm_metadata": false,
       "gluster_cli_timeout": "Optional: Timeout, in seconds, passed to the gluster cli invocations"
     },
@@ -65,6 +66,7 @@
       "password": "password for kubernetes user",
       "namespace": "OpenShift project or Kubernetes namespace",
       "fstab": "Optional: Specify fstab file on node.  Default is /etc/fstab",
+      "pv_data_alignment": "Optional: Specify PV data alignment size. Default is 256K",
       "backup_lvm_metadata": false,
       "gluster_cli_timeout": "Optional: Timeout, in seconds, passed to the gluster cli invocations"
     },

--- a/etc/heketi.json
+++ b/etc/heketi.json
@@ -53,6 +53,10 @@
       "port": "Optional: ssh port.  Default is 22",
       "fstab": "Optional: Specify fstab file on node.  Default is /etc/fstab",
       "pv_data_alignment": "Optional: Specify PV data alignment size. Default is 256K",
+      "vg_physicalextentsize": "Optional: Specify VG physical extent size. Default is 4MB",
+      "lv_chunksize": "Optional: Specify LV chunksize. Default is 256K",
+      "xfs_sw": "Optional: Specify number of data disks in the underlying RAID device",
+      "xfs_su": "Optional: Specifies a stripe unit or RAID chunk size.",
       "backup_lvm_metadata": false,
       "gluster_cli_timeout": "Optional: Timeout, in seconds, passed to the gluster cli invocations"
     },
@@ -67,6 +71,10 @@
       "namespace": "OpenShift project or Kubernetes namespace",
       "fstab": "Optional: Specify fstab file on node.  Default is /etc/fstab",
       "pv_data_alignment": "Optional: Specify PV data alignment size. Default is 256K",
+      "vg_physicalextentsize": "Optional: Specify VG physical extent size. Default is 4MB",
+      "lv_chunksize": "Optional: Specify LV chunksize. Default is 256K",
+      "xfs_sw": "Optional: Specify number of data disks in the underlying RAID device.",
+      "xfs_su": "Optional: Specifies a stripe unit or RAID chunk size.",
       "backup_lvm_metadata": false,
       "gluster_cli_timeout": "Optional: Timeout, in seconds, passed to the gluster cli invocations"
     },

--- a/executors/cmdexec/cmdexec.go
+++ b/executors/cmdexec/cmdexec.go
@@ -29,6 +29,10 @@ type RemoteCommandTransport interface {
 	SnapShotLimit() int
 	GlusterCliTimeout() uint32
 	PVDataAlignment() string
+	VGPhysicalExtentSize() string
+	LVChunkSize() string
+	XfsSw() int
+	XfsSu() int
 }
 
 type CmdExecutor struct {
@@ -141,4 +145,26 @@ func (c *CmdExecutor) PVDataAlignment() string {
 		return "256K"
 	}
 	return c.config.PVDataAlignment
+}
+
+func (c *CmdExecutor) VGPhysicalExtentSize() string {
+	if c.config.VGPhysicalExtentSize == "" {
+		return "4M"
+	}
+	return c.config.VGPhysicalExtentSize
+}
+
+func (c *CmdExecutor) LVChunkSize() string {
+	if c.config.LVChunkSize == "" {
+		return "256K"
+	}
+	return c.config.LVChunkSize
+}
+
+func (c *CmdExecutor) XfsSw() int {
+	return c.config.XfsSw
+}
+
+func (c *CmdExecutor) XfsSu() int {
+	return c.config.XfsSu
 }

--- a/executors/cmdexec/cmdexec.go
+++ b/executors/cmdexec/cmdexec.go
@@ -28,6 +28,7 @@ type RemoteCommandTransport interface {
 	RebalanceOnExpansion() bool
 	SnapShotLimit() int
 	GlusterCliTimeout() uint32
+	PVDataAlignment() string
 }
 
 type CmdExecutor struct {
@@ -133,4 +134,11 @@ func (c *CmdExecutor) GlusterCliExecTimeout() int {
 	}
 
 	return timeout
+}
+
+func (c *CmdExecutor) PVDataAlignment() string {
+	if c.config.PVDataAlignment == "" {
+		return "256K"
+	}
+	return c.config.PVDataAlignment
 }

--- a/executors/cmdexec/config.go
+++ b/executors/cmdexec/config.go
@@ -17,4 +17,8 @@ type CmdConfig struct {
 	BackupLVM            bool   `json:"backup_lvm_metadata"`
 	GlusterCliTimeout    uint32 `json:"gluster_cli_timeout"`
 	PVDataAlignment      string `json:"pv_data_alignment"`
+	VGPhysicalExtentSize string `json:"vg_physicalextentsize"`
+	LVChunkSize          string `json:"lv_chunksize"`
+	XfsSw                int    `json:"xfs_sw"`
+	XfsSu                int    `json:"xfs_su"`
 }

--- a/executors/cmdexec/config.go
+++ b/executors/cmdexec/config.go
@@ -16,4 +16,5 @@ type CmdConfig struct {
 	RebalanceOnExpansion bool   `json:"rebalance_on_expansion"`
 	BackupLVM            bool   `json:"backup_lvm_metadata"`
 	GlusterCliTimeout    uint32 `json:"gluster_cli_timeout"`
+	PVDataAlignment      string `json:"pv_data_alignment"`
 }

--- a/executors/cmdexec/device.go
+++ b/executors/cmdexec/device.go
@@ -43,7 +43,7 @@ func (s *CmdExecutor) DeviceSetup(host, device, vgid string, destroy bool) (d *e
 		logger.Info("Data on device %v (host %v) will be destroyed", device, host)
 		commands = append(commands, fmt.Sprintf("wipefs --all %v", device))
 	}
-	commands = append(commands, fmt.Sprintf("pvcreate -qq --metadatasize=128M --dataalignment=256K '%v'", device))
+	commands = append(commands, fmt.Sprintf("pvcreate -qq --metadatasize=128M --dataalignment=%v '%v'", s.config.PVDataAlignment, device))
 	commands = append(commands, fmt.Sprintf("vgcreate -qq --autobackup=%v %v %v", conv.BoolToYN(s.BackupLVM), paths.VgIdToName(vgid), device))
 
 	// Execute command

--- a/executors/cmdexec/device.go
+++ b/executors/cmdexec/device.go
@@ -43,8 +43,18 @@ func (s *CmdExecutor) DeviceSetup(host, device, vgid string, destroy bool) (d *e
 		logger.Info("Data on device %v (host %v) will be destroyed", device, host)
 		commands = append(commands, fmt.Sprintf("wipefs --all %v", device))
 	}
-	commands = append(commands, fmt.Sprintf("pvcreate -qq --metadatasize=128M --dataalignment=%v '%v'", s.config.PVDataAlignment, device))
-	commands = append(commands, fmt.Sprintf("vgcreate -qq --autobackup=%v %v %v", conv.BoolToYN(s.BackupLVM), paths.VgIdToName(vgid), device))
+	commands = append(commands, fmt.Sprintf("pvcreate -qq --metadatasize=128M --dataalignment=%v '%v'", s.PVDataAlignment(), device))
+	commands = append(commands, fmt.Sprintf("vgcreate -qq --physicalextentsize=%v --autobackup=%v %v %v",
+
+		// Physical extent size
+		s.VGPhysicalExtentSize(),
+
+		// Autobackup
+		conv.BoolToYN(s.BackupLVM),
+
+		// Device
+		paths.VgIdToName(vgid), device),
+	)
 
 	// Execute command
 	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 5))

--- a/executors/cmdexec/fakeexec_test.go
+++ b/executors/cmdexec/fakeexec_test.go
@@ -44,6 +44,9 @@ func NewFakeExecutor(f *CommandFaker) (*FakeExecutor, error) {
 	t.RemoteExecutor = t
 	config := &CmdConfig{}
 	config.GlusterCliTimeout = 42
+	config.LVChunkSize = "256K"
+	config.XfsSu = 0
+	config.XfsSw = 0
 	t.CmdExecutor.Init(config)
 	t.fake = f
 	t.Fstab = "/my/fstab"

--- a/executors/injectexec/transport.go
+++ b/executors/injectexec/transport.go
@@ -56,6 +56,10 @@ func (w *WrapCommandTransport) GlusterCliTimeout() uint32 {
 	return w.Transport.GlusterCliTimeout()
 }
 
+func (w *WrapCommandTransport) PVDataAlignment() string {
+	return w.Transport.PVDataAlignment()
+}
+
 // Before calls the WrapCommandTransport's handleBefore function
 // if one is set. If the command was handled the and no additional
 // processing of the command is needed the first return value will

--- a/executors/injectexec/transport.go
+++ b/executors/injectexec/transport.go
@@ -60,6 +60,22 @@ func (w *WrapCommandTransport) PVDataAlignment() string {
 	return w.Transport.PVDataAlignment()
 }
 
+func (w *WrapCommandTransport) VGPhysicalExtentSize() string {
+	return w.Transport.VGPhysicalExtentSize()
+}
+
+func (w *WrapCommandTransport) LVChunkSize() string {
+	return w.Transport.LVChunkSize()
+}
+
+func (w *WrapCommandTransport) XfsSw() int {
+	return w.Transport.XfsSw()
+}
+
+func (w *WrapCommandTransport) XfsSu() int {
+	return w.Transport.XfsSu()
+}
+
 // Before calls the WrapCommandTransport's handleBefore function
 // if one is set. If the command was handled the and no additional
 // processing of the command is needed the first return value will

--- a/executors/injectexec/transport_test.go
+++ b/executors/injectexec/transport_test.go
@@ -22,6 +22,7 @@ type DummyTransport struct {
 	snapShotLimit int
 	rebalance     bool
 	cliTimeout    uint32
+	dataAlignment string
 }
 
 func (d *DummyTransport) ExecCommands(
@@ -45,6 +46,10 @@ func (d *DummyTransport) SnapShotLimit() int {
 
 func (d *DummyTransport) GlusterCliTimeout() uint32 {
 	return d.cliTimeout
+}
+
+func (d *DummyTransport) PVDataAlignment() string {
+	return d.dataAlignment
 }
 
 func TestWrapCommandTransport(t *testing.T) {

--- a/executors/injectexec/transport_test.go
+++ b/executors/injectexec/transport_test.go
@@ -19,10 +19,14 @@ import (
 )
 
 type DummyTransport struct {
-	snapShotLimit int
-	rebalance     bool
-	cliTimeout    uint32
-	dataAlignment string
+	snapShotLimit      int
+	rebalance          bool
+	cliTimeout         uint32
+	dataAlignment      string
+	physicalExtentSize string
+	chunkSize          string
+	xfsSw              int
+	xfsSu              int
 }
 
 func (d *DummyTransport) ExecCommands(
@@ -50,6 +54,22 @@ func (d *DummyTransport) GlusterCliTimeout() uint32 {
 
 func (d *DummyTransport) PVDataAlignment() string {
 	return d.dataAlignment
+}
+
+func (d *DummyTransport) VGPhysicalExtentSize() string {
+	return d.physicalExtentSize
+}
+
+func (d *DummyTransport) LVChunkSize() string {
+	return d.chunkSize
+}
+
+func (d *DummyTransport) XfsSw() int {
+	return d.xfsSw
+}
+
+func (d *DummyTransport) XfsSu() int {
+	return d.xfsSu
 }
 
 func TestWrapCommandTransport(t *testing.T) {


### PR DESCRIPTION
IO alignment should be configurable for RAID based architectures as stated by GlusterFS docs. This PR is intended to add a set of configurable flags relative to the LVM stack and XFS which allow to configure IO alignment properly. 
All of these flags are not required so current deployments would not be affected.