### PR TITLE
Fix db corruption from rollback

### DIFF
--- a/apps/glusterfs/brick_entry.go
+++ b/apps/glusterfs/brick_entry.go
@@ -386,6 +386,7 @@ func (b *BrickEntry) remove(tx *bolt.Tx, v *VolumeEntry) error {
 
 	// Delete brick from volume entry
 	v.BrickDelete(b.Info.Id)
+	err = v.Save(tx)
 	if err != nil {
 		logger.Err(err)
 		return err

--- a/apps/glusterfs/operations_manage.go
+++ b/apps/glusterfs/operations_manage.go
@@ -283,6 +283,7 @@ func retryOperation(o Operation,
 	}
 	if e := o.Rollback(executor); e != nil {
 		logger.LogError("%v Rollback error: %v", label, e)
+		markFailedIfSupported(o)
 	}
 	// if we exceeded our retries, pull the "real" error out
 	// of the retry error so we return that


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

The volume cleanup code (function expungeVolumeWithOp) used to re-read the volume entry from the DB instead of operating on the in-memory copy from the operation. Hence the in-memory copy of the volume-entry of the operation was still containig the list of brick-ids from the original attempt even after the completion of expungeVolumeWithOp().

In the case the cleanup was called from the rollback of a volume create operation, when the operation was retried, the next Build() process would just continue using the in-memory volume entry and add new bricks to the existing list instead of starting over from an empty list.  When the volume entry was saved to disk at the end of Build(), it would contain the new brick ids and the old brick ids. Those old brick ids did not point to existing brick entries, because those had been cleaned  up correctly in the rollback. Hence the database was rendered inconsistent.

This patch fixes this problem by having expungeVolumeWithOp() act on the volume entry from the operation instead of re-loading it from the database.


