### PR TITLE
work around broken api use in glide

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -2,6 +2,7 @@ hash: a7e0c0723a91776f34ff8a742912c032e115701284efe18eed15e96da0ed00fd
 updated: 2019-02-07T15:18:42.253317799+01:00
 imports:
 - name: bitbucket.org/ww/goautoneg
+  vcs: hg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
 - name: github.com/asaskevich/govalidator
   version: 852d82c746b23d9b357b210ea470d99f4e023b72


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

No we really shouldn't be manually editing glide.lock but this fixes
the use of a removed bitbucket api by the apparently unmaintained
glide.

### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #


### Notes for the reviewer

Its probably time to start thinking about moving away from glide. Seriously that is.

