### PR TITLE
Make delay in API results polling an argument in the python client library 

### DIFF
--- a/client/api/python/heketi/heketi.py
+++ b/client/api/python/heketi/heketi.py
@@ -27,15 +27,17 @@ import json
 TAGS_SET = 'set'
 TAGS_UPDATE = 'update'
 TAGS_DELETE = 'delete'
+POLL_DELAY = 1  # in seconds
 
 
 class HeketiClient(object):
 
-    def __init__(self, host, user, key, verify=True):
+    def __init__(self, host, user, key, verify=True, poll_delay=POLL_DELAY):
         self.host = host
         self.user = user
         self.key = key
         self.verify = verify
+        self.poll_delay = poll_delay
 
     def _set_token_in_header(self, method, uri, headers={}):
         claims = {}
@@ -100,7 +102,7 @@ class HeketiClient(object):
             q.raise_for_status()
 
             if 'X-Pending' in q.headers:
-                time.sleep(2)
+                time.sleep(self.poll_delay)
             else:
                 if q.status_code == requests.codes.see_other:
                     return self._make_request('GET', q.headers['location'])

--- a/client/api/python/test/unit/test_client.py
+++ b/client/api/python/test/unit/test_client.py
@@ -19,6 +19,7 @@ from heketi import HeketiClient
 
 TEST_ADMIN_KEY = "My Secret"
 TEST_SERVER = "http://localhost:8080"
+TEST_POLL_DELAY = 0.2
 
 
 class test_heketi(unittest.TestCase):
@@ -72,7 +73,8 @@ class test_heketi(unittest.TestCase):
     def test_node(self):
         node_req = {}
 
-        c = HeketiClient(TEST_SERVER, "admin", TEST_ADMIN_KEY)
+        c = HeketiClient(TEST_SERVER, "admin", TEST_ADMIN_KEY,
+                         poll_delay=TEST_POLL_DELAY)
         self.assertNotEqual(c, '')
 
         # Create cluster
@@ -145,7 +147,8 @@ class test_heketi(unittest.TestCase):
 
     def test_device(self):
         # Create app
-        c = HeketiClient(TEST_SERVER, "admin", TEST_ADMIN_KEY)
+        c = HeketiClient(TEST_SERVER, "admin", TEST_ADMIN_KEY,
+                         poll_delay=TEST_POLL_DELAY)
 
         # Create cluster
         cluster_req = {}
@@ -241,7 +244,8 @@ class test_heketi(unittest.TestCase):
 
     def test_volume(self):
         # Create cluster
-        c = HeketiClient(TEST_SERVER, "admin", TEST_ADMIN_KEY)
+        c = HeketiClient(TEST_SERVER, "admin", TEST_ADMIN_KEY,
+                         poll_delay=TEST_POLL_DELAY)
         self.assertEqual(True, c != '')
 
         cluster_req = {}
@@ -343,7 +347,8 @@ class test_heketi(unittest.TestCase):
 
     def test_node_tags(self):
         # Create app
-        c = HeketiClient(TEST_SERVER, "admin", TEST_ADMIN_KEY)
+        c = HeketiClient(TEST_SERVER, "admin", TEST_ADMIN_KEY,
+                         poll_delay=TEST_POLL_DELAY)
 
         # Create cluster
         cluster_req = {}
@@ -448,7 +453,8 @@ class test_heketi(unittest.TestCase):
 
     def test_device_tags(self):
         # Create app
-        c = HeketiClient(TEST_SERVER, "admin", TEST_ADMIN_KEY)
+        c = HeketiClient(TEST_SERVER, "admin", TEST_ADMIN_KEY,
+                         poll_delay=TEST_POLL_DELAY)
 
         # Create cluster
         cluster_req = {}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Previously, the delay within the code that polls for results was hard
coded to one second. This change retains the existing default but makes
it possible to pass a different value in to the heketi client object.

Aside from one test to ensure that the default functions, make all of
the other python "unit" tests use 0.2 seconds of delay. This greatly
speeds up running the test suite from around 3m to 32s on my machine. A
very short delay is ok for these tests because they are always using the
mock executor.


### Notes for the reviewer

This only touches the python client at the moment but something similar is going on in the go client api. We should look into improving that as well.
