### PR TITLE
Rtalur diagnostics examine gluster part2

### DIFF
--- a/apps/glusterfs/examiner.go
+++ b/apps/glusterfs/examiner.go
@@ -56,11 +56,12 @@ func (examiner Examiner) fetchClusterData(cluster ClusterEntry, heketidb Db) (cl
 		nodeEntry := heketidb.Nodes[node]
 		var nodedata NodeData
 		nodedata.NodeHeketiID = nodeEntry.Info.Id
+		host := nodeEntry.ManageHostName()
 
 		// Volume Info
-		volinfo, err := examiner.executor.VolumesInfo(nodeEntry.ManageHostName())
+		volinfo, err := examiner.executor.VolumesInfo(host)
 		if err != nil {
-			errorstrings = append(errorstrings, fmt.Sprintf("could not fetch data from node %v", nodeEntry.ManageHostName()))
+			errorstrings = append(errorstrings, fmt.Sprintf("could not fetch data from node %v", host))
 		} else {
 			nodedata.VolumeInfo = volinfo
 		}

--- a/executors/cmdexec/device.go
+++ b/executors/cmdexec/device.go
@@ -82,6 +82,26 @@ func (s *CmdExecutor) PVS(host string) (d *executors.PVSCommandOutput, e error) 
 	return &pvsCommandOutput, nil
 }
 
+func (s *CmdExecutor) VGS(host string) (d *executors.VGSCommandOutput, e error) {
+
+	// Setup commands
+	commands := []string{}
+
+	commands = append(commands, fmt.Sprintf("vgs --reportformat json --units k"))
+
+	results, err := s.RemoteExecutor.ExecCommands(host, commands,
+		s.GlusterCliExecTimeout())
+	if err := rex.AnyError(results, err); err != nil {
+		return nil, fmt.Errorf("Unable to get data for LVM VGs")
+	}
+	var vgsCommandOutput executors.VGSCommandOutput
+	err = json.Unmarshal([]byte(results[0].Output), &vgsCommandOutput)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to determine LVM VGs : %v", err)
+	}
+	return &vgsCommandOutput, nil
+}
+
 func (s *CmdExecutor) GetDeviceInfo(host, device, vgid string) (d *executors.DeviceInfo, e error) {
 	// Vg info
 	d = &executors.DeviceInfo{}

--- a/executors/cmdexec/device.go
+++ b/executors/cmdexec/device.go
@@ -102,6 +102,26 @@ func (s *CmdExecutor) VGS(host string) (d *executors.VGSCommandOutput, e error) 
 	return &vgsCommandOutput, nil
 }
 
+func (s *CmdExecutor) LVS(host string) (d *executors.LVSCommandOutput, e error) {
+
+	// Setup commands
+	commands := []string{}
+
+	commands = append(commands, fmt.Sprintf("lvs --reportformat json --units k"))
+
+	results, err := s.RemoteExecutor.ExecCommands(host, commands,
+		s.GlusterCliExecTimeout())
+	if err := rex.AnyError(results, err); err != nil {
+		return nil, fmt.Errorf("Unable to get data for LVM LVs")
+	}
+	var lvsCommandOutput executors.LVSCommandOutput
+	err = json.Unmarshal([]byte(results[0].Output), &lvsCommandOutput)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to determine LVM LVs : %v", err)
+	}
+	return &lvsCommandOutput, nil
+}
+
 func (s *CmdExecutor) GetDeviceInfo(host, device, vgid string) (d *executors.DeviceInfo, e error) {
 	// Vg info
 	d = &executors.DeviceInfo{}

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -41,6 +41,7 @@ type Executor interface {
 	VGS(host string) (*VGSCommandOutput, error)
 	LVS(host string) (*LVSCommandOutput, error)
 	GetBrickMountStatus(host string) (*BricksMountStatus, error)
+	ListBlockVolumes(host string, blockhostingvolume string) ([]string, error)
 }
 
 // Enumerate durability types

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -61,6 +61,19 @@ type PVSCommandOutput struct {
 	} `json:"report"`
 }
 
