### PR TITLE
Metrics: convert device info from KiB to bytes

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -28,8 +28,6 @@ const (
 
 const (
 	KB uint64 = 1024
-	MB        = KB * 1024
-	GB        = MB * 1024
 )
 
 var (
@@ -201,7 +199,7 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 				ch <- prometheus.MustNewConstMetric(
 					deviceSizeInBytes,
 					prometheus.GaugeValue,
-					float64(device.Storage.Total*GB),
+					float64(device.Storage.Total*KB),
 					cluster.Id,
 					node.Hostnames.Manage[0],
 					device.Name,
@@ -209,14 +207,14 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 				ch <- prometheus.MustNewConstMetric(
 					deviceFreeInBytes,
 					prometheus.GaugeValue,
-					float64(device.Storage.Free*GB),
+					float64(device.Storage.Free*KB),
 					cluster.Id,
 					node.Hostnames.Manage[0],
 					device.Name,
 				)
 				ch <- prometheus.MustNewConstMetric(
 					deviceUsedInBytes, prometheus.GaugeValue,
-					float64(device.Storage.Used*GB),
+					float64(device.Storage.Used*KB),
 					cluster.Id,
 					node.Hostnames.Manage[0],
 					device.Name,


### PR DESCRIPTION
All the device information are stored in KiB format
updated the code to convert KiB to byte format.

sample output:
```
# HELP heketi_device_free Amount of Free space available on the device
# TYPE heketi_device_free gauge
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.100"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.101"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.102"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.103"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.100"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.101"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.102"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.103"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.100"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.101"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.102"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.103"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.100"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.101"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.102"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.103"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.100"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.101"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.102"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.103"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.100"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.101"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.102"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.103"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.100"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.101"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.102"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.103"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.100"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.101"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.102"} 5.24288e+08
heketi_device_free{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.103"} 5.24288e+08
# HELP heketi_device_free_bytes Amount of Free space available on the device in bytes
# TYPE heketi_device_free_bytes gauge
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.100"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.101"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.102"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.103"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.100"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.101"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.102"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.103"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.100"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.101"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.102"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.103"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.100"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.101"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.102"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.103"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.100"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.101"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.102"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.103"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.100"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.101"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.102"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.103"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.100"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.101"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.102"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.103"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.100"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.101"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.102"} 5.36870912e+11
heketi_device_free_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.103"} 5.36870912e+11
# HELP heketi_device_size Total size of the device
# TYPE heketi_device_size gauge
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.100"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.101"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.102"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.103"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.100"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.101"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.102"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.103"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.100"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.101"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.102"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.103"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.100"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.101"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.102"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.103"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.100"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.101"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.102"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.103"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.100"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.101"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.102"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.103"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.100"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.101"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.102"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.103"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.100"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.101"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.102"} 5.24288e+08
heketi_device_size{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.103"} 5.24288e+08
# HELP heketi_device_size_bytes Total size of the device in bytes
# TYPE heketi_device_size_bytes gauge
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.100"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.101"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.102"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.103"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.100"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.101"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.102"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.103"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.100"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.101"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.102"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.103"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.100"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.101"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.102"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.103"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.100"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.101"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.102"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.103"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.100"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.101"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.102"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.103"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.100"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.101"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.102"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.103"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.100"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.101"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.102"} 5.36870912e+11
heketi_device_size_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.103"} 5.36870912e+11
# HELP heketi_device_used Amount of space used on the device
# TYPE heketi_device_used gauge
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.100"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.101"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.102"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.103"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.100"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.101"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.102"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.103"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.100"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.101"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.102"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.103"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.100"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.101"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.102"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.103"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.100"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.101"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.102"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.103"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.100"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.101"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.102"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.103"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.100"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.101"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.102"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.103"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.100"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.101"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.102"} 0
heketi_device_used{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.103"} 0
# HELP heketi_device_used_bytes Amount of space used on the device in bytes
# TYPE heketi_device_used_bytes gauge
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.100"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.101"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.102"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdb",hostname="192.168.10.103"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.100"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.101"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.102"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdc",hostname="192.168.10.103"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.100"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.101"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.102"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdd",hostname="192.168.10.103"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.100"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.101"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.102"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sde",hostname="192.168.10.103"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.100"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.101"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.102"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdf",hostname="192.168.10.103"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.100"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.101"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.102"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdg",hostname="192.168.10.103"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.100"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.101"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.102"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdh",hostname="192.168.10.103"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.100"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.101"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.102"} 0
heketi_device_used_bytes{cluster="af7d9528db4f4ac00992dfaa0d05cbd9",device="/dev/sdi",hostname="192.168.10.103"} 0
```
```
Example:
device free size in bytes = 5.36870912e+11
                 in KiB = 524288000
                 in GiB = 500
```

Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>




