### PR TITLE
apps: do not emit error log line when db open is successful

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -207,7 +207,9 @@ func (app *App) initDB() error {
 		err = fmt.Errorf("Read Only DB Required")
 	} else {
 		app.db, err = OpenDB(dbfilename, false)
-		logger.LogError("Unable to open database read-write: %v", err)
+		if err != nil {
+			logger.LogError("Unable to open database read-write: %v", err)
+		}
 	}
 	if err != nil {
 		logger.Info("Trying to open db in read only mode")


### PR DESCRIPTION


### What does this PR achieve? Why do we need it?

During some previous refactoring a log line printing that the db open
in read-write mode failed was moved such that the line always gets
printed even if the err is nil. Fix this mistake and only print
the log line when the previous function actually returns an error.

### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #


### Notes for the reviewer


