### PR TITLE
Fixed migration logic for replica < 3 volumes

### DIFF
--- a/apps/glusterfs/volume_durability_replica.go
+++ b/apps/glusterfs/volume_durability_replica.go
@@ -76,7 +76,11 @@ func (r *VolumeReplicaDurability) BricksInSet() int {
 }
 
 func (r *VolumeReplicaDurability) QuorumBrickCount() int {
-	return r.BricksInSet()/2 + 1
+	if r.BricksInSet() < 3 {
+		return 1
+	} else {
+		return r.BricksInSet()/2 + 1
+	}
 }
 
 func (r *VolumeReplicaDurability) SetExecutorVolumeRequest(v *executors.VolumeRequest) {

--- a/apps/glusterfs/volume_durability_test.go
+++ b/apps/glusterfs/volume_durability_test.go
@@ -227,7 +227,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 1)
 	tests.Assert(t, brick_size == 100*GB)
 	tests.Assert(t, 2 == r.BricksInSet())
-	tests.Assert(t, 2 == r.QuorumBrickCount())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 2
 	sets, brick_size, err = gen()
@@ -235,7 +235,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 2, "sets we got:", sets)
 	tests.Assert(t, brick_size == 50*GB)
 	tests.Assert(t, 2 == r.BricksInSet())
-	tests.Assert(t, 2 == r.QuorumBrickCount())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 3
 	sets, brick_size, err = gen()
@@ -243,7 +243,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 4)
 	tests.Assert(t, brick_size == 25*GB)
 	tests.Assert(t, 2 == r.BricksInSet())
-	tests.Assert(t, 2 == r.QuorumBrickCount())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 4
 	sets, brick_size, err = gen()
@@ -251,7 +251,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 8)
 	tests.Assert(t, brick_size == 12800*1024)
 	tests.Assert(t, 2 == r.BricksInSet())
-	tests.Assert(t, 2 == r.QuorumBrickCount())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 5
 	sets, brick_size, err = gen()
@@ -259,7 +259,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 16)
 	tests.Assert(t, brick_size == 6400*1024)
 	tests.Assert(t, 2 == r.BricksInSet())
-	tests.Assert(t, 2 == r.QuorumBrickCount())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 6
 	sets, brick_size, err = gen()
@@ -267,7 +267,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 32, sets)
 	tests.Assert(t, brick_size == 3200*1024)
 	tests.Assert(t, 2 == r.BricksInSet())
-	tests.Assert(t, 2 == r.QuorumBrickCount())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 7
 	sets, brick_size, err = gen()
@@ -275,7 +275,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 64, sets)
 	tests.Assert(t, brick_size == 1600*1024)
 	tests.Assert(t, 2 == r.BricksInSet())
-	tests.Assert(t, 2 == r.QuorumBrickCount())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 
 	// Gen 8
 	sets, brick_size, err = gen()
@@ -283,7 +283,7 @@ func TestReplicaDurabilityGenerator(t *testing.T) {
 	tests.Assert(t, sets == 0)
 	tests.Assert(t, brick_size == 0)
 	tests.Assert(t, 2 == r.BricksInSet())
-	tests.Assert(t, 2 == r.QuorumBrickCount())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 }
 
 func TestReplicaDurabilityLargeBrickGenerator(t *testing.T) {
@@ -298,7 +298,7 @@ func TestReplicaDurabilityLargeBrickGenerator(t *testing.T) {
 	tests.Assert(t, sets == 32)
 	tests.Assert(t, brick_size == 3200*GB)
 	tests.Assert(t, 2 == r.BricksInSet())
-	tests.Assert(t, 2 == r.QuorumBrickCount())
+	tests.Assert(t, 1 == r.QuorumBrickCount())
 }
 
 func TestReplicaDurabilityQuorumBrickCount3(t *testing.T) {

--- a/apps/glusterfs/volume_durability_test.go
+++ b/apps/glusterfs/volume_durability_test.go
@@ -4,7 +4,7 @@
 // This file is licensed to you under your choice of the GNU Lesser
 // General Public License, version 3 or any later version (LGPLv3 or
 // later), or the GNU General Public License, version 2 (GPLv2), in all
-// cases as published by the Free Software Foundation. 
+// cases as published by the Free Software Foundation.
 //
 
 package glusterfs

--- a/apps/glusterfs/volume_durability_test.go
+++ b/apps/glusterfs/volume_durability_test.go
@@ -4,7 +4,7 @@
 // This file is licensed to you under your choice of the GNU Lesser
 // General Public License, version 3 or any later version (LGPLv3 or
 // later), or the GNU General Public License, version 2 (GPLv2), in all
-// cases as published by the Free Software Foundation.
+// cases as published by the Free Software Foundation. 
 //
 
 package glusterfs


### PR DESCRIPTION
Fixed logic for enabling brick migration for volumes with replica < 3, at least 1 brick must be online as source for migration

<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?
Migrating bricks of replica 2 volumes failed because at least 2 bricks needed to be online. The PR fixes this issue ensuring that for replica < 3 volumes at least 1 brick must be online.

### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #1628 


### Notes for the reviewer


