### PR TITLE
tests: always use the number of nodes as number of zones (for now)

### DIFF
--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -42,6 +42,8 @@ func setupSampleDbWithTopology(app *App,
 	clusters, nodes_per_cluster, devices_per_node int,
 	disksize uint64) error {
 
+	zones_per_cluster := nodes_per_cluster
+
 	err := app.db.Update(func(tx *bolt.Tx) error {
 		for c := 0; c < clusters; c++ {
 			cluster := createSampleClusterEntry()
@@ -49,7 +51,7 @@ func setupSampleDbWithTopology(app *App,
 			for n := 0; n < nodes_per_cluster; n++ {
 				node := createSampleNodeEntry()
 				node.Info.ClusterId = cluster.Info.Id
-				node.Info.Zone = n % 2
+				node.Info.Zone = n % zones_per_cluster
 
 				cluster.NodeAdd(node.Info.Id)
 


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Zones are not (yet) being really used in the tests,
but just using two zones rarely makes sense, and for
the strict zone checking, we will need more zones.

This PR changes `setupSampleDbWithTopology` to always configure one zone per node.

### Notes for the reviewer

This has been split out of PR #1518.

