### PR TITLE
Better error when unmarshaling a db entry fails

### DIFF
--- a/apps/glusterfs/dbentry.go
+++ b/apps/glusterfs/dbentry.go
@@ -139,8 +139,9 @@ func EntryLoad(tx *bolt.Tx, entry DbEntry, key string) error {
 
 	err := entry.Unmarshal(val)
 	if err != nil {
-		logger.Err(err)
-		return err
+		return logger.LogError(
+			"failed to unmarshal db entry at %v/%v: %v",
+			entry.BucketName(), key, err)
 	}
 
 	return nil


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

This change provides an improved error message that points to the bucket and key of the failing entry if the unmarshal function of an entry fetched from the db fails.
