### PR TITLE
travis: build on go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,10 @@ matrix:
     name: Test using Go 1.10
   - go: "1.11"
     name: Test using Go 1.11
-  - go: "1.11"
+  - go: "1.13"
+    name: Test using Go 1.13
+  - go: "1.13"
     script: make release
-    name: make release on Go 1.11
+    name: make release on Go 1.13
 script:
 - make all test COVERAGE=true TESTOPTIONS="-vcstdout" && bash .travis-coverage


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

Build using go 1.13. Does not drop any versions currently being tested.


### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #


### Notes for the reviewer


