### PR TITLE
Diagnostics: examine gluster

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -621,6 +621,13 @@ func (a *App) SetRoutes(router *mux.Router) error {
 			Method:      "POST",
 			Pattern:     "/operations/pending/cleanup",
 			HandlerFunc: a.PendingOperationCleanUp},
+
+		// State examination
+		rest.Route{
+			Name:        "ExamineGluster",
+			Method:      "GET",
+			Pattern:     "/internal/state/examine/gluster",
+			HandlerFunc: a.ExamineGluster},
 	}
 
 	// Register all routes from the App
@@ -729,6 +736,17 @@ func (a *App) OnDemandCleaner(ops map[string]bool) OperationCleaner {
 		sel:       sel,
 		optracker: a.optracker,
 		opClass:   TrackNormal,
+	}
+}
+
+// OnDemandExaminer returns an examiner based on the current
+// app object that can be used to examine state on user demand.
+func (a *App) OnDemandExaminer() Examiner {
+	return Examiner{
+		db:        a.db,
+		executor:  a.executor,
+		optracker: a.optracker,
+		mode:      OnDemandExaminer,
 	}
 }
 

--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -702,6 +702,18 @@ func (a *App) OfflineCleaner() OperationCleaner {
 	}
 }
 
+// OfflineExaminer returns an examiner based on the current
+// app object that can be used to perform an offline examination.
+// An offline examiner assumes that the binary is only doing examination of the
+// state and nothing else.
+func (a *App) OfflineExaminer() Examiner {
+	return Examiner{
+		db:       a.db,
+		executor: a.executor,
+		mode:     OfflineExaminer,
+	}
+}
+
 // OnDemandCleaner returns an operations cleaner based on the current
 // app object that can be used to perform clean ups requested by
 // a user (on demand).

--- a/apps/glusterfs/app_db.go
+++ b/apps/glusterfs/app_db.go
@@ -26,7 +26,9 @@ func (a *App) DbDump(w http.ResponseWriter, r *http.Request) {
 	// Write msg
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(dump); err != nil {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "    ")
+	if err := encoder.Encode(dump); err != nil {
 		panic(err)
 	}
 }

--- a/apps/glusterfs/app_examiner.go
+++ b/apps/glusterfs/app_examiner.go
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// ExamineGluster ... Compares the state of heketi db with the state of Gluster
+// This is the variant to be called via the API and running in the App
+func (a *App) ExamineGluster(w http.ResponseWriter, r *http.Request) {
+
+	response, err := a.OnDemandExaminer().ExamineGluster()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Write msg
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "    ")
+	if err := encoder.Encode(response); err != nil {
+		panic(err)
+	}
+}

--- a/apps/glusterfs/db_operations.go
+++ b/apps/glusterfs/db_operations.go
@@ -16,10 +16,11 @@ import (
 	"strings"
 
 	"github.com/boltdb/bolt"
+	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 )
 
