### PR TITLE
go-client: disable KeepAlives

### DIFF
--- a/client/api/go-client/client.go
+++ b/client/api/go-client/client.go
@@ -181,7 +181,8 @@ func (c *Client) doBasic(req *http.Request) (*http.Response, error) {
 	httpClient := &http.Client{}
 	if c.tlsClientConfig != nil {
 		httpClient.Transport = &http.Transport{
-			TLSClientConfig: c.tlsClientConfig,
+			TLSClientConfig:   c.tlsClientConfig,
+			DisableKeepAlives: true,
 		}
 	}
 	httpClient.CheckRedirect = c.checkRedirect

--- a/client/api/go-client/client.go
+++ b/client/api/go-client/client.go
@@ -61,7 +61,7 @@ type Client struct {
 	user     string
 	throttle chan bool
 
-	// http client
+	// HTTP client
 	httpClient *http.Client
 
 	// configuration for TLS support
@@ -172,7 +172,7 @@ func (c *Client) createHTTPClient() *http.Client {
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
 				Timeout:   30 * time.Second,
-				KeepAlive: 2 * time.Minute,
+				KeepAlive: 30 * time.Second,
 				DualStack: true,
 			}).DialContext,
 			DisableKeepAlives:     false,

--- a/client/api/go-client/client.go
+++ b/client/api/go-client/client.go
@@ -120,8 +120,9 @@ func NewClientNoAuth(host string) *Client {
 }
 
 // Close performs reset HTTP client
-func (c *Client) Close() {
+func (c *Client) Close() error {
 	c.resetHTTPClient()
+	return nil
 }
 
 // SetTLSOptions configures an existing heketi client for

--- a/client/api/go-client/client.go
+++ b/client/api/go-client/client.go
@@ -178,15 +178,23 @@ func (c *Client) doBasic(req *http.Request) (*http.Response, error) {
 		<-c.throttle
 	}()
 
-	httpClient := &http.Client{}
-	if c.tlsClientConfig != nil {
-		httpClient.Transport = &http.Transport{
-			TLSClientConfig:   c.tlsClientConfig,
-			DisableKeepAlives: true,
-		}
-	}
-	httpClient.CheckRedirect = c.checkRedirect
+	httpClient := c.createHTTPClient()
 	return httpClient.Do(req)
+}
+
+// createHTTPClient performs the creation of HTTP client
+func (c *Client) createHTTPClient() *http.Client {
+	tr := http.DefaultTransport.(*http.Transport)
+
+	if c.tlsClientConfig != nil {
+		tr.TLSClientConfig = c.tlsClientConfig
+	}
+	tr.DisableKeepAlives = true
+
+	return &http.Client{
+		Transport:     tr,
+		CheckRedirect: c.checkRedirect,
+	}
 }
 
 // This function is called by the http package if it detects that it needs to

--- a/client/api/go-client/client.go
+++ b/client/api/go-client/client.go
@@ -158,12 +158,12 @@ func (c *Client) SetTLSOptions(o *ClientTLSOptions) error {
 
 // isHTTPClientCloseIdler returns true if HTTP client realize closeIdler interface
 // Details: https://github.com/golang/go/blob/release-branch.go1.12/src/net/http/client.go#L843
-func (c *Client) isHTTPClientCloseIdler() bool {
+func (c *Client) isHTTPClientCloseIdler(i interface{}) bool {
 	type closeIdler interface {
 		CloseIdleConnections()
 	}
 
-	_, ok := http.DefaultTransport.(closeIdler)
+	_, ok := i.(closeIdler)
 	return ok
 }
 
@@ -208,7 +208,7 @@ func (c *Client) createHTTPTransport() *http.Transport {
 	}
 
 	// For golang 1.11 and less we need disable KeepAlives
-	if !c.isHTTPClientCloseIdler() {
+	if !c.isHTTPClientCloseIdler(tr) {
 		tr.DialContext = (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: -1 * time.Second,

--- a/client/cli/go/cmds/block_volume.go
+++ b/client/cli/go/cmds/block_volume.go
@@ -106,6 +106,7 @@ var blockVolumeCreateCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		blockvolume, err := heketi.BlockVolumeCreate(req)
 		if err != nil {
@@ -147,6 +148,7 @@ var blockVolumeDeleteCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		//set url
 		err = heketi.BlockVolumeDelete(volumeId)
@@ -178,6 +180,7 @@ var blockVolumeInfoCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		// Create cluster
 		info, err := heketi.BlockVolumeInfo(volumeId)
@@ -210,6 +213,7 @@ var blockVolumeListCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		// List volumes
 		list, err := heketi.BlockVolumeList()

--- a/client/cli/go/cmds/cluster.go
+++ b/client/cli/go/cmds/cluster.go
@@ -93,6 +93,8 @@ var clusterCreateCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
+
 		// Create cluster
 		cluster, err := heketi.ClusterCreate(req)
 		if err != nil {
@@ -140,6 +142,7 @@ var clusterSetFlagsCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		info, err := heketi.ClusterInfo(clusterId)
 		if err != nil {
@@ -196,6 +199,7 @@ var clusterDeleteCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		//set url
 		err = heketi.ClusterDelete(clusterId)
@@ -226,6 +230,7 @@ var clusterInfoCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		info, err := heketi.ClusterInfo(clusterId)
 		if err != nil {
@@ -262,6 +267,7 @@ var clusterListCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		// List clusters
 		list, err := heketi.ClusterList()

--- a/client/cli/go/cmds/db.go
+++ b/client/cli/go/cmds/db.go
@@ -39,6 +39,7 @@ var dumpDbCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		dump, err := heketi.DbDump()
 		if err != nil {
@@ -61,6 +62,7 @@ var checkDbCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		checkResponse, err := heketi.DbCheck()
 		if err != nil {

--- a/client/cli/go/cmds/device.go
+++ b/client/cli/go/cmds/device.go
@@ -91,6 +91,7 @@ var deviceAddCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		// Add node
 		err = heketi.DeviceAdd(req)
@@ -130,6 +131,7 @@ var deviceDeleteCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		//set url
 		var opts api.DeviceDeleteOptions
@@ -164,6 +166,7 @@ var deviceRemoveCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		//set url
 		req := &api.StateRequest{
@@ -198,6 +201,7 @@ var deviceInfoCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		// Create cluster
 		info, err := heketi.DeviceInfo(deviceId)
@@ -272,6 +276,7 @@ var deviceEnableCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		//set url
 		req := &api.StateRequest{
@@ -307,6 +312,7 @@ var deviceDisableCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		//set url
 		req := &api.StateRequest{
@@ -341,6 +347,7 @@ var deviceResyncCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		//set url
 		err = heketi.DeviceResync(deviceId)
@@ -363,6 +370,8 @@ var deviceSetTagsCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
+
 		return setTagsCommand(cmd, heketi.DeviceSetTags)
 	},
 }
@@ -379,6 +388,8 @@ var deviceRmTagsCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
+
 		return rmTagsCommand(cmd, heketi.DeviceSetTags)
 	},
 }

--- a/client/cli/go/cmds/heketi_storage.go
+++ b/client/cli/go/cmds/heketi_storage.go
@@ -322,7 +322,7 @@ var setupHeketiStorageCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		defer heketi.Close()
+		defer c.Close()
 
 		// Create volume
 		volume, err := createHeketiStorageVolume(c, durability, heketiStorageReplicaCount)

--- a/client/cli/go/cmds/heketi_storage.go
+++ b/client/cli/go/cmds/heketi_storage.go
@@ -322,6 +322,7 @@ var setupHeketiStorageCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		// Create volume
 		volume, err := createHeketiStorageVolume(c, durability, heketiStorageReplicaCount)

--- a/client/cli/go/cmds/loglevel.go
+++ b/client/cli/go/cmds/loglevel.go
@@ -41,6 +41,8 @@ var logLevelGetCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
+
 		llinfo, err := heketi.LogLevelGet()
 		if err == nil {
 			fmt.Fprintf(stdout, "%s\n", llinfo.LogLevel["glusterfs"])
@@ -65,6 +67,8 @@ var logLevelSetCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
+
 		err = heketi.LogLevelSet(&api.LogLevelInfo{
 			LogLevel: map[string]string{"glusterfs": args[0]},
 		})

--- a/client/cli/go/cmds/node.go
+++ b/client/cli/go/cmds/node.go
@@ -95,6 +95,7 @@ var nodeAddCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		// Add node
 		node, err := heketi.NodeAdd(req)
@@ -148,6 +149,7 @@ var nodeDeleteCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		//set url
 		err = heketi.NodeDelete(nodeId)
@@ -180,6 +182,7 @@ var nodeEnableCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		//set url
 		req := &api.StateRequest{
@@ -215,6 +218,7 @@ var nodeDisableCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		//set url
 		req := &api.StateRequest{
@@ -240,6 +244,7 @@ var nodeListCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		clusters, err := heketi.ClusterList()
 		if err != nil {
@@ -283,6 +288,7 @@ var nodeInfoCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		info, err := heketi.NodeInfo(nodeId)
 		if err != nil {
@@ -361,6 +367,7 @@ var nodeRemoveCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		//set url
 		req := &api.StateRequest{
@@ -386,6 +393,8 @@ var nodeSetTagsCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
+
 		return setTagsCommand(cmd, heketi.NodeSetTags)
 	},
 }
@@ -402,6 +411,8 @@ var nodeRmTagsCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
+
 		return rmTagsCommand(cmd, heketi.NodeSetTags)
 	},
 }

--- a/client/cli/go/cmds/server.go
+++ b/client/cli/go/cmds/server.go
@@ -84,6 +84,8 @@ func operationsInfoSummary() error {
 	if err != nil {
 		return err
 	}
+	defer heketi.Close()
+
 	t, err := template.New("opInfo").Parse(opInfoTemplate)
 	if err != nil {
 		return err
@@ -100,6 +102,8 @@ func operationDetails(id string) error {
 	if err != nil {
 		return err
 	}
+	defer heketi.Close()
+
 	t, err := template.New("popDetails").Parse(popDetailsTemplate)
 	if err != nil {
 		return err
@@ -124,6 +128,8 @@ var operationsListCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
+
 		t, err := template.New("popList").Parse(popListTemplate)
 		if err != nil {
 			return err
@@ -149,6 +155,8 @@ var operationsCleanUpCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
+
 		request := api.PendingOperationsCleanRequest{}
 		if len(args) > 0 {
 			request.Operations = args
@@ -183,6 +191,8 @@ var getModeCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
+
 		adminStatus, err := heketi.AdminStatusGet()
 		if err != nil {
 			return err
@@ -208,6 +218,8 @@ var setModeCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
+
 		value := api.AdminState(args[0])
 		err = heketi.AdminStatusSet(&api.AdminStatus{State: value})
 		return err
@@ -236,6 +248,7 @@ var stateExamineGlusterCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		result, err := heketi.StateExamineGluster()
 		if err != nil {

--- a/client/cli/go/cmds/topology.go
+++ b/client/cli/go/cmds/topology.go
@@ -158,6 +158,7 @@ var topologyLoadCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		// Load current topolgy
 		heketiTopology, err := heketi.TopologyInfo()
@@ -284,6 +285,7 @@ var topologyInfoCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		// Create Topology
 		topoinfo, err := heketi.TopologyInfo()

--- a/client/cli/go/cmds/volume.go
+++ b/client/cli/go/cmds/volume.go
@@ -194,6 +194,7 @@ var volumeCreateCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		// Add volume
 		volume, err := heketi.VolumeCreate(req)
@@ -263,6 +264,7 @@ var volumeDeleteCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		//set url
 		err = heketi.VolumeDelete(volumeId)
@@ -300,6 +302,7 @@ var volumeExpandCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		// Expand volume
 		volume, err := heketi.VolumeExpand(id, req)
@@ -353,6 +356,7 @@ var volumeBlockHostingRestrictionLockCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		// Set the flag
 		volume, err := heketi.VolumeSetBlockRestriction(volumeID, req)
@@ -400,6 +404,7 @@ var volumeBlockHostingRestrictionUnlockCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		// Set the flag
 		volume, err := heketi.VolumeSetBlockRestriction(volumeID, req)
@@ -440,6 +445,7 @@ var volumeInfoCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		info, err := heketi.VolumeInfo(volumeId)
 		if err != nil {
@@ -522,6 +528,7 @@ var volumeListCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		// List volumes
 		list, err := heketi.VolumeList()
@@ -583,6 +590,7 @@ var volumeCloneCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		defer heketi.Close()
 
 		// Clone the volume
 		volume, err := heketi.VolumeClone(volumeId, req)


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
This PR fixed connection leak in heketi go-client (TLS enabled)

You can see same problem requested to the golang repository:
https://github.com/golang/go/issues/24719#issuecomment-379371501

### Notes for the reviewer
heketi: 8.0.0
golang: 1.12.1

### Details
Our watcher requests to heketi one time per minute to get devices info. After one day works we have been seeing thousands  of established connections. We use TLS between our watcher and heketi server.