### PR TITLE
Make entry state naming consistent in heketi cli

### DIFF
--- a/client/cli/go/cmds/device.go
+++ b/client/cli/go/cmds/device.go
@@ -209,11 +209,6 @@ var deviceInfoCommand = &cobra.Command{
 			return err
 		}
 
-		var entryStateRemoved api.EntryState = "removed"
-		if info.State == api.EntryStateFailed {
-			info.State = entryStateRemoved
-		}
-
 		if options.Json {
 			data, err := json.Marshal(info)
 			if err != nil {
@@ -227,7 +222,7 @@ var deviceInfoCommand = &cobra.Command{
 				"Used (GiB): %v\n"+
 				"Free (GiB): %v\n",
 				info.Id,
-				info.State,
+				entryStateString(info.State),
 				info.Storage.Total/(1024*1024),
 				info.Storage.Used/(1024*1024),
 				info.Storage.Free/(1024*1024))

--- a/client/cli/go/cmds/topology.go
+++ b/client/cli/go/cmds/topology.go
@@ -360,7 +360,7 @@ Cluster Id: {{.Id}}
     Nodes:
 {{range .Nodes}}
 	Node Id: {{.Id}}
-	State: {{.State}}
+	State: {{.State | entryStateString }}
 	Cluster Id: {{.ClusterId}}
 	Zone: {{.Zone}}
 	Management Hostnames: {{join .Hostnames.Manage ", "}}
@@ -371,7 +371,7 @@ Cluster Id: {{.Id}}
 	Devices:
 {{- range .DevicesInfo}}
 		Id:{{.Id | printf "%-35v" -}}
-		State:{{.State | printf "%-10v" -}}
+		State:{{.State | entryStateString | printf "%-10v" -}}
 		Size (GiB):{{kibToGib .Storage.Total | printf "%-8v" -}}
 		Used (GiB):{{kibToGib .Storage.Used | printf "%-8v" -}}
 		Free (GiB):{{kibToGib .Storage.Free | printf "%-8v"}}
@@ -401,6 +401,7 @@ func printTopologyInfo(topo *api.TopologyInfoResponse, ts string) error {
 		"kibToGib": func(i uint64) string {
 			return fmt.Sprintf("%d", i/(1024*1024))
 		},
+		"entryStateString": entryStateString,
 	}
 	t, err := template.New("topology").Funcs(fm).Parse(ts)
 	if err != nil {

--- a/client/cli/go/cmds/utils.go
+++ b/client/cli/go/cmds/utils.go
@@ -111,3 +111,14 @@ func newHeketiClient() (*client.Client, error) {
 			VerifyCerts:        options.TLSCerts,
 		})
 }
+
+func entryStateString(s api.EntryState) string {
+	var out string
+	switch s {
+	case api.EntryStateFailed:
+		out = "removed"
+	default:
+		out = string(s)
+	}
+	return out
+}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

PR #831 made an attempt to rename output of state "failed" to "removed" but it was not consistent throughout the CLI. This change attempts to make the printing of "removed" more consistent.

### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #


### Notes for the reviewer


