### PR TITLE
 Add block volume count to metrics

### DIFF
--- a/apps/glusterfs/app_topology_test.go
+++ b/apps/glusterfs/app_topology_test.go
@@ -19,23 +19,29 @@ import (
 func TestTopologyInfo(t *testing.T) {
 	tmpfile := tests.Tempfile()
 	defer os.Remove(tmpfile)
-
 	app := NewTestApp(tmpfile)
 	defer app.Close()
 
 	err := setupSampleDbWithTopology(app,
-		1,      // clusters
-		2,      // nodes_per_cluster
-		1,      // devices_per_node,
-		500*GB, // disksize)
+		1,    // clusters
+		3,    // nodes_per_cluster
+		3,    // devices_per_node,
+		1*TB, // disksize
 	)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
-	// Create a volume which uses the entire storage
-	v := createSampleReplicaVolumeEntry(495, 2)
+	// Create a volume of size 500
+	v := createSampleReplicaVolumeEntry(500, 2)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	err = v.Create(app.db, app.executor)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// Create a block volume of size 10
+	bv := createSampleBlockVolumeEntry(10)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	err = bv.Create(app.db, app.executor)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 
 	topologyInfo, err := app.TopologyInfo()
@@ -45,5 +51,6 @@ func TestTopologyInfo(t *testing.T) {
 
 	tests.Assert(t, testCluster.Id != "", `expected testCluster.Id != "", got`, testCluster.Id)
 	tests.Assert(t, len(testCluster.Volumes) > 0, `expected len(testCluster.Volumes) > 0 , got`, len(testCluster.Volumes))
+	tests.Assert(t, len(testCluster.BlockVolumes) > 0, `expected len(testCluster.BlockVolumes) > 0 , got`, len(testCluster.BlockVolumes))
 	tests.Assert(t, len(testCluster.Nodes) > 0, `expected len(testCluster.Nodes) > 0 , got`, len(testCluster.Nodes))
 }

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -226,8 +226,10 @@ type ClusterFlags struct {
 
 type Cluster struct {
 	Volumes []VolumeInfoResponse `json:"volumes"`
-	Nodes   []NodeInfoResponse   `json:"nodes"`
-	Id      string               `json:"id"`
+	//currently BlockVolumes will be used only for metrics
+	BlockVolumes []BlockVolumeInfoResponse `json:"blockvolumes,omitempty"`
+	Nodes        []NodeInfoResponse        `json:"nodes"`
+	Id           string                    `json:"id"`
 	ClusterFlags
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -49,6 +49,12 @@ var (
 		[]string{"cluster"},
 	)
 
+	blockVolumesCount = promDesc(
+		"block_volumes_count",
+		"Number of block volumes on cluster",
+		[]string{"cluster"},
+	)
+
 	nodesCount = promDesc(
 		"nodes_count",
 		"Number of nodes on cluster",
@@ -117,6 +123,7 @@ func promDesc(name, help string, variableLabels []string) *prometheus.Desc {
 func (m *Metrics) Describe(ch chan<- *prometheus.Desc) {
 	ch <- clusterCount
 	ch <- volumesCount
+	ch <- blockVolumesCount
 	ch <- nodesCount
 	ch <- deviceCount
 	ch <- deviceSize
@@ -158,6 +165,14 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 			float64(len(cluster.Volumes)),
 			cluster.Id,
 		)
+
+		ch <- prometheus.MustNewConstMetric(
+			blockVolumesCount,
+			prometheus.GaugeValue,
+			float64(len(cluster.BlockVolumes)),
+			cluster.Id,
+		)
+
 		ch <- prometheus.MustNewConstMetric(
 			nodesCount,
 			prometheus.GaugeValue,


### PR DESCRIPTION
Add block volume count to metrics



<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?
This PR adds the block volume count to the metrics
### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes: [rhbz#1589012](https://bugzilla.redhat.com/show_bug.cgi?id=1589012)


Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>


logs:
```
#HELP heketi_block_volumes_count Number of block volumes on cluster
# TYPE heketi_block_volumes_count gauge
heketi_block_volumes_count{cluster="812506b5c3063c72b3cfc467951100c6"} 3
# HELP heketi_volumes_count Number of volumes on cluster
# TYPE heketi_volumes_count gauge
heketi_volumes_count{cluster="812506b5c3063c72b3cfc467951100c6"} 4

```
