### PR TITLE
executors: add a hint of possible issues to device setup error

### DIFF
--- a/executors/cmdexec/device.go
+++ b/executors/cmdexec/device.go
@@ -59,6 +59,7 @@ func (s *CmdExecutor) DeviceSetup(host, device, vgid string, destroy bool) (d *e
 	// Execute command
 	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 5))
 	if err != nil {
+		err = fmt.Errorf("Setup of device %v failed (already initialized or contains data?): %v", device, err)
 		return nil, err
 	}
 


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

Device setup can fail, for example if the partition is not wiped or is already initialized. This PR adds a hint about these possible issues to the error returned by the failed command, which can be cryptic.

### Does this PR fix issues?

Fixes #595


### Notes for the reviewer

After considering a smarter solution with individual parsing of the errors of the commands, which is error prone in itself, because there are many possible errors and the error text can also change by newer versions of the tools, this PR follows a very simplistic approach of just adding a general hint.
