### PR TITLE
Use "safer" volume options on heketidbstorage

### DIFF
--- a/apps/glusterfs/app_config.go
+++ b/apps/glusterfs/app_config.go
@@ -21,6 +21,7 @@ type RetryLimitConfig struct {
 
 type GlusterFSConfig struct {
 	DBfile       string                  `json:"db"`
+	DBReadOnly   bool                    `json:"db_read_only"`
 	Executor     string                  `json:"executor"`
 	Allocator    string                  `json:"allocator"`
 	SshConfig    sshexec.SshConfig       `json:"sshexec"`

--- a/apps/glusterfs/update_db_vol.go
+++ b/apps/glusterfs/update_db_vol.go
@@ -1,0 +1,91 @@
+//
+// Copyright (c) 2019 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"fmt"
+
+	"github.com/boltdb/bolt"
+
+	"github.com/heketi/heketi/executors"
+	"github.com/heketi/heketi/pkg/db"
+)
+
+func UpdateDbVol(app *App, volName string) error {
+	if volName == "" {
+		return fmt.Errorf("Volume name missing")
+	}
+
+	// we need a volume to validate the name we were given
+	// and so we know what hosts to contact
+	var vol *VolumeEntry
+	err := app.db.View(func(tx *bolt.Tx) error {
+		vl, err := VolumeList(tx)
+		if err != nil {
+			return err
+		}
+		for _, vid := range vl {
+			vol, err = NewVolumeEntryFromId(tx, vid)
+			if err != nil {
+				return err
+			}
+			if vol.Info.Name == volName {
+				return nil
+			}
+		}
+		return fmt.Errorf("Volume %+v not found", volName)
+	})
+	if err != nil {
+		return err
+	}
+
+	// query the current volume on gluster to get a dump of the
+	// current options
+	var vinfo *executors.Volume
+	hosts, err := vol.hosts(app.db)
+	if err != nil {
+		return err
+	}
+	err = newTryOnHosts(hosts).once().run(func(h string) error {
+		var err error
+		vinfo, err = app.executor.VolumeInfo(h, volName)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	// detect the current level or assume "0" if not present
+	var level = "0"
+	for _, o := range vinfo.Options.OptionList {
+		if o.Name == "user.heketi.dbstoragelevel" {
+			level = o.Value
+			logger.Info("Found db storage level: %v", level)
+		}
+	}
+
+	if level == "0" {
+		// level is zero. we need to update volume options
+		req := &executors.VolumeModifyRequest{
+			Name:                 volName,
+			Stopped:              false,
+			GlusterVolumeOptions: db.DbVolumeGlusterOptions,
+		}
+
+		err = newTryOnHosts(hosts).once().run(func(h string) error {
+			return app.executor.VolumeModify(h, req)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/client/cli/go/cmds/heketi_storage.go
+++ b/client/cli/go/cmds/heketi_storage.go
@@ -47,6 +47,7 @@ var (
 	heketiStorageDurability   string
 	heketiStorageReplicaCount int
 	heketiStorageOptions      string
+	appendStorageOptions      string
 	HeketiStorageJobSelector  string
 )
 
@@ -75,6 +76,12 @@ func init() {
 		"gluster-volume-options",
 		"",
 		"\n\tOptional: Comma separated list of volume options."+
+			"\n\tSee volume create --help for details.")
+	setupHeketiStorageCommand.Flags().StringVar(&appendStorageOptions,
+		"append-volume-options",
+		"",
+		"\n\tOptional: Comma separated list of volume options to be added"+
+			"\n\tto the existing/default set of options."+
 			"\n\tSee volume create --help for details.")
 	setupHeketiStorageCommand.Flags().StringVar(&HeketiStorageJobSelector,
 		"node-selector",
@@ -150,6 +157,12 @@ func createHeketiStorageVolume(c *client.Client, dt api.DurabilityType, replicaC
 		req.GlusterVolumeOptions = strings.Split(heketiStorageOptions, ",")
 		req.GlusterVolumeOptions = append(
 			req.GlusterVolumeOptions, "user.heketi.dbstoragelevel custom")
+	}
+
+	if appendStorageOptions != "" {
+		req.GlusterVolumeOptions = append(
+			req.GlusterVolumeOptions,
+			strings.Split(appendStorageOptions, ",")...)
 	}
 
 	switch dt {

--- a/client/cli/go/cmds/heketi_storage.go
+++ b/client/cli/go/cmds/heketi_storage.go
@@ -145,7 +145,7 @@ func createHeketiStorageVolume(c *client.Client, dt api.DurabilityType, replicaC
 	req.Durability.Type = dt
 
 	if heketiStorageOptions == "" {
-		req.GlusterVolumeOptions = db.HeketiStorageVolumeDefaultOptions
+		req.GlusterVolumeOptions = db.DbVolumeGlusterOptions
 	} else {
 		req.GlusterVolumeOptions = strings.Split(heketiStorageOptions, ",")
 		req.GlusterVolumeOptions = append(

--- a/client/cli/go/cmds/heketi_storage.go
+++ b/client/cli/go/cmds/heketi_storage.go
@@ -143,9 +143,15 @@ func createHeketiStorageVolume(c *client.Client, dt api.DurabilityType, replicaC
 	req.Size = HeketiStorageVolumeSize
 	req.Name = db.HeketiStorageVolumeName
 	req.Durability.Type = dt
-	// Check volume options
-	if heketiStorageOptions != "" {
-		req.GlusterVolumeOptions = strings.Split(heketiStorageOptions, ",")
+
+	if heketiStorageOptions == "" {
+		req.GlusterVolumeOptions = db.HeketiStorageVolumeDefaultOptions
+	} else {
+		// When user provided options exist, append them and change dbstoragelevel
+		req.GlusterVolumeOptions = db.HeketiStorageVolumeDefaultOptions[:len(db.HeketiStorageVolumeDefaultOptions)-1]
+		userOptions := strings.Split(heketiStorageOptions, ",")
+		req.GlusterVolumeOptions = append(req.GlusterVolumeOptions, userOptions...)
+		req.GlusterVolumeOptions = append(req.GlusterVolumeOptions, "user.heketi.dbstoragelevel custom")
 	}
 
 	switch dt {

--- a/client/cli/go/cmds/heketi_storage.go
+++ b/client/cli/go/cmds/heketi_storage.go
@@ -147,11 +147,9 @@ func createHeketiStorageVolume(c *client.Client, dt api.DurabilityType, replicaC
 	if heketiStorageOptions == "" {
 		req.GlusterVolumeOptions = db.HeketiStorageVolumeDefaultOptions
 	} else {
-		// When user provided options exist, append them and change dbstoragelevel
-		req.GlusterVolumeOptions = db.HeketiStorageVolumeDefaultOptions[:len(db.HeketiStorageVolumeDefaultOptions)-1]
-		userOptions := strings.Split(heketiStorageOptions, ",")
-		req.GlusterVolumeOptions = append(req.GlusterVolumeOptions, userOptions...)
-		req.GlusterVolumeOptions = append(req.GlusterVolumeOptions, "user.heketi.dbstoragelevel custom")
+		req.GlusterVolumeOptions = strings.Split(heketiStorageOptions, ",")
+		req.GlusterVolumeOptions = append(
+			req.GlusterVolumeOptions, "user.heketi.dbstoragelevel custom")
 	}
 
 	switch dt {

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -375,3 +375,14 @@ func (e *DeviceNotAvailableErr) Error() string {
 		"%s (already initialized or contains data?): %v",
 		head, e.OriginalError)
 }
+
+type VolumeModifyRequest struct {
+	Name string
+
+	// Stopped should be set if the changes may only be applied
+	// while the volume is stopped
+	Stopped bool
+
+	// A new set of gluster volume options
+	GlusterVolumeOptions []string
+}

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -33,6 +33,7 @@ type Executor interface {
 	VolumesInfo(host string) (*VolInfo, error)
 	VolumeClone(host string, vsr *VolumeCloneRequest) (*Volume, error)
 	VolumeSnapshot(host string, vsr *VolumeSnapshotRequest) (*Snapshot, error)
+	VolumeModify(host string, mod *VolumeModifyRequest) error
 	SnapshotCloneVolume(host string, scr *SnapshotCloneRequest) (*Volume, error)
 	SnapshotCloneBlockVolume(host string, scr *SnapshotCloneRequest) (*BlockVolumeInfo, error)
 	SnapshotDestroy(host string, snapshot string) error

--- a/executors/injectexec/mock_base.go
+++ b/executors/injectexec/mock_base.go
@@ -104,5 +104,8 @@ func newMockBase() *mockexec.MockExecutor {
 	m.MockListBlockVolumes = func(host string, blockhostingvolume string) ([]string, error) {
 		return nil, NotSupportedError
 	}
+	m.MockVolumeModify = func(host string, mod *executors.VolumeModifyRequest) error {
+		return NotSupportedError
+	}
 	return m
 }

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -35,6 +35,7 @@ type MockExecutor struct {
 	MockVolumesInfo              func(host string) (*executors.VolInfo, error)
 	MockVolumeClone              func(host string, volume *executors.VolumeCloneRequest) (*executors.Volume, error)
 	MockVolumeSnapshot           func(host string, volume *executors.VolumeSnapshotRequest) (*executors.Snapshot, error)
+	MockVolumeModify             func(host string, mod *executors.VolumeModifyRequest) error
 	MockSnapshotCloneVolume      func(host string, volume *executors.SnapshotCloneRequest) (*executors.Volume, error)
 	MockSnapshotCloneBlockVolume func(host string, volume *executors.SnapshotCloneRequest) (*executors.BlockVolumeInfo, error)
 	MockSnapshotDestroy          func(host string, snapshot string) error
@@ -252,6 +253,10 @@ func NewMockExecutor() (*MockExecutor, error) {
 		return []string{}, nil
 	}
 
+	m.MockVolumeModify = func(host string, mod *executors.VolumeModifyRequest) error {
+		return nil
+	}
+
 	m.DeviceSizeGb = func() uint64 {
 		env := os.Getenv("HEKETI_MOCK_DEVICE_SIZE_GB")
 		if env != "" {
@@ -384,4 +389,8 @@ func (m *MockExecutor) GetBrickMountStatus(host string) (*executors.BricksMountS
 
 func (m *MockExecutor) ListBlockVolumes(host string, blockhostingvolume string) ([]string, error) {
 	return m.MockListBlockVolumes(host, blockhostingvolume)
+}
+
+func (m *MockExecutor) VolumeModify(host string, mod *executors.VolumeModifyRequest) error {
+	return m.MockVolumeModify(host, mod)
 }

--- a/executors/stack/stack.go
+++ b/executors/stack/stack.go
@@ -341,3 +341,13 @@ func (es *ExecutorStack) ListBlockVolumes(host string, blockhostingvolume string
 	}
 	return nil, NotSupportedError
 }
+
+func (es *ExecutorStack) VolumeModify(host string, mod *executors.VolumeModifyRequest) error {
+	for _, e := range es.executors {
+		err := e.VolumeModify(host, mod)
+		if err != NotSupportedError {
+			return err
+		}
+	}
+	return NotSupportedError
+}

--- a/pkg/db/dbvolume.go
+++ b/pkg/db/dbvolume.go
@@ -12,3 +12,13 @@ package db
 const (
 	HeketiStorageVolumeName = "heketidbstorage"
 )
+
+var HeketiStorageVolumeDefaultOptions = []string{"performance.stat-prefetch off",
+	"performance.write-behind off",
+	"performance.open-behind off",
+	"performance.quick-read off",
+	"performance.strict-o-direct on",
+	"performance.read-ahead off",
+	"performance.io-cache off",
+	"performance.readdir-ahead off",
+	"user.heketi.dbstoragelevel 1"}

--- a/pkg/db/dbvolume.go
+++ b/pkg/db/dbvolume.go
@@ -13,7 +13,8 @@ const (
 	HeketiStorageVolumeName = "heketidbstorage"
 )
 
-var HeketiStorageVolumeDefaultOptions = []string{"performance.stat-prefetch off",
+var DbVolumeGlusterOptions = []string{
+	"performance.stat-prefetch off",
 	"performance.write-behind off",
 	"performance.open-behind off",
 	"performance.quick-read off",
@@ -21,4 +22,5 @@ var HeketiStorageVolumeDefaultOptions = []string{"performance.stat-prefetch off"
 	"performance.read-ahead off",
 	"performance.io-cache off",
 	"performance.readdir-ahead off",
-	"user.heketi.dbstoragelevel 1"}
+	"user.heketi.dbstoragelevel 1",
+}

--- a/tests/functional/TestErrorHandling/tests/update_dbvol_test.go
+++ b/tests/functional/TestErrorHandling/tests/update_dbvol_test.go
@@ -1,0 +1,140 @@
+// +build functional
+
+//
+// Copyright (c) 2018 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
+//
+
+package tests
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/heketi/tests"
+
+	//inj "github.com/heketi/heketi/executors/injectexec"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	rex "github.com/heketi/heketi/pkg/remoteexec"
+	"github.com/heketi/heketi/pkg/testutils"
+	//"github.com/heketi/heketi/server/config"
+)
+
+func TestUpdateDbVol(t *testing.T) {
+	heketiServer := testutils.NewServerCtlFromEnv("..")
+	origConf := path.Join(heketiServer.ServerDir, heketiServer.ConfPath)
+	heketiServer.ConfPath = tests.Tempfile()
+	defer os.Remove(heketiServer.ConfPath)
+	CopyFile(origConf, heketiServer.ConfPath)
+
+	fullTeardown := func() {
+		CopyFile(origConf, heketiServer.ConfPath)
+		testutils.ServerRestarted(t, heketiServer)
+		testCluster.Teardown(t)
+		testutils.ServerStopped(t, heketiServer)
+	}
+
+	partialTeardown := func() {
+		CopyFile(origConf, heketiServer.ConfPath)
+		testutils.ServerRestarted(t, heketiServer)
+		testCluster.VolumeTeardown(t)
+	}
+
+	defer fullTeardown()
+	testutils.ServerStarted(t, heketiServer)
+	heketiServer.KeepDB = true
+	testCluster.Setup(t, 3, 3)
+
+	t.Run("plainVolume", func(t *testing.T) {
+		defer partialTeardown()
+
+		volReq := &api.VolumeCreateRequest{}
+		volReq.Size = 2
+		volReq.Durability.Type = api.DurabilityReplicate
+		res, err := heketi.VolumeCreate(volReq)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, res.Name != "")
+
+		testutils.ServerStopped(t, heketiServer)
+		err = heketiServer.RunOfflineCmd(
+			[]string{"offline", "update-dbvol", heketiServer.ConfigArg(), "--force-volume-name", res.Name})
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	})
+
+	t.Run("level1Check", func(t *testing.T) {
+		defer partialTeardown()
+		na := testutils.RequireNodeAccess(t)
+		exec := na.Use(logger)
+
+		volReq := &api.VolumeCreateRequest{}
+		volReq.Size = 2
+		volReq.Durability.Type = api.DurabilityReplicate
+		res, err := heketi.VolumeCreate(volReq)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, res.Name != "")
+
+		testutils.ServerStopped(t, heketiServer)
+		err = heketiServer.RunOfflineCmd(
+			[]string{"offline", "update-dbvol", heketiServer.ConfigArg(), "--force-volume-name", res.Name})
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		sshHost := testCluster.SshHost(0)
+		cmd := rex.OneCmd(
+			fmt.Sprintf("gluster volume get %v user.heketi.dbstoragelevel", res.Name))
+		r, err := exec.ExecCommands(sshHost, cmd, 10, true)
+		tests.Assert(t, rex.AnyError(r, err) == nil,
+			"expected err == nil, got:", err)
+		tests.Assert(t,
+			strings.Contains(r[0].Output, "1"),
+			"expected 1 in output, got:", r[0].Output)
+	})
+
+	t.Run("levelCustomUntouched", func(t *testing.T) {
+		defer partialTeardown()
+		na := testutils.RequireNodeAccess(t)
+		exec := na.Use(logger)
+
+		volReq := &api.VolumeCreateRequest{}
+		volReq.Size = 2
+		volReq.Durability.Type = api.DurabilityReplicate
+		res, err := heketi.VolumeCreate(volReq)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, res.Name != "")
+
+		sshHost := testCluster.SshHost(0)
+		cmds := rex.Cmds{
+			rex.ToCmd(fmt.Sprintf("gluster volume set %v user.heketi.dbstoragelevel custom", res.Name)),
+			rex.ToCmd(fmt.Sprintf("gluster volume set %v performance.io-cache on", res.Name)),
+		}
+		err = rex.AnyError(exec.ExecCommands(sshHost, cmds, 10, true))
+
+		testutils.ServerStopped(t, heketiServer)
+		err = heketiServer.RunOfflineCmd(
+			[]string{"offline", "update-dbvol", heketiServer.ConfigArg(), "--force-volume-name", res.Name})
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		cmds = rex.Cmds{
+			rex.ToCmd(fmt.Sprintf("gluster volume get %v user.heketi.dbstoragelevel", res.Name)),
+			rex.ToCmd(fmt.Sprintf("gluster volume get %v performance.io-cache", res.Name)),
+		}
+		r, err := exec.ExecCommands(sshHost, cmds, 10, true)
+		tests.Assert(t, rex.AnyError(r, err) == nil,
+			"expected err == nil, got:", err)
+		tests.Assert(t,
+			strings.Contains(r[0].Output, "custom"),
+			"expected 'custom' in output, got:", r[0].Output)
+		tests.Assert(t,
+			strings.Contains(r[1].Output, "on"),
+			"expected 'on' in output, got:", r[0].Output)
+	})
+}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

This PR starts off by incorporating changes from PR #1640 

New instances of heketidbstorage volume will be created with options to turn of so called perf xlators.

A new "offline" subcommand "update-dbvol" is provided to conveniently update existing heketidbstorage volumes to the new set of options. Note that this *intentionally* doesn't update the options in the db. Currently this is the only tool that changes the volume options, normally heketi only sets volume options at create time. Syncing the volume options from gluster to the db is a topic reserved for future work.

A set of "error handling tests" to check the behavior of the new command.


### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #


### Notes for the reviewer

