### PR TITLE
functional tests: add check to verify volume option has precedence

### DIFF
--- a/tests/functional/TestErrorHandling/tests/heketi_zone_check_test.go
+++ b/tests/functional/TestErrorHandling/tests/heketi_zone_check_test.go
@@ -84,4 +84,16 @@ func TestVolumeCreateMultipleZone(t *testing.T) {
 		_, err := heketi.VolumeCreate(volReq)
 		tests.Assert(t, err != nil, "expected err != nil")
 	})
+
+	t.Run("volumeCreateIgnoreServerSetting", func(t *testing.T) {
+		tce.CustomizeNodeRequest = func(i int, req *api.NodeAddRequest) {
+			req.Zone = 1
+		}
+		tce.Teardown(t)
+		tce.Setup(t, 4, 4)
+		defer tce.Teardown(t)
+		volReq.GlusterVolumeOptions = []string{"user.heketi.zone-checking none"}
+		_, err := heketi.VolumeCreate(volReq)
+		tests.Assert(t, err == nil, "expected err == nil")
+	})
 }


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Add a simple check to verify that setting a zone-checking option of "none" will override the global option of strict zone checking.


