### PR TITLE
Make request poll delay configurable, and speed up tests

### DIFF
--- a/client/api/go-client/block_volume.go
+++ b/client/api/go-client/block_volume.go
@@ -16,7 +16,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
@@ -52,7 +51,7 @@ func (c *Client) BlockVolumeCreate(request *api.BlockVolumeCreateRequest) (
 		return nil, utils.GetErrorFromResponse(r)
 	}
 
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +147,7 @@ func (c *Client) BlockVolumeDelete(id string) error {
 		return utils.GetErrorFromResponse(r)
 	}
 
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return err
 	}

--- a/client/api/go-client/client.go
+++ b/client/api/go-client/client.go
@@ -81,6 +81,13 @@ var defaultClientOptions = ClientOptions{
 	PollDelay:     POLL_DELAY,
 }
 
+// DefaultClientOptions returns a ClientOptions type with all the fields
+// initialized to the default values used internally by the new-client
+// functions.
+func DefaultClientOptions() ClientOptions {
+	return defaultClientOptions
+}
+
 // NewClient creates a new client to access a Heketi server
 func NewClient(host, user, key string) *Client {
 	return NewClientWithOptions(host, user, key, defaultClientOptions)

--- a/client/api/go-client/client.go
+++ b/client/api/go-client/client.go
@@ -34,8 +34,9 @@ const (
 	RETRY_COUNT             = 6
 
 	// default delay values
-	MIN_DELAY = 10
-	MAX_DELAY = 30
+	MIN_DELAY  = 10
+	MAX_DELAY  = 30
+	POLL_DELAY = 400 // milliseconds
 )
 
 type ClientTLSOptions struct {
@@ -49,8 +50,10 @@ type ClientTLSOptions struct {
 type ClientOptions struct {
 	RetryEnabled bool
 	RetryCount   int
-	// control waits between retries
+	// control waits between retries (seconds)
 	RetryMinDelay, RetryMaxDelay int
+	// control wait time while polling for responses (milliseconds)
+	PollDelay int
 }
 
 // Client object
@@ -75,6 +78,7 @@ var defaultClientOptions = ClientOptions{
 	RetryCount:    RETRY_COUNT,
 	RetryMinDelay: MIN_DELAY,
 	RetryMaxDelay: MAX_DELAY,
+	PollDelay:     POLL_DELAY,
 }
 
 // NewClient creates a new client to access a Heketi server
@@ -193,6 +197,11 @@ func (c *Client) doBasic(req *http.Request) (*http.Response, error) {
 // Here we create a new token before it makes the next request.
 func (c *Client) checkRedirect(req *http.Request, via []*http.Request) error {
 	return c.setToken(req)
+}
+
+func (c *Client) pollResponse(r *http.Response) (*http.Response, error) {
+	return c.waitForResponseWithTimer(
+		r, time.Millisecond*time.Duration(c.opts.PollDelay))
 }
 
 // Wait for the job to finish, waiting waitTime on every loop

--- a/client/api/go-client/device.go
+++ b/client/api/go-client/device.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"time"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
@@ -54,7 +53,7 @@ func (c *Client) DeviceAdd(request *api.DeviceAddRequest) error {
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return err
 	}
@@ -138,7 +137,7 @@ func (c *Client) DeviceDeleteWithOptions(
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return err
 	}
@@ -184,7 +183,7 @@ func (c *Client) DeviceState(id string,
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return err
 	}
@@ -220,7 +219,7 @@ func (c *Client) DeviceResync(id string) error {
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Millisecond*250)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return err
 	}

--- a/client/api/go-client/node.go
+++ b/client/api/go-client/node.go
@@ -16,7 +16,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
@@ -54,7 +53,7 @@ func (c *Client) NodeAdd(request *api.NodeAddRequest) (*api.NodeInfoResponse, er
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Millisecond*250)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +130,7 @@ func (c *Client) NodeDelete(id string) error {
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Millisecond*250)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return err
 	}
@@ -175,7 +174,7 @@ func (c *Client) NodeState(id string, request *api.StateRequest) error {
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return err
 	}

--- a/client/api/go-client/operations.go
+++ b/client/api/go-client/operations.go
@@ -16,7 +16,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
@@ -151,7 +150,7 @@ func (c *Client) PendingOperationCleanUp(
 	// AND that the rest async framework in heketi needs to be
 	// polled in order to remove things from its map, the traditional
 	// poll server after request behavior is retained here.
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return err
 	}

--- a/client/api/go-client/volume.go
+++ b/client/api/go-client/volume.go
@@ -16,7 +16,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
@@ -57,7 +56,7 @@ func (c *Client) VolumeCreate(request *api.VolumeCreateRequest) (
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +110,7 @@ func (c *Client) VolumeSetBlockRestriction(id string, request *api.VolumeBlockRe
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +164,7 @@ func (c *Client) VolumeExpand(id string, request *api.VolumeExpandRequest) (
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +276,7 @@ func (c *Client) VolumeDelete(id string) error {
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return err
 	}
@@ -319,7 +318,7 @@ func (c *Client) VolumeClone(id string, request *api.VolumeCloneRequest) (*api.V
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testutils/cluster.go
+++ b/pkg/testutils/cluster.go
@@ -68,8 +68,10 @@ func (ce *ClusterEnv) Copy() *ClusterEnv {
 	return &newce
 }
 
-func (ce *ClusterEnv) client() *client.Client {
-	return client.NewClientNoAuth(ce.HeketiUrl)
+func (ce *ClusterEnv) HeketiClient() *client.Client {
+	opts := client.DefaultClientOptions()
+	opts.PollDelay = 200
+	return client.NewClientWithOptions(ce.HeketiUrl, "", "", opts)
 }
 
 func (ce *ClusterEnv) SshHost(index int) string {
@@ -97,7 +99,7 @@ func (ce *ClusterEnv) Setup(t *testing.T, numNodes, numDisks int) {
 func (ce *ClusterEnv) SetupWithCluster(
 	t *testing.T, req *api.ClusterCreateRequest, numNodes, numDisks int) {
 
-	heketi := ce.client()
+	heketi := ce.HeketiClient()
 
 	// As a testing invariant, we always expect to set up a cluster
 	// at the start of a test on a _clean_ server.
@@ -152,7 +154,7 @@ func (ce *ClusterEnv) SetupWithCluster(
 }
 
 func (ce *ClusterEnv) StateDump(t *testing.T) {
-	heketi := ce.client()
+	heketi := ce.HeketiClient()
 	if t.Failed() {
 		fmt.Println("~~~~~ dumping db state prior to teardown ~~~~~")
 		dump, err := heketi.DbDump()
@@ -166,7 +168,7 @@ func (ce *ClusterEnv) StateDump(t *testing.T) {
 }
 
 func (ce *ClusterEnv) VolumeTeardown(t *testing.T) {
-	heketi := ce.client()
+	heketi := ce.HeketiClient()
 	fmt.Println("~~~ tearing down volumes")
 
 	clusters, err := heketi.ClusterList()
@@ -220,7 +222,7 @@ func (ce *ClusterEnv) nodePurgeDevices(heketi *client.Client, nodeId string) err
 }
 
 func (ce *ClusterEnv) Teardown(t *testing.T) {
-	heketi := ce.client()
+	heketi := ce.HeketiClient()
 	fmt.Println("~~~ tearing down cluster")
 	ce.StateDump(t)
 

--- a/tests/functional/TestErrorHandling/tests/common_test.go
+++ b/tests/functional/TestErrorHandling/tests/common_test.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"os"
 
-	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/heketi/heketi/pkg/logging"
 	"github.com/heketi/heketi/pkg/testutils"
 	"github.com/heketi/heketi/server/config"
@@ -29,7 +28,6 @@ var (
 	logger = logging.NewLogger("[test]", logging.LEVEL_DEBUG)
 
 	heketiUrl = "http://localhost:8080"
-	heketi    = client.NewClientNoAuth(heketiUrl)
 
 	testCluster = &testutils.ClusterEnv{
 		HeketiUrl: heketiUrl,
@@ -51,6 +49,7 @@ var (
 			"/dev/vdi",
 		},
 	}
+	heketi = testCluster.HeketiClient()
 )
 
 // Using the original configuration file located at the path given

--- a/tests/functional/TestSmokeTest/tests/heketi_test.go
+++ b/tests/functional/TestSmokeTest/tests/heketi_test.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 	"testing"
 
-	client "github.com/heketi/heketi/client/api/go-client"
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/logging"
 	"github.com/heketi/heketi/pkg/testutils"
@@ -26,7 +25,6 @@ import (
 var (
 	// Heketi client params
 	heketiUrl = "http://localhost:8080"
-	heketi    = client.NewClientNoAuth(heketiUrl)
 
 	cenv = &testutils.ClusterEnv{
 		HeketiUrl: heketiUrl,
@@ -48,6 +46,7 @@ var (
 			"/dev/vdi",
 		},
 	}
+	heketi = cenv.HeketiClient()
 
 	logger = logging.NewLogger("[test]", logging.LEVEL_DEBUG)
 )


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

These changes remove hard coded delays in the api functions and centralizes that logic. It makes the poll delay configurable when the client type is being created and uses this configurable delay to help speed up the unit and functional tests.


### Notes for the reviewer

This has been sitting on my laptop for too long and I wanted to get it out there even in this unfinished state. Note that this PR is based on #1544 so please review and merge that first.

