### PR TITLE
all: fix goimports errors

### DIFF
--- a/client/cli/go/cmds/block_volume.go
+++ b/client/cli/go/cmds/block_volume.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	//	"os"
 	"strings"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/auth0/go-jwt-middleware"
+	jwtmiddleware "github.com/auth0/go-jwt-middleware"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/context"
 	"github.com/heketi/heketi/pkg/logging"

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -21,7 +21,7 @@ import (
 	"regexp"
 	"sort"
 
-	"github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation"
 	"github.com/go-ozzo/ozzo-validation/is"
 )
 

--- a/pkg/kubernetes/backupdb.go
+++ b/pkg/kubernetes/backupdb.go
@@ -20,7 +20,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/kubernetes/pkg/api/v1"
+	v1 "k8s.io/kubernetes/pkg/api/v1"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 )
 

--- a/pkg/kubernetes/backupdb_test.go
+++ b/pkg/kubernetes/backupdb_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/boltdb/bolt"
 
 	"github.com/heketi/tests"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	fakeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/fake"

--- a/pkg/kubernetes/namespace.go
+++ b/pkg/kubernetes/namespace.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/v1"
+	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
 const (

--- a/pkg/remoteexec/kube/target.go
+++ b/pkg/remoteexec/kube/target.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/heketi/heketi/pkg/kubernetes"
 )

--- a/server/rest/asynchttp_test.go
+++ b/server/rest/asynchttp_test.go
@@ -12,8 +12,6 @@ package rest
 import (
 	"errors"
 	"fmt"
-	"github.com/gorilla/mux"
-	"github.com/heketi/tests"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -21,6 +19,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/heketi/tests"
 )
 
 func TestNewManager(t *testing.T) {


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
There are 3 types of errors fixed:
a. one empty line is required before where third-party pkgs imports
b. packages can have dashes in import path but won't have in name[1],
explicitly name them on import.
c. packages that are just version numbers like "v1" need explicit naming
too[2].

[1] https://github.com/golang/go/issues/17546
[2] https://github.com/golang/go/issues/29041

