### PR TITLE
add functions for customizing cluster setup

### DIFF
--- a/tests/functional/TestSmokeTest/tests/heketi_test.go
+++ b/tests/functional/TestSmokeTest/tests/heketi_test.go
@@ -58,10 +58,6 @@ func setupCluster(t *testing.T, numNodes int, numDisks int) {
 	cenv.Setup(t, numNodes, numDisks)
 }
 
-func dbStateDump(t *testing.T) {
-	cenv.StateDump(t)
-}
-
 func teardownCluster(t *testing.T) {
 	cenv.Teardown(t)
 }


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Add a function to copy the ClusterEnv so customization can be applied to
a copy of the global cluster env. Add callback functions
CustomizeNodeRequest and CustomizeDeviceRequest so individual tests can
make tweaks to the cluster config without having to do the same as the
setup functions manually.


### Notes for the reviewer

This functionality can serve as a building block for future tests that need to check the behavior of the system and the stock cluster setup functions are too limiting.
