### PR TITLE
remoteexec: escape single quotes in quoted shell command

### DIFF
--- a/pkg/remoteexec/ssh/ssh.go
+++ b/pkg/remoteexec/ssh/ssh.go
@@ -16,6 +16,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"strings"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -157,7 +158,10 @@ func (s *SshExec) ExecCommands(
 			command = "sudo " + command
 		}
 		// Execute command in a shell
-		command = "/bin/bash -c '" + command + "'"
+		command = "/bin/bash -c '" +
+			// Escape single quotes in commands (' -> '\'')
+			strings.Replace(command, `'`, `'\''`, -1) +
+			"'"
 
 		// Execute command
 		err = session.Start(command)


### PR DESCRIPTION
The ssh executor wraps the to-be-executed command into single quotes
in order to pass it to bash as a command line argument.  However, the
quotes that might be contained by the command string are not handles.
This has several implications.  First, the single quotes get lost in
the intermediate shell, so they can't have any effect in last
executing shell.  Secondly, quotes allow to "escape" the quoting,
having unexpected effects, possibly even security implications.  Many
places in the code use single quotes however, resulting in incorrect
execution lines like `[/bin/bash -c 'mycmd 'foo bar'']`, which would
only execute `mycmd foo` and drop `bar`.

This change escapes the single quotes to the sequence `'\''` resulting
in the correctly interpreted line
`[/bin/bash -c 'mycmd '\''foo bar'\''']`.

Signed-off-by: Sven Anderson <sven@redhat.com>

