### PR TITLE
Add a default admin mode option

### DIFF
--- a/main.go
+++ b/main.go
@@ -383,6 +383,11 @@ func setWithEnvVariables(options *config.Config) {
 	if "" != env {
 		options.Profiling = true
 	}
+
+	env = os.Getenv("HEKETI_DEFAULT_STATE")
+	if "" != env {
+		options.DefaultState = env
+	}
 }
 
 func setupApp(config *config.Config) (a *glusterfs.App) {
@@ -517,6 +522,10 @@ func main() {
 	adminss := admin.New()
 	n.Use(adminss)
 	adminss.SetRoutes(heketiRouter)
+	if err := adminss.SetString(options.DefaultState); err != nil {
+		fmt.Fprintln(os.Stderr, "ERROR: unable to set admin state:", err)
+		os.Exit(1)
+	}
 
 	if options.BackupDbToKubeSecret {
 		// Check if running in a Kubernetes environment

--- a/server/admin/state.go
+++ b/server/admin/state.go
@@ -10,6 +10,7 @@
 package admin
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
@@ -36,4 +37,19 @@ func (s *ServerState) Get() api.AdminState {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	return s.state
+}
+
+func (s *ServerState) SetString(v string) error {
+	if v == "" {
+		return nil // do nothing for empty string
+	}
+	state := api.AdminState(v)
+	if state == api.AdminStateNormal ||
+		state == api.AdminStateLocal ||
+		state == api.AdminStateReadOnly {
+
+		s.Set(state)
+		return nil
+	}
+	return fmt.Errorf("unknown admin state name: %v", v)
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	CertFile             string                   `json:"cert_file"`
 	KeyFile              string                   `json:"key_file"`
 	Profiling            bool                     `json:"profiling"`
+	DefaultState         string                   `json:"default_state"`
 
 	// pull in the config sub-object for glusterfs app
 	GlusterFS *glusterfs.GlusterFSConfig `json:"glusterfs"`


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Add the ability to set a config param or environment variable
(HEKETI_DEFAULT_STATE) that will be applied on server start up.  This is
useful in the case that you want heketi to start up but do not want the
server to immediately start serving new requests.

Note: this does not change the behavior of internally driven changes
like the background operations cleanup. That would need to be disabled
independently.




