### PR TITLE
tests: use wipefs for cleaning disks in functional tests

### DIFF
--- a/tests/functional/TestErrorHandling/vagrant/roles/common/tasks/main.yml
+++ b/tests/functional/TestErrorHandling/vagrant/roles/common/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: clean disks
-  command: dd if=/dev/zero of={{ item }} count=100 bs=1024k
+  command: wipefs -a {{ item }}
   with_items:
     - /dev/vdb
     - /dev/vdc

--- a/tests/functional/TestManyBricksVolume/vagrant/roles/common/tasks/main.yml
+++ b/tests/functional/TestManyBricksVolume/vagrant/roles/common/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: clean disks
-  command: dd if=/dev/zero of={{ item }} count=100 bs=1024k
+  command: wipefs -a {{ item }}
   with_items:
     - /dev/vdb
     - /dev/vdc

--- a/tests/functional/TestSmokeTest/vagrant/roles/common/tasks/main.yml
+++ b/tests/functional/TestSmokeTest/vagrant/roles/common/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: clean disks
-  command: dd if=/dev/zero of={{ item }} count=100 bs=1024k
+  command: wipefs -a {{ item }}
   with_items:
     - /dev/vdb
     - /dev/vdc

--- a/tests/functional/TestVolumeNotDeletedWhenNodeIsDown/vagrant/roles/common/tasks/main.yml
+++ b/tests/functional/TestVolumeNotDeletedWhenNodeIsDown/vagrant/roles/common/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: clean disks
-  command: dd if=/dev/zero of={{ item }} count=100 bs=1024k
+  command: wipefs -a {{ item }}
   with_items:
     - /dev/vdb
     - /dev/vdc

--- a/tests/functional/TestVolumeSnapshotBehavior/vagrant/roles/common/tasks/main.yml
+++ b/tests/functional/TestVolumeSnapshotBehavior/vagrant/roles/common/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: clean disks
-  command: dd if=/dev/zero of={{ item }} count=100 bs=1024k
+  command: wipefs -a {{ item }}
   with_items:
     - /dev/vdb
     - /dev/vdc


### PR DESCRIPTION
The current approach of using "dd if=/dev/zeros ..." occupies over
3GB disk space already during provisioning and is pretty slow.
wipefs achieves the same almost without allocating disk space and is
a lot quicker.

Signed-off-by: Sven Anderson <sven@redhat.com>


