### PR TITLE
glide debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BRANCH := $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
 VER := $(shell git describe --match='v[0-9].[0-9].[0-9]')
 TAG := $(shell git tag --points-at HEAD 'v[0-9].[0-9].[0-9]' | tail -n1)
 GO:=go
-GLIDE:=glide
+GLIDE:=glide --debug
 TESTBIN:=./test.sh
 GOARCH := $(shell $(GO) env GOARCH)
 GOOS := $(shell $(GO) env GOOS)


### PR DESCRIPTION
Signed-off-by: Raghavendra Talur <rtalur@redhat.com>

### What does this PR achieve? Why do we need it?
We have been seeing issues with glide. It is not clear why glide fails to build cache for some of the packages. The error "Cannot detect VCS" does not tell what exactly failed. This patch adds debug flag to glide calls in makefile. We would like to run the glide commands in debug mode until we figure out the issue.


