### PR TITLE
Strict zone checking followup

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -393,7 +393,7 @@ func (a *App) setAdvSettings() {
 
 	if a.conf.ZoneChecking != "" {
 		logger.Info("Zone checking: '%v'", a.conf.ZoneChecking)
-		ZoneChecking = a.conf.ZoneChecking
+		ZoneChecking = ZoneCheckingStrategy(a.conf.ZoneChecking)
 	}
 }
 

--- a/apps/glusterfs/placer_settings.go
+++ b/apps/glusterfs/placer_settings.go
@@ -9,9 +9,12 @@
 
 package glusterfs
 
+type ZoneCheckingStrategy string
+
 const (
-	ZONE_CHECKING_NONE   = "none"
-	ZONE_CHECKING_STRICT = "strict"
+	ZONE_CHECKING_UNSET  ZoneCheckingStrategy = ""
+	ZONE_CHECKING_NONE   ZoneCheckingStrategy = "none"
+	ZONE_CHECKING_STRICT ZoneCheckingStrategy = "strict"
 )
 
 var (

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -44,6 +44,7 @@ const (
 
 	HEKETI_ARBITER_KEY           = "user.heketi.arbiter"
 	HEKETI_AVERAGE_FILE_SIZE_KEY = "user.heketi.average-file-size"
+	HEKETI_ZONE_CHECKING_KEY     = "user.heketi.zone-checking"
 )
 
 var (
@@ -313,6 +314,18 @@ func (v *VolumeEntry) GetAverageFileSize() uint64 {
 		}
 	}
 	return averageFileSize
+}
+
+// GetZoneCheckingStrategy returns a ZoneCheckingStrategy based on
+// the volume's options.
+func (v *VolumeEntry) GetZoneCheckingStrategy() ZoneCheckingStrategy {
+	for _, s := range v.GlusterVolumeOptions {
+		r := strings.Split(s, " ")
+		if len(r) == 2 && r[0] == HEKETI_ZONE_CHECKING_KEY {
+			return ZoneCheckingStrategy(r[1])
+		}
+	}
+	return ZONE_CHECKING_UNSET
 }
 
 func (v *VolumeEntry) BrickAdd(id string) {

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -262,11 +262,15 @@ func (v *VolumeEntry) prepForBrickReplacement(db wdb.DB,
 	return
 }
 
-func generateDeviceFilter(db wdb.RODB) (DeviceFilter, error) {
+func (v *VolumeEntry) generateDeviceFilter(db wdb.RODB) (DeviceFilter, error) {
 
 	var filter DeviceFilter = nil
+	zoneChecking := v.GetZoneCheckingStrategy()
+	if zoneChecking == ZONE_CHECKING_UNSET {
+		zoneChecking = ZoneChecking
+	}
 
-	switch ZoneChecking {
+	switch zoneChecking {
 	case ZONE_CHECKING_STRICT:
 		dzm, err := NewDeviceZoneMapFromDb(db)
 		if err != nil {
@@ -300,7 +304,7 @@ func (v *VolumeEntry) allocBrickReplacement(db wdb.DB,
 
 		var err error
 		txdb := wdb.WrapTx(tx)
-		defaultFilter, err := generateDeviceFilter(txdb)
+		defaultFilter, err := v.generateDeviceFilter(txdb)
 		if err != nil {
 			return err
 		}
@@ -505,7 +509,7 @@ func (v *VolumeEntry) allocBricks(
 		placer := PlacerForVolume(v)
 
 		txdb := wdb.WrapTx(tx)
-		deviceFilter, err := generateDeviceFilter(txdb)
+		deviceFilter, err := v.generateDeviceFilter(txdb)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

PR #1518 added the core support for strict zone checking. This PR adds the ability to request strict zone checking on a per-volume basis by setting the 'user.heketi.zone-checking' volume option to 'strict'.
This PR also adds tests for the volume option, for volume expand, and device replace (set state failure).


### Notes for the reviewer

This PR depends on PR #1518 and should only be merged after that one.
