### PR TITLE
tools: print glusterblock volume name for blockvolumes

### DIFF
--- a/extras/tools/comparison.py
+++ b/extras/tools/comparison.py
@@ -217,10 +217,6 @@ def compile_pvdata(summary, pvdata, matchsc):
         if not g and 'glusterBlockShare' not in ma:
             continue
         sc = elem.get('spec', {}).get('storageClassName', '')
-        if matchsc and sc not in matchsc:
-            sys.stderr.write(
-                'ignoring: {} from storage class "{}"\n'.format(g["path"], sc))
-            continue
         if 'path' in g:
             vn = g['path']
             block = False
@@ -229,6 +225,10 @@ def compile_pvdata(summary, pvdata, matchsc):
             block = True
         else:
             raise KeyError('path (volume name) not found in PV data')
+        if matchsc and sc not in matchsc:
+            sys.stderr.write(
+                'ignoring: {} from storage class "{}"\n'.format(vn, sc))
+            continue
         dest = summary.setdefault(vn, {})
         dest[IN_PVS] = True
         if block:


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
Earlier, the error log was referring to gluster volume name from path in
all cases.


