### PR TITLE
apps: refactor app creation and setup

### DIFF
--- a/apps/glusterfs/app_test.go
+++ b/apps/glusterfs/app_test.go
@@ -45,7 +45,7 @@ func TestAppAdvsettings(t *testing.T) {
 		BrickMaxSize, BrickMinSize, BrickMaxNum = bmax, bmin, bnum
 	}()
 
-	app := NewApp(conf)
+	app, _ := NewApp(conf)
 	defer app.Close()
 	tests.Assert(t, app != nil)
 	tests.Assert(t, app.conf.Executor == "mock")
@@ -77,7 +77,7 @@ func TestAppLogLevel(t *testing.T) {
 			Loglevel:  level,
 		}
 
-		app := NewApp(conf)
+		app, _ := NewApp(conf)
 		tests.Assert(t, app != nil, "expected app != nil, got:", app)
 
 		switch level {
@@ -106,7 +106,7 @@ func TestAppLogLevel(t *testing.T) {
 		Loglevel:  "blah",
 	}
 
-	app := NewApp(conf)
+	app, _ := NewApp(conf)
 	defer app.Close()
 	tests.Assert(t, app != nil)
 	tests.Assert(t, logger.Level() == logging.LEVEL_NOLOG)
@@ -122,7 +122,7 @@ func TestAppReadOnlyDb(t *testing.T) {
 		Executor: "mock",
 		DBfile:   dbfile,
 	}
-	app := NewApp(conf)
+	app, _ := NewApp(conf)
 	tests.Assert(t, app != nil)
 	tests.Assert(t, app.dbReadOnly == false)
 	app.Close()
@@ -136,7 +136,7 @@ func TestAppReadOnlyDb(t *testing.T) {
 	tests.Assert(t, db != nil)
 
 	// Now open it again and notice how it opened
-	app = NewApp(conf)
+	app, _ = NewApp(conf)
 	defer app.Close()
 	tests.Assert(t, app != nil)
 	tests.Assert(t, app.dbReadOnly == true)
@@ -193,7 +193,7 @@ func TestAppBlockSettings(t *testing.T) {
 		CreateBlockHostingVolumes, BlockHostingVolumeSize = blockauto, blocksize
 	}()
 
-	app := NewApp(conf)
+	app, _ := NewApp(conf)
 	defer app.Close()
 	tests.Assert(t, app != nil)
 	tests.Assert(t, app.conf.Executor == "mock")

--- a/apps/glusterfs/app_volume_test.go
+++ b/apps/glusterfs/app_volume_test.go
@@ -177,8 +177,9 @@ func TestVolumeCreateSmallSize(t *testing.T) {
 		BrickMinSize = bmin
 	}()
 
-	app := NewApp(conf)
+	app, _ := NewApp(conf)
 	defer app.Close()
+	tests.Assert(t, app != nil)
 
 	router := mux.NewRouter()
 	app.SetRoutes(router)

--- a/apps/glusterfs/testapp_mock.go
+++ b/apps/glusterfs/testapp_mock.go
@@ -23,8 +23,8 @@ func NewTestApp(dbfile string) *App {
 		BlockHostingVolumeSize:    1100,
 		MaxInflightOperations:     64, // avoid throttling test code
 	}
-	app := NewApp(appConfig)
-	godbc.Check(app != nil)
+	app, err := NewApp(appConfig)
+	godbc.Check(err == nil)
 
 	return app
 }

--- a/main.go
+++ b/main.go
@@ -387,11 +387,7 @@ func setWithEnvVariables(options *config.Config) {
 
 func setupApp(config *config.Config) (a *glusterfs.App) {
 	defer func() {
-		err := recover()
-		if a == nil {
-			fmt.Fprintln(os.Stderr, "ERROR: Unable to start application")
-			os.Exit(1)
-		} else if err != nil {
+		if err := recover(); err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: Unable to start application: %s\n", err)
 			os.Exit(1)
 		}
@@ -408,12 +404,14 @@ func setupApp(config *config.Config) (a *glusterfs.App) {
 		config.GlusterFS.DisableBackgroundCleaner,
 		"HEKETI_DISABLE_BACKGROUND_CLEANER")
 
-	a = glusterfs.NewApp(config.GlusterFS)
-	if a != nil {
-		if err := a.ServerReset(); err != nil {
-			fmt.Fprintln(os.Stderr, "ERROR: Failed to reset server application")
-			os.Exit(1)
-		}
+	a, e := glusterfs.NewApp(config.GlusterFS)
+	if e != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Unable to start application: %s\n", e)
+		os.Exit(1)
+	}
+	if err := a.ServerReset(); err != nil {
+		fmt.Fprintln(os.Stderr, "ERROR: Failed to reset server application")
+		os.Exit(1)
 	}
 	return a
 }

--- a/pkg/heketitest/heketitest.go
+++ b/pkg/heketitest/heketitest.go
@@ -83,7 +83,7 @@ func NewHeketiMockTestServer(
 		Loglevel: loglevel,
 		DBfile:   h.DbFile,
 	}
-	h.App = glusterfs.NewApp(appConfig)
+	h.App, _ = glusterfs.NewApp(appConfig)
 	if h.App == nil {
 		return nil
 	}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Previously, the NewApp function was only able to return the App or a
nil. This caused the error handling in functions that called NewApp to
be rather awkward and partly led to lack of good error reporting in
the main.go file.




