### PR TITLE
logging: grab output of 'lsof /path/to/brick' in case unmounting fails

### DIFF
--- a/docs/admin/server.md
+++ b/docs/admin/server.md
@@ -27,6 +27,7 @@ The config file has information required to run the Heketi server.  The config f
         * fstab: _string_, Fstab file where to store mount points
         * backup_lvm_metadata: _bool_, Create archives of the LVM metadata when running vgcreate/lvcreate
         * sudo: _bool_, set to true when SSHing as a non root user
+	* debug_umount_failures: _bool_, Enable to capture more details in case brick unmounting fails. Can be overridden by the HEKETI_DEBUG_UMOUNT_FAILURES environment variable.
     * kubexec: _map_, Kubernetes configuration
         * host: _string_, Kubernetes API host.  Example `https://myhost:8443`.  Can also be use using environment variable HEKETI_KUBE_APIHOST
         * cert: _string_, Certificate file to for HTTPS connection. Can also be use using environment variable HEKETI_KUBE_CERTFILE
@@ -36,6 +37,7 @@ The config file has information required to run the Heketi server.  The config f
         * namespace: _string_, Kubernetes namespace or OpenShift project where GlusterFS containers/Pods are running. Can also be use using environment variable HEKETI_KUBE_NAMESPACE.
         * fstab: _string_, Fstab file where to store mount points
         * backup_lvm_metadata: _bool_, Create archives of the LVM metadata when running vgcreate/lvcreate
+	* debug_umount_failures: _bool_, Enable to capture more details in case brick unmounting fails. Can be overridden by the HEKETI_DEBUG_UMOUNT_FAILURES environment variable.
 
 ## Advanced Options
 The following configuration options should only be set on advanced configurations under `glusterfs` section:

--- a/etc/heketi.json
+++ b/etc/heketi.json
@@ -58,7 +58,9 @@
       "xfs_sw": "Optional: Specify number of data disks in the underlying RAID device",
       "xfs_su": "Optional: Specifies a stripe unit or RAID chunk size.",
       "backup_lvm_metadata": false,
-      "gluster_cli_timeout": "Optional: Timeout, in seconds, passed to the gluster cli invocations"
+      "gluster_cli_timeout": "Optional: Timeout, in seconds, passed to the gluster cli invocations",
+      "_debug_umount_failures": "Optional: boolean to capture more details in case brick unmounting fails",
+      "debug_umount_failures": true
     },
 
     "_kubeexec_comment": "Kubernetes configuration",
@@ -76,7 +78,9 @@
       "xfs_sw": "Optional: Specify number of data disks in the underlying RAID device.",
       "xfs_su": "Optional: Specifies a stripe unit or RAID chunk size.",
       "backup_lvm_metadata": false,
-      "gluster_cli_timeout": "Optional: Timeout, in seconds, passed to the gluster cli invocations"
+      "gluster_cli_timeout": "Optional: Timeout, in seconds, passed to the gluster cli invocations",
+      "_debug_umount_failures": "Optional: boolean to capture more details in case brick unmounting fails",
+      "debug_umount_failures": true
     },
 
     "_db_comment": "Database file name",

--- a/executors/cmdexec/brick.go
+++ b/executors/cmdexec/brick.go
@@ -192,6 +192,15 @@ func (s *CmdExecutor) BrickDestroy(host string,
 			logger.Warning("brick path [%v] not mounted, assuming deleted",
 				brick.Path)
 			umountErr = nil
+		} else {
+			if s.DebugUmountFailures() {
+				// in case unmounting failed, grab the output of 'lsof /path/to/brick'
+				commands = []string{
+					fmt.Sprintf("lsof %s", brick.Path),
+				}
+				res, _ = s.RemoteExecutor.ExecCommands(host, commands, 5)
+				logger.Warning("brick path [%s] kept open by:\n%s", brick.Path, res[0].Output)
+			}
 		}
 	}
 

--- a/executors/cmdexec/cmdexec.go
+++ b/executors/cmdexec/cmdexec.go
@@ -61,6 +61,16 @@ func setWithEnvVariables(config *CmdConfig) {
 			config.GlusterCliTimeout = uint32(value)
 		}
 	}
+
+	env = os.Getenv("HEKETI_DEBUG_UMOUNT_FAILURES")
+	if env != "" {
+		value, err := strconv.ParseBool(env)
+		if err != nil {
+			logger.LogError("Error: While parsing HEKETI_DEBUG_UMOUNT_FAILURES: %v", err)
+		} else {
+			config.DebugUmountFailures = value
+		}
+	}
 }
 
 func (c *CmdExecutor) Init(config *CmdConfig) {
@@ -167,4 +177,8 @@ func (c *CmdExecutor) XfsSw() int {
 
 func (c *CmdExecutor) XfsSu() int {
 	return c.config.XfsSu
+}
+
+func (c *CmdExecutor) DebugUmountFailures() bool {
+	return c.config.DebugUmountFailures
 }

--- a/executors/cmdexec/config.go
+++ b/executors/cmdexec/config.go
@@ -21,4 +21,5 @@ type CmdConfig struct {
 	LVChunkSize          string `json:"lv_chunksize"`
 	XfsSw                int    `json:"xfs_sw"`
 	XfsSu                int    `json:"xfs_su"`
+	DebugUmountFailures  bool   `json:"debug_umount_failures"`
 }


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

There are regular problems reported where Heketi fails to remove the bricks from a Gluster volume. This is most often caused by an open filedescriptor in one of the brick processes. Debugging this needs to be done in a timely fashion, as processes may get restarted and any trace
of the kept open file is removed.

By logging the output of 'lsof /path/to/brick' when unmounting fails, we should be able to find the filenames that the brick processes did not close when the Gluster volume got stopped and deleted.