### PR TITLE
tests: try to select best python version for use in travis

### DIFF
--- a/tests/200-py-unittest.sh
+++ b/tests/200-py-unittest.sh
@@ -38,20 +38,23 @@ if ! command -v tox &>/dev/null; then
 fi
 
 TOXENVS="py27"
-if command -v python3.5 &>/dev/null; then
-	if command -v pyenv &>/dev/null; then
-		if pyenv global system 3.5; then
-			TOXENVS="${TOXENVS},py35"
+
+for v in "3.5" "3.6" "3.7"; do
+	vflat="${v/.}"
+	if command -v python"$v" &>/dev/null; then
+		if command -v pyenv &>/dev/null; then
+			if pyenv global system "$v"; then
+				TOXENVS="${TOXENVS},py${vflat}"
+			fi
+		else
+			TOXENVS="${TOXENVS},py${vflat}"
 		fi
-	else
-		TOXENVS="${TOXENVS},py35"
 	fi
-fi
-if command -v python3.6 &>/dev/null; then
-	TOXENVS="${TOXENVS},py36"
-	if command -v pyenv &>/dev/null; then
-		pyenv global system 3.6
-	fi
+done
+
+if ! echo "${TOXENVS}" | grep -q py3 ; then
+	echo "error: no python3 environment found. Python 3 is required."
+	exit 1
 fi
 
 require_server


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Travis runs have been breaking lately and it appears to be due
to a change in the version of python (3.6 -> 3.7). This change
tries to make it simple to enable and use at least one version
of python 3.




