### PR TITLE
execute LVM commands on the host instead of in a Gluster container

### DIFF
--- a/docs/admin/server.md
+++ b/docs/admin/server.md
@@ -28,6 +28,7 @@ The config file has information required to run the Heketi server.  The config f
         * backup_lvm_metadata: _bool_, Create archives of the LVM metadata when running vgcreate/lvcreate
         * sudo: _bool_, set to true when SSHing as a non root user
 	* debug_umount_failures: _bool_, Enable to capture more details in case brick unmounting fails. Can be overridden by the HEKETI_DEBUG_UMOUNT_FAILURES environment variable.
+	* lvm_wrapper: _string_, Use a wrapper for calling LVM related operations. Can be overridden by the HEKETI_LVM_WRAPPER environment variable.
     * kubexec: _map_, Kubernetes configuration
         * host: _string_, Kubernetes API host.  Example `https://myhost:8443`.  Can also be use using environment variable HEKETI_KUBE_APIHOST
         * cert: _string_, Certificate file to for HTTPS connection. Can also be use using environment variable HEKETI_KUBE_CERTFILE
@@ -38,6 +39,7 @@ The config file has information required to run the Heketi server.  The config f
         * fstab: _string_, Fstab file where to store mount points
         * backup_lvm_metadata: _bool_, Create archives of the LVM metadata when running vgcreate/lvcreate
 	* debug_umount_failures: _bool_, Enable to capture more details in case brick unmounting fails. Can be overridden by the HEKETI_DEBUG_UMOUNT_FAILURES environment variable.
+	* lvm_wrapper: _string_, Use a wrapper for calling LVM related operations. Can be overridden by the HEKETI_LVM_WRAPPER environment variable.
 
 ## Advanced Options
 The following configuration options should only be set on advanced configurations under `glusterfs` section:

--- a/etc/heketi.json
+++ b/etc/heketi.json
@@ -62,7 +62,8 @@
       "backup_lvm_metadata": false,
       "gluster_cli_timeout": "Optional: Timeout, in seconds, passed to the gluster cli invocations",
       "_debug_umount_failures": "Optional: boolean to capture more details in case brick unmounting fails",
-      "debug_umount_failures": true
+      "debug_umount_failures": true,
+      "lvm_wrapper": ""
     },
 
     "_kubeexec_comment": "Kubernetes configuration",
@@ -82,7 +83,8 @@
       "backup_lvm_metadata": false,
       "gluster_cli_timeout": "Optional: Timeout, in seconds, passed to the gluster cli invocations",
       "_debug_umount_failures": "Optional: boolean to capture more details in case brick unmounting fails",
-      "debug_umount_failures": true
+      "debug_umount_failures": true,
+      "lvm_wrapper": ""
     },
 
     "_db_comment": "Database file name",

