### PR TITLE
extra tools: properly remove block vol refs from BHVs

### DIFF
--- a/extras/tools/scrub.py
+++ b/extras/tools/scrub.py
@@ -105,11 +105,21 @@ def delete_volume(data, vid):
 def delete_block_volume(data, vid):
     log.info('deleting block volume %s', vid)
     item = data['blockvolumeentries'].pop(vid, None)
+    # remove any reference (real or dangling) from cluster
     for c in data['clusterentries'].values():
         if vid in c['Info']['blockvolumes']:
             c['Info']['blockvolumes'].remove(vid)
+    # if no item in db, just stop
     if not item:
         return
+    # remove any reference (real or dangling) from BHV
+    vol = data['volumeentries'].get(item['Info']['blockhostingvolume'])
+    if vol:
+        try:
+            vol['Info']['blockinfo']['blockvolume'].remove(vid)
+        except ValueError:
+            log.warning('block volume %s not listed in hosting volume %s',
+                        vid, vol['Info']['id'])
     log.warning('may need manual cleanup: block volume: %s',
         item['Info']['blockvolume'].get('iqn') or '???')
 


### PR DESCRIPTION


### What does this PR achieve? Why do we need it?

 The scrub.py script was not properly cleaning up block volumes in the 
case where the BHV was not also pending. It now correctly removes the 
reference to the block volume from it's BHV.



### Does this PR fix issues?



Fixes #1522

