### PR TITLE
Try to reduce flakiness of cleanup functional tests

### DIFF
--- a/tests/functional/TestErrorHandling/tests/background_cleanup_test.go
+++ b/tests/functional/TestErrorHandling/tests/background_cleanup_test.go
@@ -87,7 +87,7 @@ func TestCleanupAfterRestart(t *testing.T) {
 		time.Sleep(time.Second)
 		info, err = heketi.OperationsInfo()
 		tests.Assert(t, err == nil, "expected err == nil, got:", err)
-		if info.Stale == 0 {
+		if info.Stale == 0 && info.InFlight == 0 {
 			break
 		}
 	}
@@ -165,7 +165,7 @@ func TestCleanupPeriodic(t *testing.T) {
 		logger.Info("probing for server progress")
 		info, err = heketi.OperationsInfo()
 		tests.Assert(t, err == nil, "expected err == nil, got:", err)
-		if info.Stale == 0 && info.Failed == 0 {
+		if info.Stale == 0 && info.Failed == 0 && info.InFlight == 0 {
 			break
 		}
 	}

--- a/tests/functional/TestErrorHandling/tests/background_cleanup_test.go
+++ b/tests/functional/TestErrorHandling/tests/background_cleanup_test.go
@@ -81,9 +81,11 @@ func TestCleanupAfterRestart(t *testing.T) {
 	tests.Assert(t, info.Stale == 1,
 		"expected info.Stale == 1, got:", info.InFlight)
 
+	// wait for the background cleaner to be started
 	time.Sleep(5 * time.Second)
+
+	// wait around an additional 5 sec for stale ops to be cleaned up
 	for i := 0; i < 5; i++ {
-		// wait around and additional 5 sec for stale ops to be cleaned up
 		time.Sleep(time.Second)
 		info, err = heketi.OperationsInfo()
 		tests.Assert(t, err == nil, "expected err == nil, got:", err)

--- a/tests/functional/TestErrorHandling/tests/background_cleanup_test.go
+++ b/tests/functional/TestErrorHandling/tests/background_cleanup_test.go
@@ -159,8 +159,8 @@ func TestCleanupPeriodic(t *testing.T) {
 	os.Remove(glusterCond)
 	time.Sleep(time.Second)
 
+	// wait around up to twice the refresh interval for stale ops to be cleaned up
 	for i := 0; i < 16; i++ {
-		// wait around and additional 5 sec for stale ops to be cleaned up
 		time.Sleep(time.Second)
 		logger.Info("probing for server progress")
 		info, err = heketi.OperationsInfo()


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

It is observed that sometimes, the cleanup tests, e.g. `TestCleanupAfterRestart` fail after stale operations being cleaned up with the failure that there's an `InFlight` operation. This is because cleanup creates InFlight operations, and we don't wait for *those* to be done.

This PR tries to reduce the flakiness of `TestCleanupAfterRestart` and `TestCleanupPeriodic` by waiting for InFlight operations to vanish in addition to Stale/Failed operations.

### Notes for the reviewer:

*  We might also need to increase the additional wait time of 5 sec in `TestCleanupAfterRestart` some more. We'll see.
* Additional patches in this PR just improve some comments around the changed code path