### PR TITLE
check device state before deleting the device

### DIFF
--- a/apps/glusterfs/app_device_test.go
+++ b/apps/glusterfs/app_device_test.go
@@ -226,14 +226,29 @@ func TestDeviceAddDelete(t *testing.T) {
 	})
 	tests.Assert(t, err == nil)
 
-	// Now delete device and check for conflict
+	// Now delete device and check for bad request
 	req, err := http.NewRequest("DELETE", ts.URL+"/devices/"+fakeid, nil)
+	tests.Assert(t, err == nil)
+	r, err = http.DefaultClient.Do(req)
+	tests.Assert(t, err == nil)
+	tests.Assert(t, r.StatusCode == http.StatusBadRequest)
+
+	err = app.db.Update(func(tx *bolt.Tx) error {
+		device, err := NewDeviceEntryFromId(tx, fakeid)
+		if err != nil {
+			return err
+		}
+		device.State = api.EntryStateFailed
+		return device.Save(tx)
+	})
+	tests.Assert(t, err == nil)
+	// Now delete device and check for bad request
+	req, err = http.NewRequest("DELETE", ts.URL+"/devices/"+fakeid, nil)
 	tests.Assert(t, err == nil)
 	r, err = http.DefaultClient.Do(req)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, r.StatusCode == http.StatusConflict)
 	tests.Assert(t, utils.GetErrorFromResponse(r).Error() == devicemap["/dev/fake1"].ConflictString())
-
 	// Check the db is still intact
 	err = app.db.View(func(tx *bolt.Tx) error {
 		device, err := NewDeviceEntryFromId(tx, fakeid)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?
This PR moves checks in DeviceEntry.Delete to a new function called CheckDelete and calls the  new function from both App.DeviceDelete and DeviceEntry.Delete 
### Does this PR fix issues?


<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes: #1478 

### Notes for the reviewer