--- a/executors/cmdexec/brick_test.go
+++ b/executors/cmdexec/brick_test.go
@@ -51,7 +51,7 @@ func doTestSshExecBrickCreate(t *testing.T, f *CommandFaker, s *FakeExecutor) {
 
 			case 1:
 				tests.Assert(t,
-					cmd == "lvcreate -qq --autobackup="+conv.BoolToYN(s.BackupLVM)+" --poolmetadatasize 5K "+
+					cmd == "/usr/sbin/lvm lvcreate -qq --autobackup="+conv.BoolToYN(s.BackupLVM)+" --poolmetadatasize 5K "+
 						"--chunksize 256K --size 100K --thin vg_xvgid/tp_id --virtualsize 10K --name brick_id", cmd)
 
 			case 2:
@@ -136,7 +136,7 @@ func TestSshExecBrickCreateWithGid(t *testing.T) {
 
 			case 1:
 				tests.Assert(t,
-					cmd == "lvcreate -qq --autobackup="+conv.BoolToYN(s.BackupLVM)+" --poolmetadatasize 5K "+
+					cmd == "/usr/sbin/lvm lvcreate -qq --autobackup="+conv.BoolToYN(s.BackupLVM)+" --poolmetadatasize 5K "+
 						"--chunksize 256K --size 100K --thin vg_xvgid/tp_id --virtualsize 10K --name brick_id", cmd)
 
 			case 2:
@@ -222,7 +222,7 @@ func TestSshExecBrickCreateSudo(t *testing.T) {
 
 			case 1:
 				tests.Assert(t,
-					cmd == "lvcreate -qq --autobackup="+conv.BoolToYN(s.BackupLVM)+" --poolmetadatasize 5K "+
+					cmd == "/usr/sbin/lvm lvcreate -qq --autobackup="+conv.BoolToYN(s.BackupLVM)+" --poolmetadatasize 5K "+
 						"--chunksize 256K --size 100K --thin vg_xvgid/tp_id --virtualsize 10K --name brick_id", cmd)
 
 			case 2:
@@ -309,7 +309,7 @@ func TestSshExecBrickDestroy(t *testing.T) {
 
 			case strings.Contains(cmd, "lvs") && strings.Contains(cmd, "vg_name"):
 				tests.Assert(t,
-					cmd == "lvs --noheadings --separator=/ "+
+					cmd == "/usr/sbin/lvm lvs --noheadings --separator=/ "+
 						"-ovg_name,pool_lv /dev/vg_xvgid/brick_id", cmd)
 				// return the device that was mounted
 				output := fakeResults("vg_xvgid/tp_id", "")
@@ -317,7 +317,7 @@ func TestSshExecBrickDestroy(t *testing.T) {
 
 			case strings.Contains(cmd, "lvs") && strings.Contains(cmd, "thin_count"):
 				tests.Assert(t,
-					cmd == "lvs --noheadings --options=thin_count vg_xvgid/tp_id", cmd)
+					cmd == "/usr/sbin/lvm lvs --noheadings --options=thin_count vg_xvgid/tp_id", cmd)
 				// return the number of thin-p users
 				output := fakeResults("0", "")
 				return output[0:1], nil
@@ -329,8 +329,8 @@ func TestSshExecBrickDestroy(t *testing.T) {
 
 			case strings.Contains(cmd, "lvremove"):
 				tests.Assert(t,
-					cmd == "lvremove --autobackup="+conv.BoolToYN(s.BackupLVM)+" -f vg_xvgid/tp_id" ||
-						cmd == "lvremove --autobackup="+conv.BoolToYN(s.BackupLVM)+" -f vg_xvgid/brick_id", cmd)
+					cmd == "/usr/sbin/lvm lvremove --autobackup="+conv.BoolToYN(s.BackupLVM)+" -f vg_xvgid/tp_id" ||
+						cmd == "/usr/sbin/lvm lvremove --autobackup="+conv.BoolToYN(s.BackupLVM)+" -f vg_xvgid/brick_id", cmd)
 
 			case strings.Contains(cmd, "rmdir"):
 				tests.Assert(t,

--- a/executors/cmdexec/cmdexec.go
+++ b/executors/cmdexec/cmdexec.go
@@ -65,6 +65,14 @@ func (c *CmdExecutor) lvmCommand() string {
 	return "/usr/sbin/lvm"
 }
 
+func (c *CmdExecutor) udevCommand() string {
+	if wrapper := c.LVMWrapper(); wrapper != "" {
+		return wrapper + " /usr/bin/udevadm"
+	}
+
+	return "/usr/bin/udevadm"
+}
+
 func setWithEnvVariables(config *CmdConfig) {
 	var env string
 

--- a/executors/cmdexec/cmdexec.go
+++ b/executors/cmdexec/cmdexec.go
@@ -51,6 +51,20 @@ func (c *CmdExecutor) glusterCommand() string {
 	return fmt.Sprintf("gluster --mode=script --timeout=%v", c.GlusterCliTimeout())
 }
 
+// When running Gluster inside a container, the LVM commands need to be
+// executed on the host. The Gluster Server containers provide a wrapper script
+// for `nsenter` and its arguments as `exec-on-host`.
+//
+// All LVM commands will get prefixed with `/usr/sbin/lvm` in order to make
+// things a little more secure (hopefully).
+func (c *CmdExecutor) lvmCommand() string {
+	if wrapper := c.LVMWrapper(); wrapper != "" {
+		return wrapper + " /usr/sbin/lvm"
+	}
+
+	return "/usr/sbin/lvm"
+}
+
 func setWithEnvVariables(config *CmdConfig) {
 	var env string
 
@@ -77,6 +91,11 @@ func setWithEnvVariables(config *CmdConfig) {
 	env = os.Getenv("HEKETI_BLOCK_VOLUME_DEFAULT_PREALLOC")
 	if env != "" {
 		config.BlockVolumePrealloc = env
+	}
+
+	env = os.Getenv("HEKETI_LVM_WRAPPER")
+	if env != "" {
+		config.LVMWrapper = env
 	}
 }
 
@@ -202,4 +221,8 @@ func (c *CmdExecutor) BlockVolumeDefaultPrealloc() string {
 		return defaultValue
 	}
 	return c.config.BlockVolumePrealloc
+}
+
+func (c *CmdExecutor) LVMWrapper() string {
+	return c.config.LVMWrapper
 }

--- a/executors/cmdexec/config.go
+++ b/executors/cmdexec/config.go
@@ -23,4 +23,5 @@ type CmdConfig struct {
 	XfsSu                int    `json:"xfs_su"`
 	DebugUmountFailures  bool   `json:"debug_umount_failures"`
 	BlockVolumePrealloc  string `json:"block_prealloc"`
+	LVMWrapper           string `json:"lvm_wrapper"`
 }

--- a/executors/cmdexec/device.go
+++ b/executors/cmdexec/device.go
@@ -285,7 +285,7 @@ func (s *CmdExecutor) getDeviceHandle(host, device string) (
 	commands = append(commands,
 		fmt.Sprintf("%s pvs -o pv_name,pv_uuid,vg_name --reportformat=json %v", s.lvmCommand(), device))
 	commands = append(commands,
-		fmt.Sprintf("udevadm info --query=symlink --name=%v", device))
+		fmt.Sprintf("%s info --query=symlink --name=%v", s.udevCommand(), device))
 
 	results, err := s.RemoteExecutor.ExecCommands(host, rex.ToCmds(commands), 5)
 	if err != nil {

--- a/tests/functional/TestErrorHandling/tests/error_inject_test.go
+++ b/tests/functional/TestErrorHandling/tests/error_inject_test.go
@@ -156,7 +156,7 @@ func TestErrorInjection(t *testing.T) {
 			c.GlusterFS.Executor = "inject/ssh"
 			c.GlusterFS.InjectConfig.CmdInjection.CmdHooks = inj.CmdHooks{
 				inj.CmdHook{
-					Cmd:      "^lvcreate.*",
+					Cmd:      "(^| )lvcreate.*",
 					Reaction: inj.Reaction{Err: "fooey"},
 				},
 			}
@@ -213,7 +213,7 @@ func TestErrorInjection(t *testing.T) {
 			c.GlusterFS.Executor = "inject/ssh"
 			c.GlusterFS.InjectConfig.CmdInjection.CmdHooks = inj.CmdHooks{
 				inj.CmdHook{
-					Cmd: "^lvcreate.*",
+					Cmd: "(^| )lvcreate.*",
 					Reaction: inj.Reaction{
 						Panic: "KaBoom",
 					},


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

There are a few potential issues when running LVM commands inside a Gluster container. This can be solved by running the commands on the container host, instead of in the container. The `nsenter` command can be used to 'break out' of the container, and execute the command on the host.

### Does this PR fix issues?

* difficulties with udev synchonisation (file locking under `/run` and IPC semaphores)
* differences/incompatibilities between LVM versions on the host and in the container

### Notes for the reviewer

This PR currently is a RFC to get feedback on the approach taken. Tests have been done, and the needed functionality seems to be present.