### PR TITLE
implement strict zone checking

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -350,6 +350,11 @@ func (a *App) setFromEnvironmentalVariable() {
 	if "" != env {
 		a.conf.PostReqVolumeOptions = env
 	}
+
+	env = os.Getenv("HEKETI_ZONE_CHECKING")
+	if "" != env {
+		a.conf.ZoneChecking = env
+	}
 }
 
 func (a *App) setAdvSettings() {
@@ -386,6 +391,10 @@ func (a *App) setAdvSettings() {
 		PostReqVolumeOptions = a.conf.PostReqVolumeOptions
 	}
 
+	if a.conf.ZoneChecking != "" {
+		logger.Info("Zone checking: '%v'", a.conf.ZoneChecking)
+		ZoneChecking = a.conf.ZoneChecking
+	}
 }
 
 func (a *App) setBlockSettings() {

--- a/apps/glusterfs/app_config.go
+++ b/apps/glusterfs/app_config.go
@@ -35,6 +35,7 @@ type GlusterFSConfig struct {
 	AverageFileSize      uint64 `json:"average_file_size_kb"`
 	PreReqVolumeOptions  string `json:"pre_request_volume_options"`
 	PostReqVolumeOptions string `json:"post_request_volume_options"`
+	ZoneChecking         string `json:"zone_checking"`
 
 	//block settings
 	CreateBlockHostingVolumes bool   `json:"auto_create_block_hosting_volume"`

--- a/apps/glusterfs/app_volume_test.go
+++ b/apps/glusterfs/app_volume_test.go
@@ -1184,7 +1184,7 @@ func TestVolumeClusterResizeByAddingDevices(t *testing.T) {
 	v = createSampleReplicaVolumeEntry(495, 2)
 	tests.Assert(t, v != nil)
 	err = v.Create(app.db, app.executor)
-	tests.Assert(t, err == nil)
+	tests.Assert(t, err == nil, err)
 
 	// Try to create another volume, but this should fail
 	v = createSampleReplicaVolumeEntry(495, 2)

--- a/apps/glusterfs/brick_allocate.go
+++ b/apps/glusterfs/brick_allocate.go
@@ -15,7 +15,6 @@ import (
 	"github.com/boltdb/bolt"
 	"github.com/lpabon/godbc"
 
-	wdb "github.com/heketi/heketi/pkg/db"
 	"github.com/heketi/heketi/pkg/idgen"
 )
 
@@ -268,25 +267,6 @@ func populateBrickSet(
 		device.BrickAdd(brick.Id())
 	}
 	return bs, ds, nil
-}
-
-func allocateBricks(
-	db wdb.RODB,
-	cluster string,
-	v *VolumeEntry,
-	numBrickSets int,
-	brick_size uint64) (*BrickAllocation, error) {
-
-	var r *BrickAllocation
-	opts := NewVolumePlacementOpts(v, brick_size, numBrickSets)
-	err := db.View(func(tx *bolt.Tx) error {
-		var err error
-		dsrc := NewClusterDeviceSource(tx, cluster)
-		placer := PlacerForVolume(v)
-		r, err = placer.PlaceAll(dsrc, opts, nil)
-		return err
-	})
-	return r, err
 }
 
 type ClusterDeviceSource struct {

--- a/apps/glusterfs/placer_settings.go
+++ b/apps/glusterfs/placer_settings.go
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2017 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+const (
+	ZONE_CHECKING_NONE   = "none"
+	ZONE_CHECKING_STRICT = "strict"
+)
+
+var (
+	ZoneChecking = ZONE_CHECKING_NONE
+)

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -463,9 +463,11 @@ func (v *VolumeEntry) allocBricks(
 	}()
 
 	// mimic the previous unconditional db update behavior
+	opts := NewVolumePlacementOpts(v, brick_size, bricksets)
 	err := db.Update(func(tx *bolt.Tx) error {
-		wtx := wdb.WrapTx(tx)
-		r, e := allocateBricks(wtx, cluster, v, bricksets, brick_size)
+		dsrc := NewClusterDeviceSource(tx, cluster)
+		placer := PlacerForVolume(v)
+		r, e := placer.PlaceAll(dsrc, opts, nil)
 		if e != nil {
 			return e
 		}

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -42,7 +42,17 @@ func setupSampleDbWithTopology(app *App,
 	clusters, nodes_per_cluster, devices_per_node int,
 	disksize uint64) error {
 
-	zones_per_cluster := nodes_per_cluster
+	return setupSampleDbWithTopologyWithZones(app,
+		clusters,
+		nodes_per_cluster,
+		nodes_per_cluster,
+		devices_per_node,
+		disksize)
+}
+
+func setupSampleDbWithTopologyWithZones(app *App,
+	clusters, zones_per_cluster, nodes_per_cluster, devices_per_node int,
+	disksize uint64) error {
 
 	err := app.db.Update(func(tx *bolt.Tx) error {
 		for c := 0; c < clusters; c++ {

--- a/apps/glusterfs/zone_filter.go
+++ b/apps/glusterfs/zone_filter.go
@@ -1,0 +1,73 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"github.com/boltdb/bolt"
+
+	wdb "github.com/heketi/heketi/pkg/db"
+)
+
+type DeviceZoneMap struct {
+	AvailableZones map[int]bool
+	DeviceZones    map[string]int
+}
+
+func NewDeviceZoneMap() *DeviceZoneMap {
+	return &DeviceZoneMap{
+		AvailableZones: map[int]bool{},
+		DeviceZones:    map[string]int{},
+	}
+}
+
+func NewDeviceZoneMapFromDb(db wdb.RODB) (*DeviceZoneMap, error) {
+	dzm := NewDeviceZoneMap()
+	err := db.View(func(tx *bolt.Tx) error {
+		dl, err := DeviceList(tx)
+		if err != nil {
+			return err
+		}
+		for _, deviceId := range dl {
+			device, err := NewDeviceEntryFromId(tx, deviceId)
+			if err != nil {
+				return err
+			}
+			n, err := NewNodeEntryFromId(tx, device.NodeId)
+			if err != nil {
+				return err
+			}
+			dzm.Add(device.Info.Id, n.Info.Zone)
+		}
+		return nil
+	})
+	return dzm, err
+}
+
+func (dzm *DeviceZoneMap) Add(deviceId string, zone int) {
+	dzm.AvailableZones[zone] = true
+	dzm.DeviceZones[deviceId] = zone
+}
+
+func (dzm *DeviceZoneMap) Filter(bs *BrickSet, d *DeviceEntry) bool {
+	// TODO: need to consider cluster
+	zonesUsed := map[int]bool{}
+	for _, b := range bs.Contents() {
+		brickZone, found := dzm.DeviceZones[b.Info.DeviceId]
+		if !found {
+			// Should not happen
+			logger.Warning("device id %v not found in zone map", b.Info.DeviceId)
+			return false
+		}
+		logger.Debug("zone %v in use by brick set", brickZone)
+		zonesUsed[brickZone] = true
+	}
+	dzone := dzm.DeviceZones[d.Info.Id]
+	return !zonesUsed[dzone]
+}

--- a/apps/glusterfs/zone_filter_test.go
+++ b/apps/glusterfs/zone_filter_test.go
@@ -1,0 +1,89 @@
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"os"
+	"testing"
+
+	_ "github.com/boltdb/bolt"
+	"github.com/heketi/tests"
+
+	_ "github.com/heketi/heketi/pkg/db"
+)
+
+func TestNewDeviceZoneMap(t *testing.T) {
+	dzm := NewDeviceZoneMap()
+	dzm.Add("foobar", 1)
+	dzm.Add("beep", 1)
+	dzm.Add("blap", 2)
+
+	tests.Assert(t, len(dzm.AvailableZones) == 2)
+	tests.Assert(t, len(dzm.DeviceZones) == 3)
+}
+
+func TestNewDeviceZoneMapFromDb(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		1,    // clusters
+		3,    // nodes_per_cluster
+		3,    // devices_per_node,
+		1*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	dzm, err := NewDeviceZoneMapFromDb(app.db)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	tests.Assert(t, len(dzm.AvailableZones) == 3,
+		"expected len(dzm.AvailableZones) == 3, got:", len(dzm.AvailableZones))
+	tests.Assert(t, len(dzm.DeviceZones) == 9,
+		"expected len(dzm.DeviceZones) == 9, got:", len(dzm.DeviceZones))
+}
+
+func TestDeviceZoneMapFilter(t *testing.T) {
+
+	bs := NewBrickSet(3)
+	dzm := NewDeviceZoneMap()
+	dzm.Add("aaa", 1)
+	dzm.Add("bbb", 2)
+	dzm.Add("ccc", 3)
+	dzm.Add("ddd", 1)
+	dzm.Add("eee", 2)
+	dzm.Add("fff", 3)
+
+	d := NewDeviceEntry()
+	d.Info.Id = "aaa"
+	result := dzm.Filter(bs, d)
+	tests.Assert(t, result, "expected result true")
+
+	b := NewBrickEntry(5, 100, 100, "eee", "xxx", 0, "foo")
+	bs.Add(b)
+
+	d.Info.Id = "bbb"
+	result = dzm.Filter(bs, d)
+	tests.Assert(t, !result, "expected result false")
+
+	d.Info.Id = "ccc"
+	result = dzm.Filter(bs, d)
+	tests.Assert(t, result, "expected result true")
+
+	// insert a bad brick
+	b = NewBrickEntry(5, 100, 100, "qqqqqq", "xxx", 0, "foo")
+	bs.Add(b)
+	result = dzm.Filter(bs, d)
+	tests.Assert(t, !result, "expected result false")
+}

--- a/client/api/go-client/client_test.go
+++ b/client/api/go-client/client_test.go
@@ -187,7 +187,7 @@ func TestTopology(t *testing.T) {
 		volumeReq := &api.VolumeCreateRequest{}
 		volumeReq.Size = 10
 		volume, err := c.VolumeCreate(volumeReq)
-		tests.Assert(t, err == nil)
+		tests.Assert(t, err == nil, err)
 		tests.Assert(t, volume.Id != "")
 		tests.Assert(t, volume.Size == volumeReq.Size)
 		volumeinfos = append(volumeinfos, *volume)
@@ -636,7 +636,7 @@ func TestClientVolume(t *testing.T) {
 	volumeReq := &api.VolumeCreateRequest{}
 	volumeReq.Size = 10
 	volume, err := c.VolumeCreate(volumeReq)
-	tests.Assert(t, err == nil)
+	tests.Assert(t, err == nil, err)
 	tests.Assert(t, volume.Id != "")
 	tests.Assert(t, volume.Size == volumeReq.Size)
 
@@ -1241,7 +1241,7 @@ func TestVolumeSetBlockRestriction(t *testing.T) {
 	volumeReq.Size = 10
 	volumeReq.Block = true
 	volume, err := c.VolumeCreate(volumeReq)
-	tests.Assert(t, err == nil)
+	tests.Assert(t, err == nil, err)
 	tests.Assert(t, volume.Id != "")
 	tests.Assert(t, volume.Size == volumeReq.Size)
 


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Zones are currently a best-effort concept. While the expectation is that e.g. a replica-3 brick set will span 3 zones, this is not always the case. This PR introduces strict zone checking. The behavior can be controlled with the new config option `zone_checking` (and the corresponding environment variable `HEKETI_ZONE_CHECKING`) which can be set to `strict`, which only lets volume creates succeed if each brick set is spread across sufficiently many zones,  or to `none` (the default) which lets heketi behave like before.


### Does this PR fix issues?

<!-- Fixes # -->

### Notes for the reviewer

Filed this as a WIP PR to see what the CI thinks and to start the discussion. Will need to squash a few patches before merging if we agree about this approach.

