### PR TITLE
Fix incorrect extra brick IDs on volume after retry

### DIFF
--- a/apps/glusterfs/brick_entry.go
+++ b/apps/glusterfs/brick_entry.go
@@ -386,6 +386,7 @@ func (b *BrickEntry) remove(tx *bolt.Tx, v *VolumeEntry) error {
 
 	// Delete brick from volume entry
 	v.BrickDelete(b.Info.Id)
+	err = v.Save(tx)
 	if err != nil {
 		logger.Err(err)
 		return err

--- a/apps/glusterfs/operations_block_volume.go
+++ b/apps/glusterfs/operations_block_volume.go
@@ -350,6 +350,7 @@ func (bvc *BlockVolumeCreateOperation) CleanDone() error {
 		if err != nil {
 			return err
 		}
+		bvc.bvol = bv // set in-memory copy to match db
 		hv, bricks, err := bvc.volAndBricks(txdb)
 		if err != nil {
 			return err

--- a/apps/glusterfs/operations_volume_test.go
+++ b/apps/glusterfs/operations_volume_test.go
@@ -527,6 +527,14 @@ func TestVolumeCreateOperationRetrying(t *testing.T) {
 		po, e := PendingOperationList(tx)
 		tests.Assert(t, e == nil, "expected e == nil, got", e)
 		tests.Assert(t, len(po) == 0, "expected len(po) == 0, got:", len(po))
+		vl, e := VolumeList(tx)
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, len(vl) == 1, "expected len(bl) == 1, got:", len(bl))
+		vol, e := NewVolumeEntryFromId(tx, vl[0])
+		tests.Assert(t, e == nil, "expected e == nil, got", e)
+		tests.Assert(t, vol.Info.Size == 1024)
+		tests.Assert(t, len(vol.Bricks) == 3,
+			"expected len(vol.Bricks) == 3, got:", len(vol.Bricks))
 		return nil
 	})
 }


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

The volume create operation would incorrectly leave multiple extra un-referencable brick IDs in the list if the create operation was internally retired. This set of changes fixes this situation.



### Notes for the reviewer
This is a counter proposal for PR #1472 

