### PR TITLE
etc: remove the default secrets from heketi.json

### DIFF
--- a/etc/heketi.json
+++ b/etc/heketi.json
@@ -19,11 +19,13 @@
   "jwt": {
     "_admin": "Admin has access to all APIs",
     "admin": {
-      "key": "My Secret"
+      "_key_comment": "Set the admin key in the next line",
+      "key": ""
     },
     "_user": "User only has access to /volumes endpoint",
     "user": {
-      "key": "My Secret"
+      "_key_comment": "Set the user key in the next line",
+      "key": ""
     }
   },
 


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
Heketi requires authentication by default now. However, the sample
confin json that is in etc dir has default secrets. To discourage
packagers from using the same as-is, we are removing the default
secrets.


### Notes for the reviewer
Just realized, I don't know how to solve this in container world if the users expect it to run with no config.

