### PR TITLE
Refactor remote command handling and timeout behaviors

### DIFF
--- a/executors/cmdexec/block_volume.go
+++ b/executors/cmdexec/block_volume.go
@@ -58,7 +58,7 @@ func (s *CmdExecutor) BlockVolumeCreate(host string,
 	commands := []string{cmd}
 
 	// Execute command
-	results, err := s.RemoteExecutor.ExecCommands(host, commands, 10)
+	results, err := s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands), 10)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func (s *CmdExecutor) BlockVolumeDestroy(host string, blockHostingVolumeName str
 		fmt.Sprintf("gluster-block delete %v/%v --json",
 			blockHostingVolumeName, blockVolumeName),
 	}
-	res, err := s.RemoteExecutor.ExecCommands(host, commands, 10)
+	res, err := s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands), 10)
 	if err != nil {
 		// non-command error conditions
 		return err
@@ -171,7 +171,7 @@ func (c *CmdExecutor) ListBlockVolumes(host string, blockhostingvolume string) (
 
 	commands := []string{fmt.Sprintf("gluster-block list %v --json", blockhostingvolume)}
 
-	results, err := c.RemoteExecutor.ExecCommands(host, commands, 10)
+	results, err := c.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands), 10)
 	if err := rex.AnyError(results, err); err != nil {
 		logger.Err(err)
 		return nil, fmt.Errorf("unable to list blockvolumes on block hosting volume %v : %v", blockhostingvolume, err)

--- a/executors/cmdexec/cmdexec.go
+++ b/executors/cmdexec/cmdexec.go
@@ -26,7 +26,7 @@ var (
 )
 
 type RemoteCommandTransport interface {
-	ExecCommands(host string, commands []string, timeoutMinutes int) (rex.Results, error)
+	ExecCommands(host string, commands rex.Cmds, timeoutMinutes int) (rex.Results, error)
 	RebalanceOnExpansion() bool
 	SnapShotLimit() int
 	GlusterCliTimeout() uint32

--- a/executors/cmdexec/device.go
+++ b/executors/cmdexec/device.go
@@ -60,7 +60,7 @@ func (s *CmdExecutor) DeviceSetup(host, device, vgid string, destroy bool) (d *e
 	)
 
 	// Execute command
-	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 5))
+	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands), 5))
 	if err != nil {
 		err = fmt.Errorf("Setup of device %v failed (already initialized or contains data?): %v", device, err)
 		return nil, err
@@ -93,7 +93,7 @@ func (s *CmdExecutor) PVS(host string) (d *executors.PVSCommandOutput, e error) 
 
 	commands = append(commands, fmt.Sprintf("pvs --reportformat json --units k"))
 
-	results, err := s.RemoteExecutor.ExecCommands(host, commands,
+	results, err := s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands),
 		s.GlusterCliExecTimeout())
 	if err := rex.AnyError(results, err); err != nil {
 		return nil, fmt.Errorf("Unable to get data for LVM PVs")
@@ -113,7 +113,7 @@ func (s *CmdExecutor) VGS(host string) (d *executors.VGSCommandOutput, e error) 
 
 	commands = append(commands, fmt.Sprintf("vgs --reportformat json --units k"))
 
-	results, err := s.RemoteExecutor.ExecCommands(host, commands,
+	results, err := s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands),
 		s.GlusterCliExecTimeout())
 	if err := rex.AnyError(results, err); err != nil {
 		return nil, fmt.Errorf("Unable to get data for LVM VGs")
@@ -133,7 +133,7 @@ func (s *CmdExecutor) LVS(host string) (d *executors.LVSCommandOutput, e error) 
 
 	commands = append(commands, fmt.Sprintf("lvs --reportformat json --units k"))
 
-	results, err := s.RemoteExecutor.ExecCommands(host, commands,
+	results, err := s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands),
 		s.GlusterCliExecTimeout())
 	if err := rex.AnyError(results, err); err != nil {
 		return nil, fmt.Errorf("Unable to get data for LVM LVs")
@@ -196,7 +196,7 @@ func (s *CmdExecutor) removeDevice(host, device, vgid string) error {
 	}
 
 	// Execute command
-	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 5))
+	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands), 5))
 	if err != nil {
 		return logger.LogError(
 			"Failed to delete device %v with id %v on host %v: %v",
@@ -211,7 +211,7 @@ func (s *CmdExecutor) removeDeviceMountPoint(host, vgid string) error {
 		fmt.Sprintf("rmdir %v", pdir),
 	}
 
-	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 5))
+	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands), 5))
 	if err != nil && !strings.Contains(err.Error(), "No such file or directory") {
 		logger.LogError("Error while removing the VG directory: %v", err)
 	}
@@ -228,7 +228,7 @@ func (s *CmdExecutor) getVgSizeFromNode(
 	}
 
 	// Execute command
-	results, err := s.RemoteExecutor.ExecCommands(host, commands, 5)
+	results, err := s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands), 5)
 	if err := rex.AnyError(results, err); err != nil {
 		return err
 	}
@@ -283,7 +283,7 @@ func (s *CmdExecutor) getDeviceHandle(host, device string) (
 	commands = append(commands,
 		fmt.Sprintf("udevadm info --query=symlink --name=%v", device))
 
-	results, err := s.RemoteExecutor.ExecCommands(host, commands, 5)
+	results, err := s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands), 5)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get device handle: %v", err)
 	}