+type VGSCommandOutput struct {
+	VGSReport []struct {
+		VGS []struct {
+			VGName    string `json:"vg_name"`
+			PVCount   string `json:"pv_count:"`
+			LVCount   string `json:"lv_count"`
+			SnapCount string `json:"snap_count"`
+			VGAttr    string `json:"vg_attr"`
+			VGSize    string `json:"vg_size"`
+			VGFree    string `json:"vg_free"`
+		} `json:"vg"`
+	} `json:"report"`
+}
 // Returns the size of the device
 type DeviceInfo struct {
 	// Size in KB

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -40,6 +40,7 @@ type Executor interface {
 	PVS(host string) (*PVSCommandOutput, error)
 	VGS(host string) (*VGSCommandOutput, error)
 	LVS(host string) (*LVSCommandOutput, error)
+	GetBrickMountStatus(host string) (*BricksMountStatus, error)
 }
 
 // Enumerate durability types

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -74,6 +74,24 @@ type VGSCommandOutput struct {
 		} `json:"vg"`
 	} `json:"report"`
 }
+type LVSCommandOutput struct {
+	LVSReport []struct {
+		LVS []struct {
+			LVName          string `json:"lv_name"`
+			VGName          string `json:"vg_name"`
+			LVAttr          string `json:"lv_attr"`
+			LVSize          string `json:"lv_size"`
+			PoolLV          string `json:"pool_lv"`
+			Origin          string `json:"origin"`
+			DataPercent     string `json:"data_percent"`
+			MetaDataPercent string `json:"metadata_percent"`
+			MovePV          string `json:"move_pv"`
+			MirrorLog       string `json:"mirror_log"`
+			CopyPercent     string `json:"copy_percent"`
+			ConvertLV       string `json:"convert_lv"`
+		} `json:"lv"`
+	} `json:"report"`
+}
 // Returns the size of the device
 type DeviceInfo struct {
 	// Size in KB

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -38,6 +38,7 @@ type Executor interface {
 	BlockVolumeCreate(host string, blockVolume *BlockVolumeRequest) (*BlockVolumeInfo, error)
 	BlockVolumeDestroy(host string, blockHostingVolumeName string, blockVolumeName string) error
 	PVS(host string) (*PVSCommandOutput, error)
+	VGS(host string) (*VGSCommandOutput, error)
 }
 
 // Enumerate durability types

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -37,6 +37,7 @@ type Executor interface {
 	SetLogLevel(level string)
 	BlockVolumeCreate(host string, blockVolume *BlockVolumeRequest) (*BlockVolumeInfo, error)
 	BlockVolumeDestroy(host string, blockHostingVolumeName string, blockVolumeName string) error
+	PVS(host string) (*PVSCommandOutput, error)
 }
 
 // Enumerate durability types

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -39,6 +39,7 @@ type Executor interface {
 	BlockVolumeDestroy(host string, blockHostingVolumeName string, blockVolumeName string) error
 	PVS(host string) (*PVSCommandOutput, error)
 	VGS(host string) (*VGSCommandOutput, error)
+	LVS(host string) (*LVSCommandOutput, error)
 }
 
 // Enumerate durability types

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -92,6 +92,18 @@ type LVSCommandOutput struct {
 		} `json:"lv"`
 	} `json:"report"`
 }
