### PR TITLE
apps: ignore device id with prefix DEVICE

### DIFF
--- a/apps/glusterfs/zone_filter.go
+++ b/apps/glusterfs/zone_filter.go
@@ -10,6 +10,8 @@
 package glusterfs
 
 import (
+	"strings"
+
 	"github.com/boltdb/bolt"
 
 	wdb "github.com/heketi/heketi/pkg/db"
@@ -35,6 +37,10 @@ func NewDeviceZoneMapFromDb(db wdb.RODB) (*DeviceZoneMap, error) {
 			return err
 		}
 		for _, deviceId := range dl {
+			if strings.HasPrefix(deviceId, "DEVICE") {
+				logger.Debug("ignoring registry key %v", deviceId)
+				continue
+			}
 			device, err := NewDeviceEntryFromId(tx, deviceId)
 			if err != nil {
 				return err

--- a/tests/functional/TestErrorHandling/tests/heketi_zone_check_test.go
+++ b/tests/functional/TestErrorHandling/tests/heketi_zone_check_test.go
@@ -1,0 +1,68 @@
+// +build functional
+
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
+//
+
+package tests
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/heketi/pkg/testutils"
+	"github.com/heketi/heketi/server/config"
+	"github.com/heketi/tests"
+)
+
+func TestVolumeCreateMultipleZone(t *testing.T) {
+
+	heketiServer := testutils.NewServerCtlFromEnv("..")
+	origConf := path.Join(heketiServer.ServerDir, heketiServer.ConfPath)
+
+	heketiServer.ConfPath = tests.Tempfile()
+	defer os.Remove(heketiServer.ConfPath)
+
+	// set zoneChecking  to  strict
+	UpdateConfig(origConf, heketiServer.ConfPath, func(c *config.Config) {
+		c.GlusterFS.ZoneChecking = "strict"
+	})
+	testutils.ServerStarted(t, heketiServer)
+	defer testutils.ServerStopped(t, heketiServer)
+
+	tce := testCluster.Copy()
+	tce.Update()
+	volReq := &api.VolumeCreateRequest{}
+	volReq.Size = 10
+	volReq.Durability.Type = api.DurabilityReplicate
+	volReq.Durability.Replicate.Replica = 3
+
+	t.Run("volumeCreateSucceeds", func(t *testing.T) {
+		//Make sure we are adding nodes as below
+		//Node0 ---> Zone1
+		//Node1 ---> Zone2
+		//Node2,Node3 ---> Zone3
+		tce.CustomizeNodeRequest = func(i int, req *api.NodeAddRequest) {
+			if i >= 2 {
+				req.Zone = 3
+			} else {
+				req.Zone = i + 1
+			}
+		}
+		tce.Teardown(t)
+		tce.Setup(t, 4, 4)
+		defer tce.Teardown(t)
+		_, err := heketi.VolumeCreate(volReq)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	})
+}

--- a/tests/functional/TestErrorHandling/tests/heketi_zone_check_test.go
+++ b/tests/functional/TestErrorHandling/tests/heketi_zone_check_test.go
@@ -65,4 +65,23 @@ func TestVolumeCreateMultipleZone(t *testing.T) {
 		_, err := heketi.VolumeCreate(volReq)
 		tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	})
+
+	t.Run("volumeCreateFails", func(t *testing.T) {
+		//Make sure we are adding nodes as below
+		//Node0 ---> Zone1
+		//Node1 ---> Zone1
+		//Node2,Node3 ---> Zone2
+		tce.CustomizeNodeRequest = func(i int, req *api.NodeAddRequest) {
+			if i >= 2 {
+				req.Zone = 2
+			} else {
+				req.Zone = 1
+			}
+		}
+		tce.Teardown(t)
+		tce.Setup(t, 4, 4)
+		defer tce.Teardown(t)
+		_, err := heketi.VolumeCreate(volReq)
+		tests.Assert(t, err != nil, "expected err != nil")
+	})
 }


### PR DESCRIPTION
device info is stored with prefix DEVICE, we need to ignore these keys when we are listing the devices to add bricks.

Fixes: #1531 
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?
This PR filter out the device ID which starts with "DEVICE"

### Notes for the reviewer


