### PR TITLE
Limit volumes per Gluster cluster

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -11,6 +11,7 @@ package glusterfs
 
 import (
 	"fmt"
+	"math"
 	"net/http"
 	"os"
 	"strconv"
@@ -411,10 +412,18 @@ func (a *App) setAdvSettings() {
 		logger.Info("Post Request Volume Options: %v", a.conf.PostReqVolumeOptions)
 		PostReqVolumeOptions = a.conf.PostReqVolumeOptions
 	}
-
 	if a.conf.ZoneChecking != "" {
 		logger.Info("Zone checking: '%v'", a.conf.ZoneChecking)
 		ZoneChecking = ZoneCheckingStrategy(a.conf.ZoneChecking)
+	}
+	if a.conf.MaxVolumesPerCluster < 0 {
+		logger.Info("Volumes per cluster limit is removed as it is set to %v", a.conf.MaxVolumesPerCluster)
+		maxVolumesPerCluster = math.MaxInt32
+	} else if a.conf.MaxVolumesPerCluster == 0 {
+		logger.Info("Volumes per cluster limit is set to default value of %v", maxVolumesPerCluster)
+	} else {
+		logger.Info("Volumes per cluster limit is set to %v", a.conf.MaxVolumesPerCluster)
+		maxVolumesPerCluster = a.conf.MaxVolumesPerCluster
 	}
 }
 

--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -377,6 +377,14 @@ func (a *App) setFromEnvironmentalVariable() {
 	if "" != env {
 		a.conf.ZoneChecking = env
 	}
+
+	env = os.Getenv("HEKETI_GLUSTER_MAX_VOLUMES_PER_CLUSTER")
+	if env != "" {
+		a.conf.MaxVolumesPerCluster, err = strconv.Atoi(env)
+		if err != nil {
+			logger.LogError("Error: While parsing HEKETI_GLUSTER_MAX_VOLUMES_PER_CLUSTER: %v", err)
+		}
+	}
 }
 
 func (a *App) setAdvSettings() {

--- a/apps/glusterfs/app_config.go
+++ b/apps/glusterfs/app_config.go
@@ -36,6 +36,7 @@ type GlusterFSConfig struct {
 	PreReqVolumeOptions  string `json:"pre_request_volume_options"`
 	PostReqVolumeOptions string `json:"post_request_volume_options"`
 	ZoneChecking         string `json:"zone_checking"`
+	MaxVolumesPerCluster int    `json:"max_volumes_per_cluster"`
 
 	//block settings
 	CreateBlockHostingVolumes bool   `json:"auto_create_block_hosting_volume"`

--- a/apps/glusterfs/cluster_entry.go
+++ b/apps/glusterfs/cluster_entry.go
@@ -156,6 +156,11 @@ func (c *ClusterEntry) VolumeDelete(id string) {
 	c.Info.Volumes = sortedstrings.Delete(c.Info.Volumes, id)
 }
 
+// VolumeCount returns number of volumes in cluster *including* the pending ones
+func (c *ClusterEntry) volumeCount() int {
+	return len(c.Info.Volumes)
+}
+
 func (c *ClusterEntry) BlockVolumeAdd(id string) {
 	c.Info.BlockVolumes = append(c.Info.BlockVolumes, id)
 	c.Info.BlockVolumes.Sort()

--- a/apps/glusterfs/limits.go
+++ b/apps/glusterfs/limits.go
@@ -11,7 +11,8 @@ package glusterfs
 
 var (
 	// Default limits
-	BrickMinSize = uint64(1 * GB)
-	BrickMaxSize = uint64(4 * TB)
-	BrickMaxNum  = 32
+	BrickMinSize         = uint64(1 * GB)
+	BrickMaxSize         = uint64(4 * TB)
+	BrickMaxNum          = 32
+	maxVolumesPerCluster = 1000
 )

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -908,6 +908,12 @@ func eligibleClusters(db wdb.RODB, req ClusterReq,
 					continue
 				}
 			}
+			if c.volumeCount() >= maxVolumesPerCluster {
+				cerr.Add(
+					c.Info.Id,
+					fmt.Errorf("Cluster has %v volumes and limit is %v", c.volumeCount(), maxVolumesPerCluster))
+				continue
+			}
 			candidateClusters = append(candidateClusters, clusterId)
 		}
 		return nil


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
With this change, we can limit volumes that Heketi allows to create in a Gluster cluster.

This change is a departure from the previous behavior of heketi. Earlier, heketi did not limit the volumes per Gluster trusted storage pool but we have seen cases where the glusterd startup times out if the volumes in the trusted storage pool cross 1000. Hence, the default limit is set to 1000.

To override the default value admins should set the `max_volumes_per_cluster option` in `glusterfs` section of heketi.json.
    
Negative value means no limit.
Value set to 0 means use the default.
Positive and valid int value set the limit to that integer.

When env var HEKETI_GLUSTER_MAX_VOLUMES_PER_CLUSTER is set, it overrides the default value and the value provided in heketi config.
    
Signed-off-by: Raghavendra Talur <rtalur@redhat.com>
   
