### PR TITLE
limit for volumes only applies to block volumes with BVH

### DIFF
--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -169,7 +169,7 @@ func (v *BlockVolumeEntry) eligibleClustersAndVolumes(db wdb.RODB) (
 	}
 
 	// find clusters that support block volumes
-	cr := ClusterReq{Block: true}
+	cr := clusterReq{allowCreate: false, allowBlock: true}
 	possibleClusters, e = eligibleClusters(db, cr, possibleClusters)
 	if e != nil {
 		return
@@ -217,6 +217,13 @@ func (v *BlockVolumeEntry) eligibleClustersAndVolumes(db wdb.RODB) (
 			e = err
 			return
 		}
+	}
+
+	if len(volumes) == 0 {
+		// now filter out any clusters that can't support an additional BHV
+		possibleClusters, e = eligibleClusters(
+			db, clusterReq{allowCreate: true, allowBlock: true},
+			possibleClusters)
 	}
 	return
 }


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

When requesting a new block volume the maximum volume limit should
    only apply to BHVs. However, the code was previously treating every
    new blockvolume request as if it was going to also create a BHV.
    This change alters the code such that the check is only applied
    to file volume creates and block volume creates that do not find
    a previous BHV.


### Does this PR fix issues?

Fixes [rhbz#1476223](https://bugzilla.redhat.com/show_bug.cgi?id=1476223)


### Notes for the reviewer