+type BrickMountStatus struct {
+	Device       string
+	MountPoint   string
+	Type         string
+	MountOptions string
+	Mounted      bool
+}
+
+type BricksMountStatus struct {
+	Statuses []BrickMountStatus
+}
+
 // Returns the size of the device
 type DeviceInfo struct {
 	// Size in KB

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -48,6 +48,19 @@ const (
 	DurabilityDispersion
 )
 
+type PVSCommandOutput struct {
+	PVSReport []struct {
+		PVS []struct {
+			PVName string `json:"pv_name"`
+			VGName string `json:"vg_name"`
+			PVFmt  string `json:"pv_fmt"`
+			PVAttr string `json:"pv_attr"`
+			PVSize string `json:"pv_size"`
+			PVFree string `json:"pv_free"`
+		} `json:"pv"`
+	} `json:"report"`
+}
+
 // Returns the size of the device
 type DeviceInfo struct {
 	// Size in KB

--- a/executors/injectexec/mock_base.go
+++ b/executors/injectexec/mock_base.go
@@ -92,5 +92,8 @@ func newMockBase() *mockexec.MockExecutor {
 	m.MockPVS = func(host string) (*executors.PVSCommandOutput, error) {
 		return nil, NotSupportedError
 	}
+	m.MockVGS = func(host string) (*executors.VGSCommandOutput, error) {
+		return nil, NotSupportedError
+	}
 	return m
 }

--- a/executors/injectexec/mock_base.go
+++ b/executors/injectexec/mock_base.go
@@ -98,5 +98,8 @@ func newMockBase() *mockexec.MockExecutor {
 	m.MockLVS = func(host string) (*executors.LVSCommandOutput, error) {
 		return nil, NotSupportedError
 	}
+	m.MockGetBrickMountStatus = func(host string) (*executors.BricksMountStatus, error) {
+		return nil, NotSupportedError
+	}
 	return m
 }

--- a/executors/injectexec/mock_base.go
+++ b/executors/injectexec/mock_base.go
@@ -95,5 +95,8 @@ func newMockBase() *mockexec.MockExecutor {
 	m.MockVGS = func(host string) (*executors.VGSCommandOutput, error) {
 		return nil, NotSupportedError
 	}
+	m.MockLVS = func(host string) (*executors.LVSCommandOutput, error) {
+		return nil, NotSupportedError
+	}
 	return m
 }

--- a/executors/injectexec/mock_base.go
+++ b/executors/injectexec/mock_base.go
@@ -101,5 +101,8 @@ func newMockBase() *mockexec.MockExecutor {
 	m.MockGetBrickMountStatus = func(host string) (*executors.BricksMountStatus, error) {
 		return nil, NotSupportedError
 	}
+	m.MockListBlockVolumes = func(host string, blockhostingvolume string) ([]string, error) {
+		return nil, NotSupportedError
+	}
 	return m
 }

--- a/executors/injectexec/mock_base.go
+++ b/executors/injectexec/mock_base.go
@@ -89,6 +89,8 @@ func newMockBase() *mockexec.MockExecutor {
 	m.MockSnapshotDestroy = func(host string, snapshot string) error {
 		return NotSupportedError
 	}
-
+	m.MockPVS = func(host string) (*executors.PVSCommandOutput, error) {
+		return nil, NotSupportedError
+	}
 	return m
 }

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -39,6 +39,7 @@ type MockExecutor struct {
 	MockBlockVolumeCreate        func(host string, blockVolume *executors.BlockVolumeRequest) (*executors.BlockVolumeInfo, error)
 	MockBlockVolumeDestroy       func(host string, blockHostingVolumeName string, blockVolumeName string) error
 	MockPVS                      func(host string) (*executors.PVSCommandOutput, error)
+	MockVGS                      func(host string) (*executors.VGSCommandOutput, error)
 }
 
 func NewMockExecutor() (*MockExecutor, error) {
@@ -224,6 +225,10 @@ func NewMockExecutor() (*MockExecutor, error) {
 		return &executors.PVSCommandOutput{}, nil
 	}
 
+	m.MockVGS = func(host string) (*executors.VGSCommandOutput, error) {
+		return &executors.VGSCommandOutput{}, nil
+	}
+
 	return m, nil
 }
 
@@ -329,4 +334,8 @@ func (m *MockExecutor) BlockVolumeDestroy(host string, blockHostingVolumeName st
 
 func (m *MockExecutor) PVS(host string) (*executors.PVSCommandOutput, error) {
 	return m.MockPVS(host)
+}
+
+func (m *MockExecutor) VGS(host string) (*executors.VGSCommandOutput, error) {
+	return m.MockVGS(host)
 }

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -40,6 +40,7 @@ type MockExecutor struct {
 	MockBlockVolumeDestroy       func(host string, blockHostingVolumeName string, blockVolumeName string) error
 	MockPVS                      func(host string) (*executors.PVSCommandOutput, error)
 	MockVGS                      func(host string) (*executors.VGSCommandOutput, error)
+	MockLVS                      func(host string) (*executors.LVSCommandOutput, error)
 }
 
 func NewMockExecutor() (*MockExecutor, error) {
@@ -229,6 +230,10 @@ func NewMockExecutor() (*MockExecutor, error) {
 		return &executors.VGSCommandOutput{}, nil
 	}
 
+	m.MockLVS = func(host string) (*executors.LVSCommandOutput, error) {
+		return &executors.LVSCommandOutput{}, nil
+	}
+
 	return m, nil
 }
 
@@ -338,4 +343,8 @@ func (m *MockExecutor) PVS(host string) (*executors.PVSCommandOutput, error) {
 
 func (m *MockExecutor) VGS(host string) (*executors.VGSCommandOutput, error) {
 	return m.MockVGS(host)
+}
+
+func (m *MockExecutor) LVS(host string) (*executors.LVSCommandOutput, error) {
+	return m.MockLVS(host)
 }

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -42,6 +42,7 @@ type MockExecutor struct {
 	MockVGS                      func(host string) (*executors.VGSCommandOutput, error)
 	MockLVS                      func(host string) (*executors.LVSCommandOutput, error)
 	MockGetBrickMountStatus      func(host string) (*executors.BricksMountStatus, error)
+	MockListBlockVolumes         func(host string, blockhostingvolume string) ([]string, error)
 }
 
 func NewMockExecutor() (*MockExecutor, error) {
@@ -239,6 +240,10 @@ func NewMockExecutor() (*MockExecutor, error) {
 		return &executors.BricksMountStatus{}, nil
 	}
 
+	m.MockListBlockVolumes = func(host string, blockhostingvolume string) ([]string, error) {
+		return []string{}, nil
+	}
+
 	return m, nil
 }
 
@@ -356,4 +361,8 @@ func (m *MockExecutor) LVS(host string) (*executors.LVSCommandOutput, error) {
 
 func (m *MockExecutor) GetBrickMountStatus(host string) (*executors.BricksMountStatus, error) {
 	return m.MockGetBrickMountStatus(host)
+}
+
+func (m *MockExecutor) ListBlockVolumes(host string, blockhostingvolume string) ([]string, error) {
+	return m.MockListBlockVolumes(host, blockhostingvolume)
 }

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -38,6 +38,7 @@ type MockExecutor struct {
 	MockHealInfo                 func(host string, volume string) (*executors.HealInfo, error)
 	MockBlockVolumeCreate        func(host string, blockVolume *executors.BlockVolumeRequest) (*executors.BlockVolumeInfo, error)
 	MockBlockVolumeDestroy       func(host string, blockHostingVolumeName string, blockVolumeName string) error
+	MockPVS                      func(host string) (*executors.PVSCommandOutput, error)
 }
 
 func NewMockExecutor() (*MockExecutor, error) {
@@ -219,6 +220,10 @@ func NewMockExecutor() (*MockExecutor, error) {
 		return nil
 	}
 
+	m.MockPVS = func(host string) (*executors.PVSCommandOutput, error) {
+		return &executors.PVSCommandOutput{}, nil
+	}
+
 	return m, nil
 }
 
@@ -320,4 +325,8 @@ func (m *MockExecutor) BlockVolumeCreate(host string, blockVolume *executors.Blo
 
 func (m *MockExecutor) BlockVolumeDestroy(host string, blockHostingVolumeName string, blockVolumeName string) error {
 	return m.MockBlockVolumeDestroy(host, blockHostingVolumeName, blockVolumeName)
+}
+
+func (m *MockExecutor) PVS(host string) (*executors.PVSCommandOutput, error) {
+	return m.MockPVS(host)
 }

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -41,6 +41,7 @@ type MockExecutor struct {
 	MockPVS                      func(host string) (*executors.PVSCommandOutput, error)
 	MockVGS                      func(host string) (*executors.VGSCommandOutput, error)
 	MockLVS                      func(host string) (*executors.LVSCommandOutput, error)
+	MockGetBrickMountStatus      func(host string) (*executors.BricksMountStatus, error)
 }
 
 func NewMockExecutor() (*MockExecutor, error) {
@@ -234,6 +235,10 @@ func NewMockExecutor() (*MockExecutor, error) {
 		return &executors.LVSCommandOutput{}, nil
 	}
 
+	m.MockGetBrickMountStatus = func(host string) (*executors.BricksMountStatus, error) {
+		return &executors.BricksMountStatus{}, nil
+	}
+
 	return m, nil
 }
 
@@ -347,4 +352,8 @@ func (m *MockExecutor) VGS(host string) (*executors.VGSCommandOutput, error) {
 
 func (m *MockExecutor) LVS(host string) (*executors.LVSCommandOutput, error) {
 	return m.MockLVS(host)
+}
+
+func (m *MockExecutor) GetBrickMountStatus(host string) (*executors.BricksMountStatus, error) {
+	return m.MockGetBrickMountStatus(host)
 }

--- a/executors/stack/stack.go
+++ b/executors/stack/stack.go
@@ -291,3 +291,13 @@ func (es *ExecutorStack) SnapshotDestroy(
 	}
 	return NotSupportedError
 }
+
+func (es *ExecutorStack) PVS(host string) (*executors.PVSCommandOutput, error) {
+	for _, e := range es.executors {
+		v, err := e.PVS(host)
+		if err != NotSupportedError {
+			return v, err
+		}
+	}
+	return nil, NotSupportedError
+}

--- a/executors/stack/stack.go
+++ b/executors/stack/stack.go
@@ -331,3 +331,13 @@ func (es *ExecutorStack) GetBrickMountStatus(host string) (*executors.BricksMoun
 	}
 	return nil, NotSupportedError
 }
+
+func (es *ExecutorStack) ListBlockVolumes(host string, blockhostingvolume string) ([]string, error) {
+	for _, e := range es.executors {
+		v, err := e.ListBlockVolumes(host, blockhostingvolume)
+		if err != NotSupportedError {
+			return v, err
+		}
+	}
+	return nil, NotSupportedError
+}

--- a/executors/stack/stack.go
+++ b/executors/stack/stack.go
@@ -311,3 +311,13 @@ func (es *ExecutorStack) VGS(host string) (*executors.VGSCommandOutput, error) {
 	}
 	return nil, NotSupportedError
 }
+
+func (es *ExecutorStack) LVS(host string) (*executors.LVSCommandOutput, error) {
+	for _, e := range es.executors {
+		v, err := e.LVS(host)
+		if err != NotSupportedError {
+			return v, err
+		}
+	}
+	return nil, NotSupportedError
+}

--- a/executors/stack/stack.go
+++ b/executors/stack/stack.go
@@ -301,3 +301,13 @@ func (es *ExecutorStack) PVS(host string) (*executors.PVSCommandOutput, error) {
 	}
 	return nil, NotSupportedError
 }
+
+func (es *ExecutorStack) VGS(host string) (*executors.VGSCommandOutput, error) {
+	for _, e := range es.executors {
+		v, err := e.VGS(host)
+		if err != NotSupportedError {
+			return v, err
+		}
+	}
+	return nil, NotSupportedError
+}

--- a/executors/stack/stack.go
+++ b/executors/stack/stack.go
@@ -321,3 +321,13 @@ func (es *ExecutorStack) LVS(host string) (*executors.LVSCommandOutput, error) {
 	}
 	return nil, NotSupportedError
 }
+
+func (es *ExecutorStack) GetBrickMountStatus(host string) (*executors.BricksMountStatus, error) {
+	for _, e := range es.executors {
+		v, err := e.GetBrickMountStatus(host)
+		if err != NotSupportedError {
+			return v, err
+		}
+	}
+	return nil, NotSupportedError
+}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
This PR extends the diagnostics information that is fetched from Gluster nodes. Earlier, we collected information only about Gluster volumes. With this PR, we fetch information about devices, bricks and blockvolumes too.
