### PR TITLE
apps: update total counter when checking pending ops in db

### DIFF
--- a/apps/glusterfs/db_operations.go
+++ b/apps/glusterfs/db_operations.go
@@ -636,6 +636,8 @@ func dbCheckBricks(dump Db) (bricksCheckResponse DbBucketCheckResponse) {
 func dbCheckPendingOps(dump Db) (pendingOpsCheckResponse DbBucketCheckResponse) {
 	for _, pendingOpEntry := range dump.PendingOperations {
 
+		pendingOpsCheckResponse.Total++
+
 		pendingOpCheckResponse := pendingOpEntry.consistencyCheck(dump)
 
 		if len(pendingOpCheckResponse.Inconsistencies) > 0 {


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

The pending ops check was not updating the "Total" counter
when looping over the pending operations in the db. This
change makes the loop update that counter.

### Does this PR fix issues?

Fixes [rhbz#1667797](https://bugzilla.redhat.com/show_bug.cgi?id=1667797)