@@ -323,7 +323,7 @@ func (s *CmdExecutor) upgradeHandle(host string, dh *executors.DeviceVgHandle) e
 	commands = append(commands,
 		fmt.Sprintf("vgs -o pv_name,pv_uuid,vg_name --reportformat=json %v",
 			paths.VgIdToName(dh.VgId)))
-	results, err := s.RemoteExecutor.ExecCommands(host, commands, 5)
+	results, err := s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands), 5)
 	if e := rex.AnyError(results, err); e != nil {
 		logger.Warning("failed to get vgs info for handle: %v", err)
 		return nil

--- a/executors/cmdexec/fakeexec_test.go
+++ b/executors/cmdexec/fakeexec_test.go
@@ -70,7 +70,7 @@ func (s *FakeExecutor) RemoteCommandExecute(host string,
 }
 
 func (s *FakeExecutor) ExecCommands(host string,
-	commands []string,
+	commands rex.Cmds,
 	timeoutMinutes int) (rex.Results, error) {
 
 	s.AccessConnection(host)

--- a/executors/cmdexec/fakeexec_test.go
+++ b/executors/cmdexec/fakeexec_test.go
@@ -76,8 +76,12 @@ func (s *FakeExecutor) ExecCommands(host string,
 	s.AccessConnection(host)
 	defer s.FreeConnection(host)
 
+	c := make([]string, len(commands))
+	for i, v := range commands {
+		c[i] = v.String()
+	}
 	return s.fake.FakeConnectAndExec(
-		host+":"+s.portStr, commands, timeoutMinutes, s.useSudo)
+		host+":"+s.portStr, c, timeoutMinutes, s.useSudo)
 }
 
 func (s *FakeExecutor) RebalanceOnExpansion() bool {

--- a/executors/cmdexec/peer.go
+++ b/executors/cmdexec/peer.go
@@ -28,7 +28,7 @@ func (s *CmdExecutor) PeerProbe(host, newnode string) error {
 	commands := []string{
 		fmt.Sprintf("%v peer probe %v", s.glusterCommand(), newnode),
 	}
-	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands,
+	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands),
 		s.GlusterCliExecTimeout()))
 	if err != nil {
 		return err
@@ -41,7 +41,7 @@ func (s *CmdExecutor) PeerProbe(host, newnode string) error {
 			fmt.Sprintf("%v snapshot config snap-max-hard-limit %v",
 				s.glusterCommand(), s.RemoteExecutor.SnapShotLimit()),
 		}
-		err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands,
+		err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands),
 			s.GlusterCliExecTimeout()))
 		if err != nil {
 			return err
@@ -60,7 +60,7 @@ func (s *CmdExecutor) PeerDetach(host, detachnode string) error {
 	commands := []string{
 		fmt.Sprintf("%v peer detach %v", s.glusterCommand(), detachnode),
 	}
-	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands,
+	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands),
 		s.GlusterCliExecTimeout()))
 	if err != nil {
 		logger.Err(err)
@@ -76,7 +76,7 @@ func (s *CmdExecutor) GlusterdCheck(host string) error {
 	commands := []string{
 		fmt.Sprintf("systemctl status glusterd"),
 	}
-	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands, 10))
+	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands), 10))
 	if err != nil {
 		logger.Err(err)
 		return err

--- a/executors/cmdexec/peer.go
+++ b/executors/cmdexec/peer.go
@@ -73,10 +73,9 @@ func (s *CmdExecutor) GlusterdCheck(host string) error {
 	godbc.Require(host != "")
 
 	logger.Info("Check Glusterd service status in node %v", host)
-	commands := []string{
-		fmt.Sprintf("systemctl status glusterd"),
-	}
-	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands), 10))
+	cmd := rex.ToCmd("systemctl status glusterd")
+	cmd.Options.Quiet = true
+	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, rex.Cmds{cmd}, 10))
 	if err != nil {
 		logger.Err(err)
 		return err

--- a/executors/cmdexec/snapshot.go
+++ b/executors/cmdexec/snapshot.go
@@ -30,9 +30,7 @@ func (s *CmdExecutor) snapshotActivate(host string, snapshot string) error {
 		SnapActivate executors.SnapActivate `xml:"snapActivate"`
 	}
 
-	command := []string{
-		fmt.Sprintf("%v --xml snapshot activate %v", s.glusterCommand(), snapshot),
-	}
+	command := rex.OneCmd(fmt.Sprintf("%v --xml snapshot activate %v", s.glusterCommand(), snapshot))
 
 	results, err := s.RemoteExecutor.ExecCommands(host, command,
 		s.GlusterCliExecTimeout())
@@ -64,9 +62,7 @@ func (s *CmdExecutor) snapshotDeactivate(host string, snapshot string) error {
 		SnapDeactivate executors.SnapDeactivate `xml:"snapDeactivate"`
 	}
 
-	command := []string{
-		fmt.Sprintf("%v --xml snapshot deactivate %v", s.glusterCommand(), snapshot),
-	}
+	command := rex.OneCmd(fmt.Sprintf("%v --xml snapshot deactivate %v", s.glusterCommand(), snapshot))
 
 	results, err := s.RemoteExecutor.ExecCommands(host, command,
 		s.GlusterCliExecTimeout())
@@ -107,9 +103,9 @@ func (s *CmdExecutor) SnapshotCloneVolume(host string, vcr *executors.SnapshotCl
 		SnapClone executors.SnapClone `xml:"CloneCreate"`
 	}
 
-	command := []string{
+	command := rex.OneCmd(
 		fmt.Sprintf("%v --xml snapshot clone %v %v", s.glusterCommand(), vcr.Volume, vcr.Snapshot),
-	}
+	)
 
 	results, err := s.RemoteExecutor.ExecCommands(host, command,
 		s.GlusterCliExecTimeout())
@@ -128,9 +124,9 @@ func (s *CmdExecutor) SnapshotCloneVolume(host string, vcr *executors.SnapshotCl
 	}
 
 	// start the newly cloned volume
-	command = []string{
+	command = rex.OneCmd(
 		fmt.Sprintf("%v --xml volume start %v", s.glusterCommand(), vcr.Volume),
-	}
+	)
 
 	err = rex.AnyError(s.RemoteExecutor.ExecCommands(host, command,
 		s.GlusterCliExecTimeout()))
@@ -158,9 +154,9 @@ func (s *CmdExecutor) SnapshotDestroy(host string, snapshot string) error {
 		SnapDelete executors.SnapDelete `xml:"snapDelete"`
 	}
 
-	command := []string{
+	command := rex.OneCmd(
 		fmt.Sprintf("%v --xml snapshot delete %v", s.glusterCommand(), snapshot),
-	}
+	)
 
 	results, err := s.RemoteExecutor.ExecCommands(host, command,
 		s.GlusterCliExecTimeout())

--- a/executors/cmdexec/volume.go
+++ b/executors/cmdexec/volume.go
@@ -73,7 +73,7 @@ func (s *CmdExecutor) VolumeCreate(host string,
 
 	commands = append(commands, fmt.Sprintf("%v volume start %v", s.glusterCommand(), volume.Name))
 
-	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands,
+	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands),
 		s.GlusterCliExecTimeout()))
 	if err != nil {
 		return nil, err
@@ -110,7 +110,7 @@ func (s *CmdExecutor) VolumeExpand(host string,
 		0, // start at the beginning of the brick list
 		inSet,
 		maxPerSet)
-	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands,
+	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands),
 		s.GlusterCliExecTimeout()))
 	if err != nil {
 		return nil, err
@@ -118,7 +118,7 @@ func (s *CmdExecutor) VolumeExpand(host string,
 
 	if s.RemoteExecutor.RebalanceOnExpansion() {
 		commands = []string{fmt.Sprintf("%v volume rebalance %v start", s.glusterCommand(), volume.Name)}
-		err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands,
+		err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands),
 			s.GlusterCliExecTimeout()))
 		if err != nil {
 			// This is a hack. We fake success if rebalance fails.
@@ -144,7 +144,7 @@ func (s *CmdExecutor) VolumeDestroy(host string, volume string) error {
 		fmt.Sprintf("%v volume stop %v force", s.glusterCommand(), volume),
 	}
 
-	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands,
+	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands),
 		s.GlusterCliExecTimeout()))
 	if err != nil {
 		logger.LogError("Unable to stop volume %v: %v", volume, err)
@@ -154,7 +154,7 @@ func (s *CmdExecutor) VolumeDestroy(host string, volume string) error {
 		fmt.Sprintf("%v volume delete %v", s.glusterCommand(), volume),
 	}
 
-	err = rex.AnyError(s.RemoteExecutor.ExecCommands(host, commands,
+	err = rex.AnyError(s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands),
 		s.GlusterCliExecTimeout()))
 	if err != nil {
 		return logger.Err(fmt.Errorf("Unable to delete volume %v: %v", volume, err))
@@ -232,7 +232,7 @@ func (s *CmdExecutor) checkForSnapshots(host, volume string) error {
 		fmt.Sprintf("%v snapshot list %v --xml", s.glusterCommand(), volume),
 	}
 
-	results, err := s.RemoteExecutor.ExecCommands(host, commands,
+	results, err := s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands),
 		s.GlusterCliExecTimeout())
 	if err := rex.AnyError(results, err); err != nil {
 		return fmt.Errorf("Unable to get snapshot information from volume %v: %v", volume, err)
@@ -269,9 +269,9 @@ func (s *CmdExecutor) VolumeInfo(host string, volume string) (*executors.Volume,
 		VolInfo  executors.VolInfo `xml:"volInfo"`
 	}
 
-	command := []string{
+	command := rex.OneCmd(
 		fmt.Sprintf("%v volume info %v --xml", s.glusterCommand(), volume),
-	}
+	)
 
 	//Get the xml output of volume info
 	results, err := s.RemoteExecutor.ExecCommands(host, command,
@@ -299,9 +299,9 @@ func (s *CmdExecutor) VolumesInfo(host string) (*executors.VolInfo, error) {
 		VolInfo  executors.VolInfo `xml:"volInfo"`
 	}
 
-	command := []string{
+	command := rex.OneCmd(
 		fmt.Sprintf("%v volume info --xml", s.glusterCommand()),
-	}
+	)
 
 	//Get the xml output of volume info
 	results, err := s.RemoteExecutor.ExecCommands(host, command,
@@ -324,9 +324,9 @@ func (s *CmdExecutor) VolumeReplaceBrick(host string, volume string, oldBrick *e
 	godbc.Require(newBrick != nil)
 
 	// Replace the brick
-	command := []string{
+	command := rex.OneCmd(
 		fmt.Sprintf("%v volume replace-brick %v %v:%v %v:%v commit force", s.glusterCommand(), volume, oldBrick.Host, oldBrick.Path, newBrick.Host, newBrick.Path),
-	}
+	)
 	err := rex.AnyError(s.RemoteExecutor.ExecCommands(host, command,
 		s.GlusterCliExecTimeout()))
 	if err != nil {
@@ -378,10 +378,10 @@ func (s *CmdExecutor) VolumeSnapshot(host string, vsr *executors.VolumeSnapshotR
 		SnapCreate executors.SnapCreate `xml:"snapCreate"`
 	}
 
-	command := []string{
+	command := rex.OneCmd(
 		fmt.Sprintf("%v --xml snapshot create %v %v no-timestamp", s.glusterCommand(), vsr.Snapshot, vsr.Volume),
 		// TODO: set the snapshot description if vsr.Description is non-empty
-	}
+	)
 
 	results, err := s.RemoteExecutor.ExecCommands(host, command,
 		s.GlusterCliExecTimeout())
@@ -418,9 +418,9 @@ func (s *CmdExecutor) HealInfo(host string, volume string) (*executors.HealInfo,
 		HealInfo executors.HealInfo `xml:"healInfo"`
 	}
 
-	command := []string{
+	command := rex.OneCmd(
 		fmt.Sprintf("%v volume heal %v info --xml", s.glusterCommand(), volume),
-	}
+	)
 
 	results, err := s.RemoteExecutor.ExecCommands(host, command,
 		s.GlusterCliExecTimeout())

--- a/executors/injectexec/transport.go
+++ b/executors/injectexec/transport.go
@@ -25,7 +25,7 @@ type WrapCommandTransport struct {
 }
 
 func (w *WrapCommandTransport) ExecCommands(
-	host string, commands []string, timeoutMinutes int) (rex.Results, error) {
+	host string, commands rex.Cmds, timeoutMinutes int) (rex.Results, error) {
 
 	results := make(rex.Results, len(commands))
 	for i, c := range commands {

--- a/executors/injectexec/transport.go
+++ b/executors/injectexec/transport.go
@@ -35,7 +35,7 @@ func (w *WrapCommandTransport) ExecCommands(
 			continue
 		}
 		tres, err := w.Transport.ExecCommands(
-			host, []string{c}, timeoutMinutes)
+			host, rex.Cmds{c}, timeoutMinutes)
 		if err != nil {
 			return results, err
 		}
@@ -81,10 +81,10 @@ func (w *WrapCommandTransport) XfsSu() int {
 // processing of the command is needed the first return value will
 // be true. The remaining return values are the command's results
 // or error.
-func (w *WrapCommandTransport) Before(command string) rex.Result {
+func (w *WrapCommandTransport) Before(command rex.Cmd) rex.Result {
 
 	if w.handleBefore != nil {
-		return w.handleBefore(command)
+		return w.handleBefore(command.String())
 	}
 	return rex.Result{}
 }
@@ -93,11 +93,11 @@ func (w *WrapCommandTransport) Before(command string) rex.Result {
 // if one is set. The handleAfter function may or may not alter
 // the results of the input results or error condition.
 func (w *WrapCommandTransport) After(
-	command string, results rex.Results) rex.Result {
+	command rex.Cmd, results rex.Results) rex.Result {
 
 	r := results[0]
 	if w.handleAfter != nil {
-		return w.handleAfter(command, r)
+		return w.handleAfter(command.String(), r)
 	}
 	return r
 }

--- a/executors/injectexec/transport_test.go
+++ b/executors/injectexec/transport_test.go
@@ -30,7 +30,7 @@ type DummyTransport struct {
 }
 
 func (d *DummyTransport) ExecCommands(
-	host string, commands []string, timeoutMinutes int) (rex.Results, error) {
+	host string, commands rex.Cmds, timeoutMinutes int) (rex.Results, error) {
 
 	out := make(rex.Results, len(commands))
 	for i, c := range commands {

--- a/executors/injectexec/transport_test.go
+++ b/executors/injectexec/transport_test.go
@@ -35,7 +35,7 @@ func (d *DummyTransport) ExecCommands(
 	out := make(rex.Results, len(commands))
 	for i, c := range commands {
 		out[i].Completed = true
-		out[i].Output = fmt.Sprintf("RESULT(%v)", c)
+		out[i].Output = fmt.Sprintf("RESULT(%v)", c.String())
 	}
 	return out, nil
 }
@@ -76,7 +76,7 @@ func TestWrapCommandTransport(t *testing.T) {
 	w1 := &WrapCommandTransport{Transport: &DummyTransport{}}
 	w2 := &WrapCommandTransport{Transport: w1}
 
-	r, err := w2.ExecCommands("foo", []string{"ls 1", "ls 2"}, 10)
+	r, err := w2.ExecCommands("foo", rex.ToCmds([]string{"ls 1", "ls 2"}), 10)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, len(r) == 2, "expected len(r) == 2, got:", len(r))
 	tests.Assert(t, r[0].Output == "RESULT(ls 1)")
@@ -89,7 +89,7 @@ func TestWrapCommandTransport(t *testing.T) {
 		}
 	}
 
-	r, err = w2.ExecCommands("foo", []string{"ls 1", "ls 2"}, 10)
+	r, err = w2.ExecCommands("foo", rex.ToCmds([]string{"ls 1", "ls 2"}), 10)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, len(r) == 2, "expected len(r) == 2, got:", len(r))
 	tests.Assert(t, r[0].Output == "foo(ls 1)")
@@ -102,7 +102,7 @@ func TestWrapCommandTransport(t *testing.T) {
 		}
 	}
 
-	r, err = w2.ExecCommands("foo", []string{"ls 1", "ls 2"}, 10)
+	r, err = w2.ExecCommands("foo", rex.ToCmds([]string{"ls 1", "ls 2"}), 10)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, len(r) == 2, "expected len(r) == 2, got:", len(r))
 	tests.Assert(t, r[0].Output == "XXXfoo(ls 1)XXX", r[0])
@@ -119,10 +119,10 @@ func TestWrapCommandTransportError(t *testing.T) {
 	w1 := &WrapCommandTransport{Transport: &DummyTransport{}}
 	w2 := &WrapCommandTransport{Transport: w1}
 
-	r, err := w2.ExecCommands("foo", []string{"ls 1", "ls 2"}, 10)
+	r, err := w2.ExecCommands("foo", rex.ToCmds([]string{"ls 1", "ls 2"}), 10)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, len(r) == 2, "expected len(r) == 2, got:", len(r))
-	tests.Assert(t, r[0].Output == "RESULT(ls 1)")
+	tests.Assert(t, r[0].Output == "RESULT(ls 1)", "got", r[0].Output)
 	tests.Assert(t, r[1].Output == "RESULT(ls 2)")
 
 	w1.handleBefore = func(c string) rex.Result {
@@ -131,7 +131,7 @@ func TestWrapCommandTransportError(t *testing.T) {
 			Err:       fmt.Errorf("HipHooray"),
 		}
 	}
-	r, err = w2.ExecCommands("foo", []string{"ls 1", "ls 2"}, 10)
+	r, err = w2.ExecCommands("foo", rex.ToCmds([]string{"ls 1", "ls 2"}), 10)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, !r.Ok(), "expected r.Ok() is false")
 	tests.Assert(t, r[0].Err.Error() == "HipHooray",

--- a/executors/kubeexec/config.go
+++ b/executors/kubeexec/config.go
@@ -22,4 +22,8 @@ type KubeConfig struct {
 	// Use POD name instead of using label
 	// to access POD
 	UsePodNames bool `json:"use_pod_names"`
+
+	// connection resource control and timeouts
+	MaxConnections       int64 `json:"max_connections"`
+	DisableTimeoutPrefix bool  `json:"disable_timeout_prefix"`
 }

--- a/executors/kubeexec/kubeexec.go
+++ b/executors/kubeexec/kubeexec.go
@@ -128,7 +128,7 @@ func NewKubeExecutor(config *KubeConfig) (*KubeExecutor, error) {
 }
 
 func (k *KubeExecutor) ExecCommands(
-	host string, commands []string,
+	host string, commands rex.Cmds,
 	timeoutMinutes int) (rex.Results, error) {
 
 	// Throttle

--- a/executors/kubeexec/kubeexec.go
+++ b/executors/kubeexec/kubeexec.go
@@ -39,6 +39,9 @@ type KubeExecutor struct {
 
 var (
 	logger = logging.NewLogger("[kubeexec]", logging.LEVEL_DEBUG)
+
+	// if not specifified in the config json
+	DefaultMaxConnThreshold uint64 = 64
 )
 
 func setWithEnvVariables(config *KubeConfig) {
@@ -120,6 +123,13 @@ func NewKubeExecutor(config *KubeConfig) (*KubeExecutor, error) {
 	if err != nil {
 		return nil, err
 	}
+	if config.MaxConnections == 0 {
+		k.kconn.MaxConnThreshold = DefaultMaxConnThreshold
+	} else if config.MaxConnections > 0 {
+		k.kconn.MaxConnThreshold = uint64(config.MaxConnections)
+	} else {
+		k.kconn.MaxConnThreshold = 0
+	}
 
 	godbc.Ensure(k != nil)
 	godbc.Ensure(k.Fstab != "")
@@ -167,7 +177,8 @@ func (k *KubeExecutor) ExecCommands(
 	}
 
 	return kube.ExecCommands(k.kconn, tc, commands, kube.TimeoutOptions{
-		TimeoutMinutes: timeoutMinutes,
+		TimeoutMinutes:   timeoutMinutes,
+		UseTimeoutPrefix: !k.config.DisableTimeoutPrefix,
 	})
 }
 

--- a/executors/kubeexec/kubeexec.go
+++ b/executors/kubeexec/kubeexec.go
@@ -166,7 +166,9 @@ func (k *KubeExecutor) ExecCommands(
 		return nil, err
 	}
 
-	return kube.ExecCommands(k.kconn, tc, commands, timeoutMinutes)
+	return kube.ExecCommands(k.kconn, tc, commands, kube.TimeoutOptions{
+		TimeoutMinutes: timeoutMinutes,
+	})
 }
 
 func (k *KubeExecutor) RebalanceOnExpansion() bool {

--- a/executors/sshexec/sshexec.go
+++ b/executors/sshexec/sshexec.go
@@ -24,7 +24,7 @@ import (
 )
 
 type Ssher interface {
-	ExecCommands(host string, commands []string, timeoutMinutes int, useSudo bool) (rex.Results, error)
+	ExecCommands(host string, commands rex.Cmds, timeoutMinutes int, useSudo bool) (rex.Results, error)
 }
 
 type SshExecutor struct {
@@ -138,7 +138,7 @@ func NewSshExecutor(config *SshConfig) (*SshExecutor, error) {
 }
 
 func (s *SshExecutor) ExecCommands(
-	host string, commands []string, timeoutMinutes int) (rex.Results, error) {
+	host string, commands rex.Cmds, timeoutMinutes int) (rex.Results, error) {
 
 	// Throttle
 	s.AccessConnection(host)

--- a/executors/sshexec/sshexec_test.go
+++ b/executors/sshexec/sshexec_test.go
@@ -22,7 +22,7 @@ import (
 // Mock SSH calls
 type FakeSsh struct {
 	FakeExecCommands func(host string,
-		commands []string,
+		commands rex.Cmds,
 		timeoutMinutes int,
 		useSudo bool) (rex.Results, error)
 }
@@ -31,7 +31,7 @@ func NewFakeSsh() *FakeSsh {
 	f := &FakeSsh{}
 
 	f.FakeExecCommands = func(host string,
-		commands []string,
+		commands rex.Cmds,
 		timeoutMinutes int,
 		useSudo bool) (rex.Results, error) {
 		return rex.Results{}, nil
@@ -41,7 +41,7 @@ func NewFakeSsh() *FakeSsh {
 }
 
 func (f *FakeSsh) ExecCommands(host string,
-	commands []string,
+	commands rex.Cmds,
 	timeoutMinutes int,
 	useSudo bool) (rex.Results, error) {
 	return f.FakeExecCommands(host, commands, timeoutMinutes, useSudo)

--- a/pkg/remoteexec/cmd.go
+++ b/pkg/remoteexec/cmd.go
@@ -1,0 +1,12 @@
+//
+// Copyright (c) 2019 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package remoteexec
+
+type Cmds []string

--- a/pkg/remoteexec/cmd.go
+++ b/pkg/remoteexec/cmd.go
@@ -10,6 +10,8 @@
 package remoteexec
 
 type CmdOpts struct {
+	Quiet   bool // suppress output logging on success
+	ErrorOk bool // treat error conditions same as successes
 }
 
 type Cmd interface {

--- a/pkg/remoteexec/cmd.go
+++ b/pkg/remoteexec/cmd.go
@@ -9,4 +9,47 @@
 
 package remoteexec
 
-type Cmds []string
+type CmdOpts struct {
+}
+
+type Cmd interface {
+	String() string
+	Opts() CmdOpts
+}
+
+type StringCmd struct {
+	Command string
+	Options CmdOpts
+}
+
+func (sc StringCmd) String() string {
+	return sc.Command
+}
+
+func (sc StringCmd) Opts() CmdOpts {
+	return sc.Options
+}
+
+type Cmds []Cmd
+
+// conversion functions
+
+// ToCmd converts a single string representing a command to a StringCmd.
+func ToCmd(s string) StringCmd {
+	return StringCmd{Command: s}
+}
+
+// ToCmds converts a string slice to a Cmds group.
+func ToCmds(s []string) Cmds {
+	c := make(Cmds, len(s))
+	for i, val := range s {
+		c[i] = StringCmd{Command: val}
+	}
+	return c
+}
+
+// OneCmd converts a single string representing a command to a Cmds group
+// containing just one command.
+func OneCmd(s string) Cmds {
+	return Cmds{StringCmd{Command: s}}
+}

--- a/pkg/remoteexec/kube/counter.go
+++ b/pkg/remoteexec/kube/counter.go
@@ -1,0 +1,44 @@
+//
+// Copyright (c) 2019 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package kube
+
+import (
+	"sync"
+)
+
+type connectionCounter struct {
+	count uint64
+	lock  *sync.RWMutex
+}
+
+func newConnectionCounter() *connectionCounter {
+	return &connectionCounter{
+		count: 0,
+		lock:  &sync.RWMutex{},
+	}
+}
+
+func (c *connectionCounter) increment() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.count++
+}
+
+func (c *connectionCounter) decrement() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.count--
+}
+
+func (c *connectionCounter) get() uint64 {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.count
+}

--- a/pkg/remoteexec/kube/exec.go
+++ b/pkg/remoteexec/kube/exec.go
@@ -69,7 +69,7 @@ func ExecCommands(
 		var b bytes.Buffer
 		var berr bytes.Buffer
 
-		// Excute command
+		// Execute command
 		err = exec.Stream(remotecommand.StreamOptions{
 			SupportedProtocols: kubeletcmd.SupportedStreamingProtocols,
 			Stdout:             &b,

--- a/pkg/remoteexec/kube/exec.go
+++ b/pkg/remoteexec/kube/exec.go
@@ -33,7 +33,8 @@ func ExecCommands(
 
 	results := make(rex.Results, len(commands))
 
-	for index, command := range commands {
+	for index, cmd := range commands {
+		command := cmd.String()
 
 		// Remove any whitespace
 		command = strings.Trim(command, " ")

--- a/pkg/remoteexec/kube/exec.go
+++ b/pkg/remoteexec/kube/exec.go
@@ -29,7 +29,7 @@ import (
 // are returned as the function's error condition.
 func ExecCommands(
 	k *KubeConn, t TargetContainer,
-	commands []string, timeoutMinutes int) (rex.Results, error) {
+	commands rex.Cmds, timeoutMinutes int) (rex.Results, error) {
 
 	results := make(rex.Results, len(commands))
 

--- a/pkg/remoteexec/kube/exec_test.go
+++ b/pkg/remoteexec/kube/exec_test.go
@@ -19,6 +19,9 @@ import (
 	rex "github.com/heketi/heketi/pkg/remoteexec"
 )
 
+// test timeout options
+var tto = TimeoutOptions{1, false}
+
 // TestExecCommands tests running commands on an actual container.
 // To be honest, this is a bit hokey but was an expedient way to actually
 // test some of the code in this package. To use, build the tests with
@@ -93,7 +96,7 @@ func TestExecCommands(t *testing.T) {
 }
 
 func testExecSimple(t *testing.T, kc *KubeConn, tc TargetContainer) {
-	r, err := ExecCommands(kc, tc, rex.ToCmds([]string{"ls /"}), 1)
+	r, err := ExecCommands(kc, tc, rex.ToCmds([]string{"ls /"}), tto)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, len(r) == 1)
 }
@@ -104,7 +107,7 @@ func testExecSimple3(t *testing.T, kc *KubeConn, tc TargetContainer) {
 		"true",
 		"false",
 	}
-	r, err := ExecCommands(kc, tc, rex.ToCmds(cmds), 1)
+	r, err := ExecCommands(kc, tc, rex.ToCmds(cmds), tto)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, len(r) == 3)
 	tests.Assert(t, r[0].Ok(), "expected r0 OK")
@@ -118,7 +121,7 @@ func testExecStopEarly(t *testing.T, kc *KubeConn, tc TargetContainer) {
 		"ls /proc",
 		"true",
 	}
-	r, err := ExecCommands(kc, tc, rex.ToCmds(cmds), 1)
+	r, err := ExecCommands(kc, tc, rex.ToCmds(cmds), tto)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, len(r) == 3)
 	tests.Assert(t, !r[0].Ok(), "expected r0 not OK")

--- a/pkg/remoteexec/kube/exec_test.go
+++ b/pkg/remoteexec/kube/exec_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 
 	"github.com/heketi/tests"
+
+	rex "github.com/heketi/heketi/pkg/remoteexec"
 )
 
 // TestExecCommands tests running commands on an actual container.
@@ -91,7 +93,7 @@ func TestExecCommands(t *testing.T) {
 }
 
 func testExecSimple(t *testing.T, kc *KubeConn, tc TargetContainer) {
-	r, err := ExecCommands(kc, tc, []string{"ls /"}, 1)
+	r, err := ExecCommands(kc, tc, rex.ToCmds([]string{"ls /"}), 1)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, len(r) == 1)
 }
@@ -102,7 +104,7 @@ func testExecSimple3(t *testing.T, kc *KubeConn, tc TargetContainer) {
 		"true",
 		"false",
 	}
-	r, err := ExecCommands(kc, tc, cmds, 1)
+	r, err := ExecCommands(kc, tc, rex.ToCmds(cmds), 1)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, len(r) == 3)
 	tests.Assert(t, r[0].Ok(), "expected r0 OK")
@@ -116,7 +118,7 @@ func testExecStopEarly(t *testing.T, kc *KubeConn, tc TargetContainer) {
 		"ls /proc",
 		"true",
 	}
-	r, err := ExecCommands(kc, tc, cmds, 1)
+	r, err := ExecCommands(kc, tc, rex.ToCmds(cmds), 1)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, len(r) == 3)
 	tests.Assert(t, !r[0].Ok(), "expected r0 not OK")

--- a/pkg/remoteexec/log/commandlog.go
+++ b/pkg/remoteexec/log/commandlog.go
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2019 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package log
+
+import (
+	rex "github.com/heketi/heketi/pkg/remoteexec"
+)
+
+// Logger interface exists to allow the library to use a
+// logging object provided by the caller.
+type Logger interface {
+	LogError(s string, v ...interface{}) error
+	Err(e error) error
+	Critical(s string, v ...interface{})
+	Debug(s string, v ...interface{})
+}
+
+type CommandLogger struct {
+	logger Logger
+}
+
+func NewCommandLogger(l Logger) *CommandLogger {
+	return &CommandLogger{logger: l}
+}
+
+func (cl *CommandLogger) Before(c rex.Cmd, where string) {
+	cl.logger.Debug(
+		"Will run command [%v] on [%v]",
+		c.String(), where)
+}
+
+func (cl *CommandLogger) Success(c rex.Cmd, where, out, errout string) {
+	if c.Opts().Quiet {
+		cl.logger.Debug(
+			"Ran command [%v] on [%v]: Stdout filtered, Stderr filtered",
+			c.String(), where)
+		return
+	}
+	cl.logger.Debug(
+		"Ran command [%v] on [%v]: Stdout [%v]: Stderr [%v]",
+		c.String(), where, out, errout)
+}
+
+func (cl *CommandLogger) Error(c rex.Cmd, err error, where, out, errout string) {
+	if c.Opts().ErrorOk {
+		cl.Success(c, where, out, errout)
+		return
+	}
+	cl.logger.LogError(
+		"Failed to run command [%v] on [%v]: Err[%v]: Stdout [%v]: Stderr [%v]",
+		c.String(), where, err, out, errout)
+}
+
+func (cl *CommandLogger) Timeout(c rex.Cmd, err error, where, out, errout string) {
+	cl.logger.LogError(
+		"Timeout on command [%v] on [%v]: Err[%v]: Stdout [%v]: Stderr [%v]",
+		c.String(), where, err, out, errout)
+}

--- a/pkg/remoteexec/ssh/ssh.go
+++ b/pkg/remoteexec/ssh/ssh.go
@@ -102,7 +102,7 @@ func NewSshExecWithKeyFile(logger *logging.Logger, user string, file string) *Ss
 // This function was based from https://github.com/coreos/etcd-manager/blob/master/main.go
 func (s *SshExec) ConnectAndExec(host string, commands []string, timeoutMinutes int, useSudo bool) ([]string, error) {
 
-	results, err := s.ExecCommands(host, commands, timeoutMinutes, useSudo)
+	results, err := s.ExecCommands(host, rex.ToCmds(commands), timeoutMinutes, useSudo)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (s *SshExec) ExecCommands(
 	defer client.Close()
 
 	// Execute each command
-	for index, command := range commands {
+	for index, cmd := range commands {
 
 		session, err := client.NewSession()
 		if err != nil {
@@ -139,6 +139,7 @@ func (s *SshExec) ExecCommands(
 		session.Stdout = &b
 		session.Stderr = &berr
 
+		command := cmd.String()
 		if useSudo {
 			command = "sudo " + command
 		}

--- a/pkg/remoteexec/ssh/ssh.go
+++ b/pkg/remoteexec/ssh/ssh.go
@@ -110,7 +110,7 @@ func (s *SshExec) ConnectAndExec(host string, commands []string, timeoutMinutes 
 }
 
 func (s *SshExec) ExecCommands(
-	host string, commands []string,
+	host string, commands rex.Cmds,
 	timeoutMinutes int, useSudo bool) (rex.Results, error) {
 
 	results := make(rex.Results, len(commands))

--- a/tests/functional/TestErrorHandling/tests/device_test.go
+++ b/tests/functional/TestErrorHandling/tests/device_test.go
@@ -366,9 +366,9 @@ func linkDevice(
 
 	sshHost := tc.SshHost(hostIdx)
 	diskPath := tc.Disks[diskIdx]
-	cmds := []string{
+	cmds := rex.OneCmd(
 		fmt.Sprintf("ln -sf %s %s", diskPath, newPath),
-	}
+	)
 	return rex.AnyError(exec.ExecCommands(sshHost, cmds, 10, true))
 }
 
@@ -377,9 +377,9 @@ func rmLink(
 	hostIdx int, path string) error {
 
 	sshHost := tc.SshHost(hostIdx)
-	cmds := []string{
+	cmds := rex.OneCmd(
 		fmt.Sprintf("rm -f %s", path),
-	}
+	)
 	return rex.AnyError(exec.ExecCommands(sshHost, cmds, 10, true))
 }
 

--- a/tests/functional/TestErrorHandling/tests/timeout_test.go
+++ b/tests/functional/TestErrorHandling/tests/timeout_test.go
@@ -33,7 +33,7 @@ var (
 
 func addDelay(timeOut int, node string, exec *ssh.SshExec) error {
 	dumpData := fmt.Sprintf("echo -e %ds >%s", timeOut, delayFile)
-	cmd := []string{dumpData}
+	cmd := rex.OneCmd(dumpData)
 	err := rex.AnyError(exec.ExecCommands(node, cmd, 10, true))
 	return err
 }
@@ -44,7 +44,7 @@ func cleanDelay(node string, exec *ssh.SshExec) error {
 	removePIDFile := fmt.Sprintf("rm -f %s", pidFile)
 
 	cmd := []string{removeSleep, removeDelayFile, removePIDFile}
-	err := rex.AnyError(exec.ExecCommands(node, cmd, 10, true))
+	err := rex.AnyError(exec.ExecCommands(node, rex.ToCmds(cmd), 10, true))
 	return err
 }
 


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Various refactorings in and around the remote execution subsystem.
Highlights include:
* Adding a richer `Cmd` type for commands and their options
* Making logging in the remote exec backends more uniform
* Suppressing the output of noisy commands when they succeed
* Adding a form of timeout to the kube exec backend

### Does this PR fix issues?


Fixes #1555


### Notes for the reviewer