-func dbDumpInternal(db *bolt.DB) (Db, error) {
+func dbDumpInternal(db wdb.DB) (Db, error) {
 	var dump Db
 	clusterEntryList := make(map[string]ClusterEntry, 0)
 	volEntryList := make(map[string]VolumeEntry, 0)
@@ -383,7 +384,7 @@ func DbCreate(jsonfile string, dbfile string) error {
 	return nil
 }
 
-func DeleteBricksWithEmptyPath(db *bolt.DB, all bool, clusterIDs []string, nodeIDs []string, deviceIDs []string) error {
+func DeleteBricksWithEmptyPath(db wdb.DB, all bool, clusterIDs []string, nodeIDs []string, deviceIDs []string) error {
 
 	for _, id := range clusterIDs {
 		if err := api.ValidateUUID(id); err != nil {

--- a/apps/glusterfs/examiner.go
+++ b/apps/glusterfs/examiner.go
@@ -1,0 +1,153 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/boltdb/bolt"
+	"github.com/heketi/heketi/executors"
+)
+
+type ExaminerMode string
+
+const (
+	OnDemandExaminer ExaminerMode = "ondemand"
+	OfflineExaminer  ExaminerMode = "offline"
+)
+
+type Examiner struct {
+	db        *bolt.DB
+	executor  executors.Executor
+	optracker *OpTracker
+	mode      ExaminerMode
+}
+
+type NodeData struct {
+	NodeHeketiID string
+	VolumeInfo   *executors.VolInfo
+}
+
+type ClusterData struct {
+	ClusterHeketiID string
+	NodesData       []NodeData
+}
+
+type GlusterStateExaminationResponse struct {
+	HeketiDB Db            `json:"heketidb"`
+	Report   []string      `json:"report"`
+	Clusters []ClusterData `json:"clusters"`
+}
+
+func (examiner Examiner) fetchClusterData(cluster ClusterEntry, heketidb Db) (clusterdata ClusterData, errorstrings []string) {
+
+	clusterdata.ClusterHeketiID = cluster.Info.Id
+
+	for _, node := range cluster.Info.Nodes {
+		nodeEntry := heketidb.Nodes[node]
+		var nodedata NodeData
+		nodedata.NodeHeketiID = nodeEntry.Info.Id
+
+		// Volume Info
+		volinfo, err := examiner.executor.VolumesInfo(nodeEntry.ManageHostName())
+		if err != nil {
+			errorstrings = append(errorstrings, fmt.Sprintf("could not fetch data from node %v", nodeEntry.ManageHostName()))
+		} else {
+			nodedata.VolumeInfo = volinfo
+		}
+
+		// Append whatever information we could gather, minimum is the node ID
+		clusterdata.NodesData = append(clusterdata.NodesData, nodedata)
+	}
+
+	return
+
+}
+
+func matchVolumes(heketidb Db, cdata ClusterData) (errorstrings []string) {
+
+	var heketiVolList []string
+
+	for _, volume := range heketidb.Clusters[cdata.ClusterHeketiID].Info.Volumes {
+		heketiVolList = append(heketiVolList, heketidb.Volumes[volume].Info.Name)
+	}
+
+	for _, node := range cdata.NodesData {
+		var volList []string
+		if node.VolumeInfo == nil {
+			errorstrings = append(errorstrings, fmt.Sprintf("heketi volume list could not be compared with volume list of node %v due to missing info", node.NodeHeketiID))
+			continue
+		}
+		for _, volume := range node.VolumeInfo.Volumes.VolumeList {
+			volList = append(volList, volume.VolumeName)
+		}
+		if !reflect.DeepEqual(heketiVolList, volList) {
+			errorstrings = append(errorstrings, fmt.Sprintf("heketi volume list does not match with volume list of node %v", node.NodeHeketiID))
+		}
+	}
+
+	return
+}
+
+func compareHeketiAndGluster(heketidb Db, cdata ClusterData) (errorstrings []string) {
+
+	matchErrors := matchVolumes(heketidb, cdata)
+	if matchErrors != nil {
+		errorstrings = append(errorstrings, matchErrors...)
+	} else {
+		errorstrings = append(errorstrings, fmt.Sprintf("heketi volume list matches with volume list of all nodes"))
+	}
+
+	return
+}
+
+// ExamineGluster ... fetches information about resources heketi is managing
+// from the database and then queries information for each of those resources.
+// It matches the information from heketi and Gluster resources and reports any
+// errors that are found.
+func (examiner Examiner) ExamineGluster() (response GlusterStateExaminationResponse, err error) {
+	logger.Debug("Examining Gluster")
+
+	if examiner.mode == OnDemandExaminer {
+		trackedOps := examiner.optracker.Get()
+		response.Report = append(response.Report, fmt.Sprintf("OnDemand Examiner invoked while %v ops are in flight", trackedOps))
+	}
+
+	// Fetch information from Heketi DB
+	response.HeketiDB, err = dbDumpInternal(examiner.db)
+	if err != nil {
+		response.Report = append(response.Report, fmt.Sprintf("not able to fetch dump of database"))
+		return
+	}
+
+	// Fetch information from Gluster
+	for _, clusterEntry := range response.HeketiDB.Clusters {
+		var clusterdata ClusterData
+		clusterdata.ClusterHeketiID = clusterEntry.Info.Id
+
+		clusterdata, fetcherrors := examiner.fetchClusterData(clusterEntry, response.HeketiDB)
+		if len(fetcherrors) > 0 {
+			response.Report = append(response.Report, fetcherrors...)
+		}
+		if len(clusterdata.NodesData) == 0 {
+			response.Report = append(response.Report, fmt.Sprintf("not able to fetch any data from cluster %v", clusterEntry.Info.Id))
+		}
+		response.Clusters = append(response.Clusters, clusterdata)
+
+		// Compare data
+		compareErrors := compareHeketiAndGluster(response.HeketiDB, clusterdata)
+		if len(compareErrors) > 0 {
+			response.Report = append(response.Report, compareErrors...)
+		}
+	}
+
+	return
+}

--- a/client/api/go-client/state.go
+++ b/client/api/go-client/state.go
@@ -1,0 +1,52 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
+//
+
+package client
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	"github.com/heketi/heketi/pkg/utils"
+)
+
+// StateExamineGluster provides a comparision of DB and Gluster
+func (c *Client) StateExamineGluster() (string, error) {
+	req, err := http.NewRequest("GET", c.host+"/internal/state/examine/gluster", nil)
+	if err != nil {
+		return "", err
+	}
+
+	// Set token
+	err = c.setToken(req)
+	if err != nil {
+		return "", err
+	}
+
+	// Send request
+	r, err := c.do(req)
+	if err != nil {
+		return "", err
+	}
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		return "", utils.GetErrorFromResponse(r)
+	}
+
+	respBytes, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return "", err
+	}
+
+	respJSON := string(respBytes)
+	return respJSON, nil
+}

--- a/client/cli/go/cmds/server.go
+++ b/client/cli/go/cmds/server.go
@@ -214,6 +214,41 @@ var setModeCommand = &cobra.Command{
 	},
 }
 
+var stateCommand = &cobra.Command{
+	Use:   "state",
+	Short: "View and/or modify state of server",
+	Long:  "View and/or modify state of server",
+}
+
+var stateExamineCommand = &cobra.Command{
+	Use:   "examine",
+	Short: "Compare state of server",
+	Long:  "Compare state of server",
+}
+
+var stateExamineGlusterCommand = &cobra.Command{
+	Use:     "gluster",
+	Short:   "Compare state of server with gluster",
+	Long:    "Compare state of server with gluster",
+	Example: `  $ heketi-cli server state examine gluster`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
+
+		result, err := heketi.StateExamineGluster()
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(stdout, "%v", result)
+
+		return nil
+
+	},
+}
+
 func init() {
 	RootCmd.AddCommand(serverCommand)
 	// operations command(s)
@@ -232,4 +267,11 @@ func init() {
 	getModeCommand.SilenceUsage = true
 	modeCommand.AddCommand(setModeCommand)
 	setModeCommand.SilenceUsage = true
+	// state command(s)
+	serverCommand.AddCommand(stateCommand)
+	stateCommand.SilenceUsage = true
+	stateCommand.AddCommand(stateExamineCommand)
+	stateExamineCommand.SilenceUsage = true
+	stateExamineCommand.AddCommand(stateExamineGlusterCommand)
+	stateExamineGlusterCommand.SilenceUsage = true
 }

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -27,6 +27,7 @@ type Executor interface {
 	VolumeExpand(host string, volume *VolumeRequest) (*Volume, error)
 	VolumeReplaceBrick(host string, volume string, oldBrick *BrickInfo, newBrick *BrickInfo) error
 	VolumeInfo(host string, volume string) (*Volume, error)
+	VolumesInfo(host string) (*VolInfo, error)
 	VolumeClone(host string, vsr *VolumeCloneRequest) (*Volume, error)
 	VolumeSnapshot(host string, vsr *VolumeSnapshotRequest) (*Snapshot, error)
 	SnapshotCloneVolume(host string, scr *SnapshotCloneRequest) (*Volume, error)

--- a/executors/injectexec/mock_base.go
+++ b/executors/injectexec/mock_base.go
@@ -62,6 +62,9 @@ func newMockBase() *mockexec.MockExecutor {
 	m.MockVolumeInfo = func(host string, volume string) (*executors.Volume, error) {
 		return nil, NotSupportedError
 	}
+	m.MockVolumesInfo = func(host string) (*executors.VolInfo, error) {
+		return nil, NotSupportedError
+	}
 	m.MockHealInfo = func(host string, volume string) (*executors.HealInfo, error) {
 		return nil, NotSupportedError
 	}

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -29,6 +29,7 @@ type MockExecutor struct {
 	MockVolumeDestroyCheck       func(host, volume string) error
 	MockVolumeReplaceBrick       func(host string, volume string, oldBrick *executors.BrickInfo, newBrick *executors.BrickInfo) error
 	MockVolumeInfo               func(host string, volume string) (*executors.Volume, error)
+	MockVolumesInfo              func(host string) (*executors.VolInfo, error)
 	MockVolumeClone              func(host string, volume *executors.VolumeCloneRequest) (*executors.Volume, error)
 	MockVolumeSnapshot           func(host string, volume *executors.VolumeSnapshotRequest) (*executors.Snapshot, error)
 	MockSnapshotCloneVolume      func(host string, volume *executors.SnapshotCloneRequest) (*executors.Volume, error)
@@ -123,6 +124,34 @@ func NewMockExecutor() (*MockExecutor, error) {
 			Bricks: Bricks,
 		}
 		return vinfo, nil
+	}
+
+	m.MockVolumesInfo = func(host string) (*executors.VolInfo, error) {
+		var bricks []executors.Brick
+		brick := executors.Brick{Name: host + ":/mockpath"}
+		bricks = append(bricks, brick)
+		brick = executors.Brick{Name: host + ":/mockpath"}
+		bricks = append(bricks, brick)
+		brick = executors.Brick{Name: host + ":/mockpath"}
+		bricks = append(bricks, brick)
+		Bricks := executors.Bricks{
+			BrickList: bricks,
+		}
+		vinfo := executors.Volume{
+			Bricks: Bricks,
+		}
+		volumelist := make([]executors.Volume, 0)
+		volumelist = append(volumelist, vinfo)
+		volumelist = append(volumelist, vinfo)
+
+		volumes := executors.Volumes{
+			Count:      2,
+			VolumeList: volumelist,
+		}
+		volinfo := &executors.VolInfo{
+			Volumes: volumes,
+		}
+		return volinfo, nil
 	}
 
 	m.MockVolumeSnapshot = func(host string, vsr *executors.VolumeSnapshotRequest) (*executors.Snapshot, error) {
@@ -255,6 +284,10 @@ func (m *MockExecutor) VolumeReplaceBrick(host string, volume string, oldBrick *
 
 func (m *MockExecutor) VolumeInfo(host string, volume string) (*executors.Volume, error) {
 	return m.MockVolumeInfo(host, volume)
+}
+
+func (m *MockExecutor) VolumesInfo(host string) (*executors.VolInfo, error) {
+	return m.MockVolumesInfo(host)
 }
 
 func (m *MockExecutor) VolumeClone(host string, vcr *executors.VolumeCloneRequest) (*executors.Volume, error) {

--- a/executors/stack/stack.go
+++ b/executors/stack/stack.go
@@ -186,6 +186,16 @@ func (es *ExecutorStack) VolumeInfo(host string, volume string) (*executors.Volu
 	return nil, NotSupportedError
 }
 
+func (es *ExecutorStack) VolumesInfo(host string) (*executors.VolInfo, error) {
+	for _, e := range es.executors {
+		v, err := e.VolumesInfo(host)
+		if err != NotSupportedError {
+			return v, err
+		}
+	}
+	return nil, NotSupportedError
+}
+
 func (es *ExecutorStack) HealInfo(host string, volume string) (*executors.HealInfo, error) {
 	for _, e := range es.executors {
 		hi, err := e.HealInfo(host, volume)

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ package main
 
 import (
 	crand "crypto/rand"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -243,6 +244,64 @@ var cleanupOperationsCmd = &cobra.Command{
 	},
 }
 
+var stateExamineCmd = &cobra.Command{
+	Use:   "examine",
+	Short: "compare heketi database with real state of backend/user systems",
+	Long:  "compare heketi database with real state of backend/user systems",
+}
+
+var stateCmd = &cobra.Command{
+	Use:   "state",
+	Short: "view or modify heketi's state",
+	Long:  "view or modify heketi's state",
+}
+
+var examineGlusterCmd = &cobra.Command{
+	Use:     "gluster",
+	Short:   "compare heketi database with state of Gluster",
+	Long:    "compare heketi database with state of Gluster",
+	Example: "heketi offline state examine gluster --config=keti.json",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Fprintf(os.Stdout, "OFFLINE COMMAND: Examine state of Gluster\n")
+		if configfile == "" {
+			fmt.Fprintf(os.Stderr, "Configuration file is required\n")
+			os.Exit(1)
+		}
+
+		// Read configuration
+		c, err := config.ReadConfig(configfile)
+		if err != nil {
+			os.Exit(1)
+		}
+
+		randSeed()
+		// option to not start the background node monitor?
+		// FIXME, this is a hacky way to disable this background activity
+		// c.GlusterFS.DisableMonitorGlusterNodes = true
+		// Never start the background cleaner when running
+		// an offline cleanup
+		c.GlusterFS.DisableBackgroundCleaner = true
+		app := setupApp(c)
+
+		fmt.Fprintf(os.Stdout, "Starting examiner now...\n")
+		response, err := app.OfflineExaminer().ExamineGluster()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to examine Gluster: %v\n", err)
+			os.Exit(1)
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "    ")
+
+		fmt.Fprintf(os.Stdout, "EXAMINER_OUTPUT_STARTS\n")
+		if err := enc.Encode(response); err != nil {
+			fmt.Fprintf(os.Stderr, "Could not encode dump as JSON: %v", err)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stdout, "EXAMINER_OUTPUT_ENDS\n")
+		os.Exit(0)
+	},
+}
+
 func init() {
 	RootCmd.Flags().StringVar(&configfile, "config", "", "Configuration file")
 	RootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "Show version")
@@ -283,6 +342,15 @@ func init() {
 	offlineCmd.AddCommand(cleanupOperationsCmd)
 	cleanupOperationsCmd.SilenceUsage = true
 	cleanupOperationsCmd.Flags().StringVar(&configfile, "config", "", "Configuration file")
+
+	offlineCmd.AddCommand(stateCmd)
+	stateCmd.SilenceUsage = true
+	stateCmd.AddCommand(stateExamineCmd)
+	stateExamineCmd.SilenceUsage = true
+	stateExamineCmd.AddCommand(examineGlusterCmd)
+	examineGlusterCmd.SilenceUsage = true
+	examineGlusterCmd.Flags().StringVar(&configfile, "config", "", "Configuration file")
+
 }
 
 func setWithEnvVariables(options *config.Config) {


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
This PR introduces diagnostics ability to heketi. 

Primarily, heketi provides a single command to fetch all the necessary information from Gluster to compare its database with the Gluster backend.

Further, it also performs some comparison between the two data sets to report problems and suggest fixes.

### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #


### Notes for the reviewer


