### PR TITLE
tests: use recommended method to install packages with ansible

### DIFF
--- a/tests/functional/TestErrorHandling/vagrant/roles/common/tasks/main.yml
+++ b/tests/functional/TestErrorHandling/vagrant/roles/common/tasks/main.yml
@@ -11,10 +11,11 @@
     - /dev/vdi
 
 - name: install repo source packages
-  yum: name={{ item }} state=present
-  with_items:
-    - epel-release
-    - centos-release-gluster41
+  yum:
+    name:
+      - epel-release
+      - centos-release-gluster41
+    state: present
 
 - name: copy private key
   copy: src=insecure_private_key owner=vagrant group=vagrant dest=/home/vagrant/.ssh/id_rsa force=no mode=0600

--- a/tests/functional/TestErrorHandling/vagrant/roles/gluster/tasks/main.yml
+++ b/tests/functional/TestErrorHandling/vagrant/roles/gluster/tasks/main.yml
@@ -1,9 +1,10 @@
 - name: install glusterfs, gluster-block
-  yum: name={{ item }} state=present
-  with_items:
-    - glusterfs-server
-    - glusterfs-client
-    - gluster-block
+  yum:
+    name:
+      - glusterfs-server
+      - glusterfs-client
+      - gluster-block
+    state: present
 
 - name: start glusterd, gluster-blockd
   service: name={{ item }} state=started enabled=yes

--- a/tests/functional/TestManyBricksVolume/vagrant/roles/common/tasks/main.yml
+++ b/tests/functional/TestManyBricksVolume/vagrant/roles/common/tasks/main.yml
@@ -13,10 +13,11 @@
     - /dev/vdk
 
 - name: install repo source packages
-  yum: name={{ item }} state=present
-  with_items:
-    - epel-release
-    - centos-release-gluster41
+  yum:
+    name:
+      - epel-release
+      - centos-release-gluster41
+    state: present
 
 - name: copy private key
   copy: src=insecure_private_key owner=vagrant group=vagrant dest=/home/vagrant/.ssh/id_rsa force=no mode=0600

--- a/tests/functional/TestManyBricksVolume/vagrant/roles/gluster/tasks/main.yml
+++ b/tests/functional/TestManyBricksVolume/vagrant/roles/gluster/tasks/main.yml
@@ -1,7 +1,8 @@
 - name: install glusterfs
-  yum: name={{ item }} state=present
-  with_items:
-    - glusterfs-server
+  yum:
+    name:
+      - glusterfs-server
+    state: present
 
 - name: start glusterd
   service: name=glusterd state=started enabled=yes

--- a/tests/functional/TestSmokeTest/vagrant/roles/common/tasks/main.yml
+++ b/tests/functional/TestSmokeTest/vagrant/roles/common/tasks/main.yml
@@ -11,10 +11,12 @@
     - /dev/vdi
 
 - name: install repo source packages
-  yum: name={{ item }} state=present
-  with_items:
-    - epel-release
-    - centos-release-gluster41
+  yum:
+    name:
+      - epel-release
+      - centos-release-gluster
+      - centos-release-gluster41
+    state: present
 
 - name: copy private key
   copy: src=insecure_private_key owner=vagrant group=vagrant dest=/home/vagrant/.ssh/id_rsa force=no mode=0600

--- a/tests/functional/TestSmokeTest/vagrant/roles/gluster/tasks/main.yml
+++ b/tests/functional/TestSmokeTest/vagrant/roles/gluster/tasks/main.yml
@@ -1,9 +1,10 @@
 - name: install glusterfs, gluster-block
-  yum: name={{ item }} state=present
-  with_items:
-    - glusterfs-server
-    - glusterfs-client
-    - gluster-block
+  yum:
+    name:
+      - glusterfs-server
+      - glusterfs-client
+      - gluster-block
+    state: present
 
 - name: start glusterd, gluster-blockd
   service: name={{ item }} state=started enabled=yes

--- a/tests/functional/TestVolumeNotDeletedWhenNodeIsDown/vagrant/roles/common/tasks/main.yml
+++ b/tests/functional/TestVolumeNotDeletedWhenNodeIsDown/vagrant/roles/common/tasks/main.yml
@@ -6,10 +6,11 @@
     - /dev/vdd
 
 - name: install repo source packages
-  yum: name={{ item }} state=present
-  with_items:
-    - epel-release
-    - centos-release-gluster41
+  yum:
+    name:
+      - epel-release
+      - centos-release-gluster41
+    state: present
 
 - name: copy private key
   copy: src=insecure_private_key owner=vagrant group=vagrant dest=/home/vagrant/.ssh/id_rsa force=no mode=0600

--- a/tests/functional/TestVolumeNotDeletedWhenNodeIsDown/vagrant/roles/gluster/tasks/main.yml
+++ b/tests/functional/TestVolumeNotDeletedWhenNodeIsDown/vagrant/roles/gluster/tasks/main.yml
@@ -1,7 +1,8 @@
 - name: install glusterfs
-  yum: name={{ item }} state=present
-  with_items:
-    - glusterfs-server
+  yum:
+    name:
+      - glusterfs-server
+    state: present
 
 - name: start glusterd
   service: name=glusterd state=started enabled=yes

--- a/tests/functional/TestVolumeSnapshotBehavior/vagrant/roles/common/tasks/main.yml
+++ b/tests/functional/TestVolumeSnapshotBehavior/vagrant/roles/common/tasks/main.yml
@@ -7,10 +7,11 @@
     - /dev/vde
 
 - name: install repo source packages
-  yum: name={{ item }} state=present
-  with_items:
-    - epel-release
-    - centos-release-gluster41
+  yum:
+    name:
+      - epel-release
+      - centos-release-gluster41
+    state: present
 
 - name: copy private key
   copy: src=insecure_private_key owner=vagrant group=vagrant dest=/home/vagrant/.ssh/id_rsa force=no mode=0600

--- a/tests/functional/TestVolumeSnapshotBehavior/vagrant/roles/gluster/tasks/main.yml
+++ b/tests/functional/TestVolumeSnapshotBehavior/vagrant/roles/gluster/tasks/main.yml
@@ -1,7 +1,8 @@
 - name: install glusterfs
-  yum: name={{ item }} state=present
-  with_items:
-    - glusterfs-server
+  yum:
+    name:
+      - glusterfs-server
+    state: present
 
 - name: start glusterd
   service: name=glusterd state=started enabled=yes


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

The following deprecation warning is reported when running the functional tests:

    [DEPRECATION WARNING]: Invoking "yum" only once while using a loop via
    squash_actions is deprecated. Instead of using a loop to supply multiple items
    and specifying `name: {{ item }}`, please use `name: ['epel-release', 'centos-
    release-gluster']` and remove the loop. This feature will be removed in version
     2.11. Deprecation warnings can be disabled by setting
    deprecation_warnings=False in ansible.cfg.

By modifying the task to install all packages without the loop, the warning does not get shown anymore.