### PR TITLE
Clean up the "parsing" and precedence for volume options

### DIFF
--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -286,33 +286,43 @@ func (v *VolumeEntry) Unmarshal(buffer []byte) error {
 	return nil
 }
 
+// volOptsMap returns the volume options as a map of space separated
+// key-value pairs. Keys that are found later in the list will overwrite
+// the same key if it occurred earlier in the list. Strings that lack a
+// space separating key from value will be treated as a key  with a
+// value of "".
+func (v *VolumeEntry) volOptsMap() map[string]string {
+	om := map[string]string{}
+	for _, s := range v.GlusterVolumeOptions {
+		r := strings.SplitN(s, " ", 2)
+		if len(r) == 2 {
+			om[r[0]] = r[1]
+		} else {
+			om[r[0]] = ""
+		}
+	}
+	return om
+}
+
 // HasArbiterOption returns true if this volume is flagged for
 // arbiter support.
 func (v *VolumeEntry) HasArbiterOption() bool {
-	for _, s := range v.GlusterVolumeOptions {
-		r := strings.Split(s, " ")
-		if len(r) == 2 && r[0] == HEKETI_ARBITER_KEY {
-			if b, e := strconv.ParseBool(r[1]); e == nil {
-				return b
-			}
-		}
+	value := v.volOptsMap()[HEKETI_ARBITER_KEY]
+	if b, e := strconv.ParseBool(value); e == nil {
+		return b
 	}
 	return false
 }
 
 // GetAverageFileSize returns averageFileSize provided by user or default averageFileSize
 func (v *VolumeEntry) GetAverageFileSize() uint64 {
-	for _, s := range v.GlusterVolumeOptions {
-		r := strings.Split(s, " ")
-		if len(r) == 2 && r[0] == HEKETI_AVERAGE_FILE_SIZE_KEY {
-			if v, e := strconv.ParseUint(r[1], 10, 64); e == nil {
-				if v == 0 {
-					logger.LogError("Average File Size cannot be zero, using default file size %v", averageFileSize)
-					return averageFileSize
-				}
-				return v
-			}
+	value := v.volOptsMap()[HEKETI_AVERAGE_FILE_SIZE_KEY]
+	if size, e := strconv.ParseUint(value, 10, 64); e == nil {
+		if size == 0 {
+			logger.LogError("Average File Size cannot be zero, using default file size %v", averageFileSize)
+			return averageFileSize
 		}
+		return size
 	}
 	return averageFileSize
 }
@@ -320,11 +330,9 @@ func (v *VolumeEntry) GetAverageFileSize() uint64 {
 // GetZoneCheckingStrategy returns a ZoneCheckingStrategy based on
 // the volume's options.
 func (v *VolumeEntry) GetZoneCheckingStrategy() ZoneCheckingStrategy {
-	for _, s := range v.GlusterVolumeOptions {
-		r := strings.Split(s, " ")
-		if len(r) == 2 && r[0] == HEKETI_ZONE_CHECKING_KEY {
-			return ZoneCheckingStrategy(r[1])
-		}
+	value := v.volOptsMap()[HEKETI_ZONE_CHECKING_KEY]
+	if value != "" {
+		return ZoneCheckingStrategy(value)
 	}
 	return ZONE_CHECKING_UNSET
 }

--- a/apps/glusterfs/volume_entry_test.go
+++ b/apps/glusterfs/volume_entry_test.go
@@ -3000,6 +3000,25 @@ func TestVolumeCreateTooFewZones(t *testing.T) {
 		err = v.Create(app.db, app.executor)
 		tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	})
+
+	t.Run("VolOpt ZoneChecking overwrite", func(t *testing.T) {
+		// server defaults to none but volume requests strict checking
+		// after setting none checking (test of option precedence).
+		ZoneChecking = ZONE_CHECKING_NONE
+		req := &api.VolumeCreateRequest{}
+		req.Size = 10
+		req.Durability.Type = api.DurabilityReplicate
+		req.Durability.Replicate.Replica = 3
+		req.GlusterVolumeOptions = []string{
+			"user.heketi.zone-checking none",
+			"user.phony.option 100",
+			"user.heketi.zone-checking strict",
+		}
+		v := NewVolumeEntryFromRequest(req)
+
+		err = v.Create(app.db, app.executor)
+		tests.Assert(t, err == ErrNoSpace, "expected err == ErrNoSpace, got:", err)
+	})
 }
 
 //


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

When extracting a volume option meant for heketi from the volume options
of a volume, use the more common "last item takes precedence" rule. This
will cause heketi to match what the options meant for gluster do and
matches with common expectations.

This change also creates a volume options to map function such that the
functions that extract/parse a value do not have to handle the common
aspects of searching through the options list to find keys and handle
the precedence individually.

### Does this PR fix issues?


Fixes #1551


### Notes for the reviewer

This issue was found when testing the recently added zone checking feature but also turned out to impact the options we added for the arbiter feature.

