### PR TITLE
extra tools: when deleting a single block volume, adjust bhv freesize

### DIFF
--- a/extras/tools/scrub.py
+++ b/extras/tools/scrub.py
@@ -117,6 +117,7 @@ def delete_block_volume(data, vid):
     if vol:
         try:
             vol['Info']['blockinfo']['blockvolume'].remove(vid)
+            vol['Info']['blockinfo']['freesize'] += item['Info']['size']
         except ValueError:
             log.warning('block volume %s not listed in hosting volume %s',
                         vid, vol['Info']['id'])


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?
Previously, the scrub.py script was not adjusting the freesize of
the block hosting volume in accordance with the block volume being
deleted. This patch fixes that oversight.


### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #


### Notes for the reviewer


