### PR TITLE
Upgrade negroni version to 1.0.0 and update glide.lock

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 5fc263bfacc703e0a599166ccae968891dd53d7b4e42a3d8356b3194e45833bb
-updated: 2018-06-01T15:20:52.053211272+02:00
+hash: a7e0c0723a91776f34ff8a742912c032e115701284efe18eed15e96da0ed00fd
+updated: 2019-02-07T15:18:42.253317799+01:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -137,7 +137,7 @@ imports:
   subpackages:
   - codec
 - name: github.com/urfave/negroni
-  version: fde5e16d32adc7ad637e9cd9ad21d4ebc6192535
+  version: c6a59be0ce122566695fbd5e48a77f8f10c8a63a
 - name: golang.org/x/crypto
   version: d172538b2cfce0c13cee31e647d0367aa8cd2486
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,7 +15,7 @@ import:
 - package: github.com/spf13/pflag
   version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
 - package: github.com/urfave/negroni
-  version: ^0.2.0
+  version: ^1.0.0
 - package: golang.org/x/crypto
   subpackages:
   - ssh


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Negroni is still locked to version 0.2.0 which doesn't include timestamps in logs. This PR upgrades negroni to version 1.0.0.

### Does this PR fix issues?

Fixes #694 
