### PR TITLE
Streamline retry operation code

### DIFF
--- a/apps/glusterfs/operations_manage.go
+++ b/apps/glusterfs/operations_manage.go
@@ -156,10 +156,8 @@ func runOperationAfterBuild(o Operation,
 		logger.LogError("%v Failed: %v", label, err)
 		return err
 	}
-	if err := o.Finalize(); err != nil {
-		return err
-	}
-	return nil
+
+	return o.Finalize()
 }
 
 // AsyncHttpOperation runs all the steps of an operation with the long-running

--- a/apps/glusterfs/operations_manage.go
+++ b/apps/glusterfs/operations_manage.go
@@ -157,6 +157,7 @@ func runOperationAfterBuild(o Operation,
 		return err
 	}
 
+	// if we reach this, we have succeeded
 	return o.Finalize()
 }
 

--- a/apps/glusterfs/operations_test.go
+++ b/apps/glusterfs/operations_test.go
@@ -410,8 +410,8 @@ func TestRunOperationExecRetryRollbackFail(t *testing.T) {
 	e := RunOperation(o, app.executor)
 	tests.Assert(t, e != nil, "expected e != nil, got:", e)
 	// even if rollback fails we expect the error from Exec
-	tests.Assert(t, strings.Contains(e.Error(), "rollbackfail"),
-		`expected strings.Contains(e.Error(), "rollbackfail"), got:`, e)
+	tests.Assert(t, strings.Contains(e.Error(), "foobar"),
+		`expected strings.Contains(e.Error(), "foobar"), got:`, e)
 	// check that rollback got called
 	tests.Assert(t, rollback_cc == 1,
 		"expected rollback_cc == 1, got:", rollback_cc)


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

This small series of patches rewrites the run-operation/retry operation code to a more simple and streamlined manner. It removes code duplication and leaves the (re)try logic in one more easily understandable loop with only one call to Exec and only one call to Rollback with consistent return values and making failed from rollback.

### Does this PR fix issues?

Fixes #1493 

### Notes

overall diffstat:
```
 apps/glusterfs/operations_manage.go | 128 ++++++++++++++++++++++++++++++++++++++++++++++++++++++--------------------------------------------------------------------------
 apps/glusterfs/operations_test.go   |   4 ++--
 2 files changed, 56 insertions(+), 76 deletions(-)
```

