### PR TITLE
provide an endpoint patch for volumes

### DIFF
--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -237,7 +237,9 @@ func (v *VolumeEntry) NewInfoResponse(tx *bolt.Tx) (*api.VolumeInfoResponse, err
 	info := api.NewVolumeInfoResponse()
 	info.Id = v.Info.Id
 	info.Cluster = v.Info.Cluster
-	info.Mount = v.Info.Mount
+	if err := v.updateMountInfo(wdb.WrapTx(tx), &info.VolumeInfo); err != nil {
+		return nil, err
+	}
 	info.Snapshot = v.Info.Snapshot
 	info.Size = v.Info.Size
 	info.Durability = v.Info.Durability

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -628,7 +628,7 @@ func (v *VolumeEntry) saveCreateVolume(db wdb.DB,
 			return ErrNoSpace
 		}
 
-		err = v.updateMountInfo(txdb)
+		err = v.updateMountInfo(txdb, &v.Info)
 		if err != nil {
 			return err
 		}

--- a/client/cli/go/cmds/heketi_storage.go
+++ b/client/cli/go/cmds/heketi_storage.go
@@ -197,8 +197,7 @@ func createHeketiEndpointService() *kubeapi.Service {
 	return service
 }
 
-func createHeketiStorageEndpoints(c *client.Client,
-	volume *api.VolumeInfoResponse) *kubeapi.Endpoints {
+func createHeketiStorageEndpoints(volume *api.VolumeInfoResponse) *kubeapi.Endpoints {
 
 	endpoint := &kubeapi.Endpoints{}
 	endpoint.Kind = "Endpoints"
@@ -345,7 +344,7 @@ var setupHeketiStorageCommand = &cobra.Command{
 		list.Items = append(list.Items, secret)
 
 		// Create endpoints
-		endpoints := createHeketiStorageEndpoints(c, volume)
+		endpoints := createHeketiStorageEndpoints(volume)
 		list.Items = append(list.Items, endpoints)
 
 		// Create service for the endpoints


### PR DESCRIPTION
# What does this PR achieve? Why do we need it?
In Kubernetes and OpenShift, the gluster volume provisioner parses the volume information provided by heketi during volume creation to create the endpoint that is used for mounting the volume.

Some heketi operations, like node or device replace can change the cluster information such that the IPs listed in the endpoints become outdated. In this patch, we provide a command that outputs the current mount information for the volume and can be used to patch an existing endpoint resource.


### Notes for the reviewer

