### PR TITLE
apps: add the heketi volume id to the gluster volume meta data

### DIFF
--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -42,6 +42,7 @@ const (
 	DEFAULT_EC_REDUNDANCY         = 2
 	DEFAULT_THINP_SNAPSHOT_FACTOR = 1.5
 
+	HEKETI_ID_KEY                = "user.heketi.id"
 	HEKETI_ARBITER_KEY           = "user.heketi.arbiter"
 	HEKETI_AVERAGE_FILE_SIZE_KEY = "user.heketi.average-file-size"
 	HEKETI_ZONE_CHECKING_KEY     = "user.heketi.zone-checking"

--- a/apps/glusterfs/volume_entry_create.go
+++ b/apps/glusterfs/volume_entry_create.go
@@ -134,6 +134,8 @@ func (v *VolumeEntry) createVolumeRequest(db wdb.RODB,
 	vr.Name = v.Info.Name
 	v.Durability.SetExecutorVolumeRequest(vr)
 	vr.GlusterVolumeOptions = v.GlusterVolumeOptions
+	vr.GlusterVolumeOptions = append(vr.GlusterVolumeOptions,
+		fmt.Sprintf("%s %s", HEKETI_ID_KEY, v.Info.Id))
 	vr.Arbiter = v.HasArbiterOption()
 
 	return vr, sshhost, nil


### PR DESCRIPTION
In order to be easily able to back-reference the gluster volumes to
heketi volumes, the heketi volume id is stored under user.heketi.id
in the gluster volume options.

Closes #1322

Signed-off-by: Sven Anderson <sven@redhat.com>
