### PR TITLE
docs: change arbiter doc to note that "supported" is default

### DIFF
--- a/docs/design/arbiter.md
+++ b/docs/design/arbiter.md
@@ -40,7 +40,7 @@ following specific meanings:
 * supported: The node or device may support data or arbiter bricks.
 * disabled: The node or device must not host arbiter bricks.
 
-Any other string will be de-facto treated the same as "disabled".
+Any other string will be de-facto treated the same as "supported".
 
 For convenience, a device that lacks a specific tag key will
 "inherit" the key and value from the node it resides on.


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

Fixes a mistake in the design doc. If people read the design doc it will still be a little out of date but not wrong.

### Does this PR fix issues?


Fixes #1301


### Notes for the reviewer


