### PR TITLE
Display distribute and replica counts in 'heketi-cli volume info'

### DIFF
--- a/client/cli/go/cmds/volume.go
+++ b/client/cli/go/cmds/volume.go
@@ -440,7 +440,6 @@ var volumeInfoCommand = &cobra.Command{
 			return err
 		}
 
-		// Create cluster
 		info, err := heketi.VolumeInfo(volumeId)
 		if err != nil {
 			return err

--- a/client/cli/go/cmds/volume.go
+++ b/client/cli/go/cmds/volume.go
@@ -234,7 +234,7 @@ var volumeCreateCommand = &cobra.Command{
 				}
 				fmt.Fprintf(stdout, string(data))
 			} else {
-				fmt.Fprintf(stdout, "%v", volume)
+				printVolumeInfo(volume)
 			}
 		}
 
@@ -314,7 +314,7 @@ var volumeExpandCommand = &cobra.Command{
 			}
 			fmt.Fprintf(stdout, string(data))
 		} else {
-			fmt.Fprintf(stdout, "%v", volume)
+			printVolumeInfo(volume)
 		}
 		return nil
 	},
@@ -367,7 +367,7 @@ var volumeBlockHostingRestrictionLockCommand = &cobra.Command{
 			}
 			fmt.Fprintf(stdout, string(data))
 		} else {
-			fmt.Fprintf(stdout, "%v", volume)
+			printVolumeInfo(volume)
 		}
 		return nil
 	},
@@ -414,7 +414,7 @@ var volumeBlockHostingRestrictionUnlockCommand = &cobra.Command{
 			}
 			fmt.Fprintf(stdout, string(data))
 		} else {
-			fmt.Fprintf(stdout, "%v", volume)
+			printVolumeInfo(volume)
 		}
 		return nil
 	},
@@ -582,7 +582,7 @@ var volumeCloneCommand = &cobra.Command{
 			}
 			fmt.Fprintf(stdout, string(data))
 		} else {
-			fmt.Fprintf(stdout, "%v", volume)
+			printVolumeInfo(volume)
 		}
 		return nil
 	},

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -535,23 +535,6 @@ func (v *VolumeInfoResponse) String() string {
 		s += fmt.Sprintf("Snapshot Factor: %.2f\n",
 			v.Snapshot.Factor)
 	}
-
-	/*
-		s += "\nBricks:\n"
-		for _, b := range v.Bricks {
-			s += fmt.Sprintf("Id: %v\n"+
-				"Path: %v\n"+
-				"Size (GiB): %v\n"+
-				"Node: %v\n"+
-				"Device: %v\n\n",
-				b.Id,
-				b.Path,
-				b.Size/(1024*1024),
-				b.NodeId,
-				b.DeviceId)
-		}
-	*/
-
 	return s
 }
 


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
* Minor cleanups
* Convert 'volume info' to display via template
* Print an 'NxM' string for distribue + replica line

Example:
```
$ ./heketi-cli volume info fc66a36f8c368e6803859c02efe95ca6
Name: vol_fc66a36f8c368e6803859c02efe95ca6
Size: 105
Volume Id: fc66a36f8c368e6803859c02efe95ca6
Cluster Id: 9f295b5ab4a965e22f6d24cf73970f01
Mount: 10.70.47.92:vol_fc66a36f8c368e6803859c02efe95ca6
Mount Options: backup-volfile-servers=10.70.47.196,10.70.46.72
Block: true
Free Size: 70
Reserved Size: 0
Block Hosting Restriction: (none)
Block Volumes: [0c25795f72d359b4325b47f96c906b3c 0dae4bd21cdf4fd7d86b8f1884d7d0bf 128837a348d834c9182a814cd15930b0 138b48fcf42edbcee294d5457ce44a4c 166629ff21aac44c4c860664de06090b 1d49f75a38a837accabc036e2d883511 276d636cc9c885013b614ad823466010 2df867a85bf131dac06347253ff263ce 4ece75c9b250a49144c393ea30bcc663]
Durability Type: replicate
Distributed+Replica: 2x3

```

### Does this PR fix issues?
Fixes rhbz#1655066


### Notes for the reviewer

Looking for any feedback if this is sufficient or if there's any tweaks we should to to match gluster.

