### PR TITLE
prevent running 'device resync' with pending operations present

### DIFF
--- a/apps/glusterfs/app_device_test.go
+++ b/apps/glusterfs/app_device_test.go
@@ -911,6 +911,81 @@ func TestDeviceSyncIdNotFound(t *testing.T) {
 	tests.Assert(t, r.StatusCode == http.StatusNotFound)
 }
 
+func TestDeviceSyncBlockedByPending(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+	router := mux.NewRouter()
+	app.SetRoutes(router)
+
+	// Setup the server
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	var total uint64 = 600 * 1024 * 1024
+	var used uint64 = 250 * 1024 * 1024
+	var free uint64 = 350 * 1024 * 1024
+
+	// Init test database
+	err := setupSampleDbWithTopology(app,
+		1,    // clusters
+		1,    // nodes_per_cluster
+		1,    // devices_per_node,
+		1*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	var deviceId string
+	app.db.View(func(tx *bolt.Tx) error {
+		ids, err := DeviceList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(ids) == 1)
+		deviceId = ids[0]
+		return nil
+	})
+
+	app.xo.MockGetDeviceInfo = func(host, device, vgid string) (*executors.DeviceInfo, error) {
+		d := &executors.DeviceInfo{}
+		d.TotalSize = total
+		d.FreeSize = free
+		d.UsedSize = used
+		d.ExtentSize = 4096
+		return d, nil
+	}
+
+	vreq := &api.VolumeCreateRequest{
+		Size: 1,
+	}
+	vop := NewVolumeCreateOperation(
+		NewVolumeEntryFromRequest(vreq),
+		app.db)
+	err = vop.Build()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	r, err := http.Get(ts.URL + "/devices/" + deviceId + "/resync")
+	tests.Assert(t, err == nil)
+	tests.Assert(t, r.StatusCode == http.StatusAccepted)
+
+	location, err := r.Location()
+	tests.Assert(t, err == nil)
+
+	for {
+		r, err := http.Get(location.String())
+		tests.Assert(t, err == nil)
+		if r.Header.Get("X-Pending") == "true" {
+			tests.Assert(t, r.StatusCode == http.StatusOK)
+			time.Sleep(time.Millisecond * 10)
+			continue
+		} else {
+			tests.Assert(t, r.StatusCode == http.StatusInternalServerError)
+			break
+		}
+	}
+}
+
 func TestDeviceSetTags(t *testing.T) {
 	tmpfile := tests.Tempfile()
 	defer os.Remove(tmpfile)


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

If the device being resync'ed is part of any pending operations,
deny the resync. This will prevent getting wrong values for the
system and db as changes are being made.

### Does this PR fix issues?

Fixes #1539


### Notes for the reviewer

Note that the issue contemplated adding a --force flag. I opted not to add the flag because this would need additional plumbing in the api and cli and thus additional complexity, where the preferable approach would be to clear all pending operations first (using heketi-cli server operations clean for example). Additionally, only devices that have pending ops on them are blocked so if a device had no pending ops, even though there were pending ops on other devices, it would still be resyncable. But I'm willing to reconsider the force flag if reviewers want to.

