### PR TITLE
Ensure pending volumes filter works on delete operations

### DIFF
--- a/apps/glusterfs/listing.go
+++ b/apps/glusterfs/listing.go
@@ -90,8 +90,12 @@ func UpdateClusterInfoComplete(tx *bolt.Tx, ci *api.ClusterInfoResponse) error {
 // an error if the db cannot be read.
 func MapPendingVolumes(tx *bolt.Tx) (map[string]string, error) {
 	return mapPendingItems(tx, func(op *PendingOperationEntry, a PendingOperationAction) bool {
-		return ((op.Type == OperationCreateVolume && a.Change == OpAddVolume) ||
-			(op.Type == OperationCreateBlockVolume && a.Change == OpAddVolume))
+		t := op.Type
+		c := a.Change
+		return ((t == OperationCreateVolume && c == OpAddVolume) ||
+			(t == OperationDeleteVolume && c == OpDeleteVolume) ||
+			(t == OperationCreateBlockVolume && c == OpAddVolume) ||
+			(t == OperationCloneVolume && c == OpAddVolumeClone))
 	})
 }
 
@@ -99,7 +103,10 @@ func MapPendingVolumes(tx *bolt.Tx) (map[string]string, error) {
 // an error if the db cannot be read.
 func MapPendingBlockVolumes(tx *bolt.Tx) (map[string]string, error) {
 	return mapPendingItems(tx, func(op *PendingOperationEntry, a PendingOperationAction) bool {
-		return (op.Type == OperationCreateBlockVolume && a.Change == OpAddBlockVolume)
+		t := op.Type
+		c := a.Change
+		return ((t == OperationCreateBlockVolume && c == OpAddBlockVolume) ||
+			(t == OperationDeleteBlockVolume && c == OpDeleteBlockVolume))
 	})
 }
 


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

The functions used to filter out pending volumes and block volumes were not correctly checking for all cases where a pending operation was indicating that a volume or block volume was pending & incomplete.

### Does this PR fix issues?

Fixes [rhbz#1662141](https://bugzilla.redhat.com/show_bug.cgi?id=1662141)


### Notes for the reviewer

It is now possible for a volume to go pending for delete and then be unmarked pending if the delete fails. This implies that it is possible for a volume to vanish from the listing and then reappear some time later. This is a bit odd but I don't think this behavior is worse than failing the listing commands because a pending delete operation is in the db.
