### PR TITLE
Default to authenticated access [behavior change]

### DIFF
--- a/pkg/testutils/serverctl.go
+++ b/pkg/testutils/serverctl.go
@@ -141,7 +141,7 @@ func (s *ServerCtl) Start() error {
 	if err := s.openLog(); err != nil {
 		return err
 	}
-	c := exec.Command(s.HeketiBin, s.ConfigArg())
+	c := exec.Command(s.HeketiBin, s.ConfigArg(), "--disable-auth")
 	if err := s.run(c, nil, nil); err != nil {
 		return err
 	}

--- a/pkg/testutils/serverctl.go
+++ b/pkg/testutils/serverctl.go
@@ -247,6 +247,7 @@ func (s *ServerCtl) Stop() error {
 // set of functionally from testing.T.
 type Tester interface {
 	Fatalf(format string, args ...interface{})
+	Helper()
 }
 
 // ServerStarted asserts that the server s is in the started
@@ -254,6 +255,7 @@ type Tester interface {
 // the server fails to start the function triggers a test
 // failure (through the Tester interface).
 func ServerStarted(t Tester, s *ServerCtl) {
+	t.Helper()
 	if s.IsAvailable() {
 		return
 	}
@@ -270,6 +272,7 @@ func ServerStarted(t Tester, s *ServerCtl) {
 // the server fails to stop the function triggers a test
 // failure (through the Tester interface).
 func ServerStopped(t Tester, s *ServerCtl) {
+	t.Helper()
 	if !s.IsAlive() {
 		return
 	}
@@ -286,6 +289,7 @@ func ServerStopped(t Tester, s *ServerCtl) {
 // steps fails the function triggers a test failure
 // (through the TestSuite interface).
 func ServerRestarted(t Tester, s *ServerCtl) {
+	t.Helper()
 	ServerStopped(t, s)
 	ServerStarted(t, s)
 }

--- a/pkg/testutils/serverctl.go
+++ b/pkg/testutils/serverctl.go
@@ -35,6 +35,8 @@ type ServerCfg struct {
 	ConfPath  string
 	DbPath    string
 	KeepDB    bool
+	// disable auth in the server
+	DisableAuth bool
 	// HelloPort is _only_ to test if the server is running.
 	// It does not control the port the server listens to.
 	HelloPort string
@@ -72,6 +74,9 @@ func NewServerCfgFromEnv(dirDefault string) *ServerCfg {
 		DbPath:    getEnvValue("HEKETI_DB_PATH", "./heketi.db"),
 		ConfPath:  getEnvValue("HEKETI_CONF_PATH", "heketi.json"),
 		HelloPort: getEnvValue("HEKETI_HELLO_PORT", "8080"),
+		// defaulting DisableAuth to true for now to match
+		// historical behavior of our functional tests
+		DisableAuth: true,
 	}
 }
 
@@ -132,6 +137,18 @@ func (s *ServerCtl) ConfigArg() string {
 	return fmt.Sprintf("--config=%v", s.ConfPath)
 }
 
+// ServerArgs returns a string slice of all the arguments to be
+// passed to the heketi binary for server start up.
+func (s *ServerCtl) ServerArgs() []string {
+	args := []string{
+		s.ConfigArg(),
+	}
+	if s.DisableAuth {
+		args = append(args, "--disable-auth")
+	}
+	return args
+}
+
 // Start will start a new instance of the heketi server.
 func (s *ServerCtl) Start() error {
 	if !s.KeepDB {
@@ -141,7 +158,7 @@ func (s *ServerCtl) Start() error {
 	if err := s.openLog(); err != nil {
 		return err
 	}
-	c := exec.Command(s.HeketiBin, s.ConfigArg(), "--disable-auth")
+	c := exec.Command(s.HeketiBin, s.ServerArgs()...)
 	if err := s.run(c, nil, nil); err != nil {
 		return err
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -21,7 +21,7 @@ import (
 
 type Config struct {
 	Port                 string                   `json:"port"`
-	AuthEnabled          bool                     `json:"use_auth"`
+	AuthEnabled          bool                     `json:"use_auth"` // deprecated
 	JwtConfig            middleware.JwtAuthConfig `json:"jwt"`
 	BackupDbToKubeSecret bool                     `json:"backup_db_to_kube_secret"`
 	EnableTls            bool                     `json:"enable_tls"`

--- a/tests/300-db-import-export.sh
+++ b/tests/300-db-import-export.sh
@@ -17,13 +17,13 @@ require_heketi_binaries() {
 
 start_server() {
 	rm -f heketi.db &> /dev/null
-	./heketi-server --config="./heketi.json" &> heketi.log &
+	./heketi-server --config="./heketi.json" --disable-auth &> heketi.log &
 	server_pid=$!
 	sleep 2
 }
 
 restart_server() {
-	./heketi-server --config="./heketi.json" &>> heketi.log &
+	./heketi-server --config="./heketi.json" --disable-auth &>> heketi.log &
 	server_pid=$!
 	sleep 2
 }

--- a/tests/functional/TestEnabledTLS/test_tls.py
+++ b/tests/functional/TestEnabledTLS/test_tls.py
@@ -48,7 +48,7 @@ class HeketiServer(object):
         # do not preserve the heketi db between server instances
         _remove(self.db_path)
         self._proc = subprocess.Popen(
-            [self.heketi_bin, '--config=heketi.json'],
+            [self.heketi_bin, '--config=heketi.json', '--disable-auth'],
             stdin=subprocess.PIPE,
             stdout=self._log,
             stderr=self._log)

--- a/tests/functional/TestUpgrade/test_upgrade.py
+++ b/tests/functional/TestUpgrade/test_upgrade.py
@@ -58,7 +58,7 @@ class HeketiServer(object):
     def start(self):
         self._log = open(self.log_path, 'wb')
         self._proc = subprocess.Popen(
-            [self.heketi_bin, '--config=heketi.json'],
+            [self.heketi_bin, '--config=heketi.json', '--disable-auth'],
             stdin=subprocess.PIPE,
             stdout=self._log,
             stderr=self._log)

--- a/tests/functional/lib.sh
+++ b/tests/functional/lib.sh
@@ -42,7 +42,7 @@ start_heketi() {
 
     # Start server
     rm -f heketi.db > /dev/null 2>&1
-    $HEKETI_SERVER --config=config/heketi.json &
+    $HEKETI_SERVER --config=config/heketi.json --disable-auth &
     HEKETI_PID=$!
 
     wait_for_heketi


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

The heketi server will fail to start if authentication parameters
are not supplied in the configuration. The only way to disable
authentication is to pass the --disable-auth option as a server
command line argument.

Note: This is a significant behavior change.

This is being done to ensure more secure deployments by default. Instead of having to opt-in to authentication, Heketi now requires one to opt out of authentication. Generally, there is not much need to even opt out of authentication (just use auth with a well-known "secret") except for testing and backwards compatibility for older clients where auth has not been configured.



### Notes for the reviewer

If this PR is accepted I plan on mailing the list as well as making a change to the README so visitors to the github page see a highlighted note.

Last changes still need to be squashed, was keeping them seperate for smoke testing purposes.