### PR TITLE
Have the server refuse to start if db has unknown dbattributes

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -219,6 +219,14 @@ func (app *App) initDB() error {
 				return logger.LogError("Unable to initialize buckets: %v", err)
 			}
 
+			// Check that this is db we can safely use
+			validAttributes := validDbAttributeKeys(tx, mapDbAtrributeKeys())
+			if !validAttributes {
+				return logger.LogError(
+					"Unable to initialize db, unknown attributes are present" +
+						" (db from a newer version of heketi?)")
+			}
+
 			// Handle Upgrade Changes
 			err = UpgradeDB(tx)
 			if err != nil {
@@ -228,7 +236,7 @@ func (app *App) initDB() error {
 			return nil
 		})
 	}
-	return nil
+	return err
 }
 
 func (app *App) initNodeMonitor() {

--- a/apps/glusterfs/dbattribute_entry.go
+++ b/apps/glusterfs/dbattribute_entry.go
@@ -17,6 +17,15 @@ import (
 	"github.com/lpabon/godbc"
 )
 
+var (
+	dbAttributeKeys = []string{
+		DB_BRICK_HAS_SUBTYPE_FIELD,
+		DB_CLUSTER_HAS_FILE_BLOCK_FLAG,
+		DB_GENERATION_ID,
+		DB_HAS_PENDING_OPS_BUCKET,
+	}
+)
+
 type DbAttributeEntry struct {
 	Key   string
 	Value string
@@ -79,4 +88,31 @@ func DbAttributeList(tx *bolt.Tx) ([]string, error) {
 		return nil, ErrAccessList
 	}
 	return list, nil
+}
+
+// validDbAttributeKeys returns true if all dbattribute keys in the
+// database match keys in knownKeys map.
+func validDbAttributeKeys(tx *bolt.Tx, knownKeys map[string]bool) bool {
+	list := EntryKeys(tx, BOLTDB_BUCKET_DBATTRIBUTE)
+	if list == nil {
+		logger.LogError("unable to list keys in dbattribute bucket")
+		return false
+	}
+	for _, key := range list {
+		if !knownKeys[key] {
+			logger.LogError("unknown dbattribute key: %+v", key)
+			return false
+		}
+	}
+	return true
+}
+
+// mapDbAtrributeKeys returns a map equivalent of dbAttributeKeys
+// for fast lookup.
+func mapDbAtrributeKeys() map[string]bool {
+	m := map[string]bool{}
+	for _, k := range dbAttributeKeys {
+		m[k] = true
+	}
+	return m
 }

--- a/apps/glusterfs/dbattribute_entry_test.go
+++ b/apps/glusterfs/dbattribute_entry_test.go
@@ -1,0 +1,63 @@
+//
+// Copyright (c) 2019 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"os"
+	"testing"
+
+	"github.com/boltdb/bolt"
+	"github.com/heketi/tests"
+)
+
+func TestMapDbAtrributeKeys(t *testing.T) {
+	x := mapDbAtrributeKeys()
+	tests.Assert(t, len(x) == len(dbAttributeKeys), "different lengths")
+	for _, k := range dbAttributeKeys {
+		tests.Assert(t, x[k], k, "missing from", x)
+	}
+}
+
+func TestValidDbAttributeKeys(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	app := NewTestApp(tmpfile)
+
+	// test normal db attributes (for this version)
+	app.db.View(func(tx *bolt.Tx) error {
+		v := validDbAttributeKeys(tx, mapDbAtrributeKeys())
+		tests.Assert(t, v, "expected db attributes valid")
+		return nil
+	})
+
+	// add some fake known attributes. This is still valid
+	// if the db lacks keys we know about. DB is probably just old.
+	app.db.View(func(tx *bolt.Tx) error {
+		m := mapDbAtrributeKeys()
+		m["LOVELY_WATER"] = true
+		m["THAT_SINKING_FEELING"] = true
+		v := validDbAttributeKeys(tx, m)
+		tests.Assert(t, v, "expected db attributes valid")
+		return nil
+	})
+
+	app.db.Update(func(tx *bolt.Tx) error {
+		entry := NewDbAttributeEntry()
+		entry.Key = "LOVELY_FISH"
+		entry.Value = "no"
+		err := entry.Save(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		v := validDbAttributeKeys(tx, mapDbAtrributeKeys())
+		tests.Assert(t, !v, "expected db attributes not valid")
+		return nil
+	})
+}

--- a/tests/functional/TestErrorHandling/tests/db_contents_test.go
+++ b/tests/functional/TestErrorHandling/tests/db_contents_test.go
@@ -1,0 +1,114 @@
+// +build functional
+
+//
+// Copyright (c) 2019 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
+//
+
+package tests
+
+import (
+	"encoding/json"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/heketi/tests"
+
+	"github.com/heketi/heketi/pkg/testutils"
+)
+
+func TestServerStartUnknownDbAttrs(t *testing.T) {
+	heketiServer := testutils.NewServerCtlFromEnv("..")
+	origConf := path.Join(heketiServer.ServerDir, heketiServer.ConfPath)
+
+	heketiServer.ConfPath = tests.Tempfile()
+	defer os.Remove(heketiServer.ConfPath)
+	CopyFile(origConf, heketiServer.ConfPath)
+
+	defer func() {
+		CopyFile(origConf, heketiServer.ConfPath)
+		testutils.ServerRestarted(t, heketiServer)
+		testCluster.Teardown(t)
+		testutils.ServerStopped(t, heketiServer)
+	}()
+
+	testutils.ServerStarted(t, heketiServer)
+	heketiServer.KeepDB = true
+
+	// we only need setup to put something in the db
+	testCluster.Setup(t, 3, 3)
+	testutils.ServerStopped(t, heketiServer)
+
+	// we need a clean copy of the db so we can actually clean up later
+	tmpDb := tests.Tempfile()
+	defer os.Remove(tmpDb)
+
+	dbPath := path.Join(heketiServer.ServerDir, heketiServer.DbPath)
+	err := CopyFile(dbPath, tmpDb)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	defer CopyFile(tmpDb, dbPath)
+
+	dbJson := tests.Tempfile()
+	defer os.Remove(dbJson)
+
+	// export the db to json so we can hack it up
+	err = heketiServer.RunOfflineCmd(
+		[]string{"db", "export",
+			"--dbfile", heketiServer.DbPath,
+			"--jsonfile", dbJson})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// edit the json dump so that it contains a bogus db attribute
+	var dump map[string]interface{}
+	readJsonDump(t, dbJson, &dump)
+	dbat, ok := dump["dbattributeentries"].(map[string]interface{})
+	tests.Assert(t, ok, "conversion failed")
+	type tempk struct {
+		Key   string
+		Value string
+	}
+	dbat["NOPE_NOPE_NOPE"] = tempk{"NOPE_NOPE_NOPE", "no"}
+	writeJsonDump(t, dbJson, dump)
+
+	// restore the "hacked" json to a heketi db (replacing old version)
+	os.Remove(dbPath)
+	err = heketiServer.RunOfflineCmd(
+		[]string{"db", "import",
+			"--dbfile", heketiServer.DbPath,
+			"--jsonfile", dbJson})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// server should refuse to start due to "bad" attributes
+	err = heketiServer.Start()
+	tests.Assert(t, err != nil, "expected err != nil")
+	tests.Assert(t, !heketiServer.IsAlive(), "expected heketi server stopped")
+}
+
+func readJsonDump(t *testing.T, path string, v interface{}) {
+	fp, err := os.Open(path)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	defer fp.Close()
+
+	jdec := json.NewDecoder(fp)
+	err = jdec.Decode(v)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+}
+
+func writeJsonDump(t *testing.T, path string, v interface{}) {
+	fp, err := os.Create(path)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	defer fp.Close()
+
+	enc := json.NewEncoder(fp)
+	enc.SetIndent("", "    ")
+	err = enc.Encode(v)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+}


### PR DESCRIPTION


### What does this PR achieve? Why do we need it?

Check that all the dbattributes in the db are known and if there is an
unknown attribute, which is probably from a too-new version of heketi,
refuse to start.
* Adds unit tests
* Adds functional test

### Does this PR fix issues?


Fixes #1361


### Notes for the reviewer

I have made this unconditional, but I'm open to making this test conditional. I didn't think we hit too many cases where we'd need to turn the check off though so I left it out. Any opinions?

