### PR TITLE
Use temporary directory for db extraction

### DIFF
--- a/extras/container/heketi-start.sh
+++ b/extras/container/heketi-start.sh
@@ -6,6 +6,7 @@
 
 : "${HEKETI_PATH:=/var/lib/heketi}"
 : "${BACKUPDB_PATH:=/backupdb}"
+: "${TMP_PATH:=/tmp}"
 LOG="${HEKETI_PATH}/container.log"
 
 info() {
@@ -72,13 +73,11 @@ fi
 
 if [[ -d "${BACKUPDB_PATH}" ]]; then
     if [[ -f "${BACKUPDB_PATH}/heketi.db.gz" ]] ; then
-        gunzip -c "${BACKUPDB_PATH}/heketi.db.gz" > "${BACKUPDB_PATH}/heketi.db"
+        gunzip -c "${BACKUPDB_PATH}/heketi.db.gz" > "${TMP_PATH}/heketi.db"
         if [[ $? -ne 0 ]]; then
             fail "Unable to extract backup database"
         fi
-    fi
-    if [[ -f "${BACKUPDB_PATH}/heketi.db" ]] ; then
-        cp "${BACKUPDB_PATH}/heketi.db" "${HEKETI_PATH}/heketi.db"
+        cp "${TMP_PATH}/heketi.db" "${HEKETI_PATH}/heketi.db"
         if [[ $? -ne 0 ]]; then
             fail "Unable to copy backup database"
         fi


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

This PR fix issue with start the heketi in kubernetes environment when uses backup db to kube secret and sum of sizes packed db and unpacked db is more than 1MiB.
[Kubernetes secrets are limited to 1MiB in size.](https://kubernetes.io/docs/concepts/configuration/secret/#restrictions)


### Does this PR fix issues?

Fixes #1574

### Notes for the reviewer

Line 80 was here only for compatibility with versions prior to 5.0 when db compression was introduced during backup. 