### PR TITLE
Implement core "Tag Matching" feature for placing bricks on devices

### DIFF
--- a/apps/glusterfs/tag_matching_rule.go
+++ b/apps/glusterfs/tag_matching_rule.go
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2019 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var tag_match_regex = regexp.MustCompile(
+	`^([a-zA-Z0-9.-_]+)(\!?=)([a-zA-Z0-9.-_]+)$`)
+
+type TagMatchingRule struct {
+	Key   string
+	Match string
+	Value string
+}
+
+func ParseTagMatchingRule(s string) (*TagMatchingRule, error) {
+	m := tag_match_regex.FindAllStringSubmatch(s, -1)
+	if !(len(m) == 1 && len(m[0]) == 4) {
+		return nil, fmt.Errorf("Invalid tag match rule: %v", s)
+	}
+	return &TagMatchingRule{m[0][1], m[0][2], m[0][3]}, nil
+}
+
+func (tmr *TagMatchingRule) Test(v string) bool {
+	logger.Debug("Testing tag value %#v with rule %+v", v, tmr)
+	if tmr.Match == "=" {
+		return tmr.Value == v
+	} else {
+		return tmr.Value != v
+	}
+}
+
+func (tmr *TagMatchingRule) Filter(bs *BrickSet, d *DeviceEntry) bool {
+	return tmr.Test(d.AllTags()[tmr.Key])
+}

--- a/apps/glusterfs/tag_matching_rule.go
+++ b/apps/glusterfs/tag_matching_rule.go
@@ -40,6 +40,15 @@ func (tmr *TagMatchingRule) Test(v string) bool {
 	}
 }
 
-func (tmr *TagMatchingRule) Filter(bs *BrickSet, d *DeviceEntry) bool {
-	return tmr.Test(d.AllTags()[tmr.Key])
+func (tmr *TagMatchingRule) GetFilter(dsrc DeviceSource) DeviceFilter {
+	return func(bs *BrickSet, d *DeviceEntry) bool {
+		n, err := dsrc.Node(d.NodeId)
+		if err != nil {
+			logger.LogError("failed to fetch node (%v) in tag matching filter: %v",
+				d.NodeId, err)
+			return false
+		}
+		tags := MergeTags(n, d)
+		return tmr.Test(tags[tmr.Key])
+	}
 }

--- a/apps/glusterfs/tag_matching_rule_test.go
+++ b/apps/glusterfs/tag_matching_rule_test.go
@@ -72,3 +72,82 @@ func TestTagMatchingRuleTest(t *testing.T) {
 		tests.Assert(t, tmr.Test("blob"))
 	})
 }
+
+func TestTagMatchingRuleFilter(t *testing.T) {
+	dsrc := NewTestDeviceSource()
+	var (
+		n         *NodeEntry
+		d         *DeviceEntry
+		deviceAdd func(string, string) *DeviceEntry
+	)
+	n, deviceAdd = tmrNodeAdd(dsrc, "foo")
+	n.Info.Tags["charles"] = "brown"
+	d = deviceAdd("foo000d1", "/dev/d1")
+	d.Info.Tags["tier"] = "one"
+
+	t.Run("on dev", func(t *testing.T) {
+		tmr := &TagMatchingRule{"tier", "=", "one"}
+		f := tmr.GetFilter(dsrc)
+		res := f(nil, d)
+		tests.Assert(t, res)
+	})
+	t.Run("on node", func(t *testing.T) {
+		tmr := &TagMatchingRule{"charles", "=", "brown"}
+		f := tmr.GetFilter(dsrc)
+		res := f(nil, d)
+		tests.Assert(t, res)
+	})
+	t.Run("no match on node or dev", func(t *testing.T) {
+		tmr := &TagMatchingRule{"charles", "!=", "xavier"}
+		f := tmr.GetFilter(dsrc)
+		res := f(nil, d)
+		tests.Assert(t, res)
+	})
+	t.Run("not on node or dev", func(t *testing.T) {
+		tmr := &TagMatchingRule{"charles", "=", "darwin"}
+		f := tmr.GetFilter(dsrc)
+		res := f(nil, d)
+		tests.Assert(t, !res)
+	})
+
+	// test invalid lookup. for completeness & coverage
+	dx := NewDeviceEntry()
+	dx.Info.Id = "bob"
+	dx.Info.Name = "bad"
+	dx.NodeId = "xxx"
+	dsrc.AddDevice(dx)
+
+	t.Run("with bad lookup", func(t *testing.T) {
+		tmr := &TagMatchingRule{"yeah", "=", "fangoriously"}
+		f := tmr.GetFilter(dsrc)
+		res := f(nil, dx)
+		tests.Assert(t, !res)
+	})
+}
+
+func tmrNodeAdd(tds *TestDeviceSource, nodeId string) (*NodeEntry, func(string, string) *DeviceEntry) {
+
+	n := NewNodeEntry()
+	n.Info.Id = nodeId
+	n.Info.Zone = 1
+	n.Info.Hostnames.Manage = []string{"mng-" + nodeId}
+	n.Info.Hostnames.Storage = []string{"stor-" + nodeId}
+	n.Info.ClusterId = "0000000000c"
+	n.Info.Tags = map[string]string{}
+	tds.AddNode(n)
+
+	f := func(deviceId, dname string) *DeviceEntry {
+		d := NewDeviceEntry()
+		d.Info.Id = deviceId
+		d.Info.Name = dname
+		d.Info.Storage.Total = 100
+		d.Info.Storage.Free = 100
+		d.NodeId = nodeId
+		d.Info.Tags = map[string]string{}
+
+		n.Devices = append(n.Devices, d.Info.Id)
+		tds.AddDevice(d)
+		return d
+	}
+	return n, f
+}

--- a/apps/glusterfs/tag_matching_rule_test.go
+++ b/apps/glusterfs/tag_matching_rule_test.go
@@ -1,0 +1,74 @@
+//
+// Copyright (c) 2019 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package glusterfs
+
+import (
+	"testing"
+
+	"github.com/heketi/tests"
+)
+
+func TestParseTagMatchingRule(t *testing.T) {
+	t.Run("empty_string", func(t *testing.T) {
+		r, e := ParseTagMatchingRule("")
+		tests.Assert(t, r == nil)
+		tests.Assert(t, e != nil)
+	})
+	t.Run("dummy string", func(t *testing.T) {
+		r, e := ParseTagMatchingRule("joe")
+		tests.Assert(t, r == nil)
+		tests.Assert(t, e != nil)
+	})
+	t.Run("bad match 1", func(t *testing.T) {
+		r, e := ParseTagMatchingRule("joe=")
+		tests.Assert(t, r == nil)
+		tests.Assert(t, e != nil)
+	})
+	t.Run("bad match 2", func(t *testing.T) {
+		r, e := ParseTagMatchingRule("=crumb")
+		tests.Assert(t, r == nil)
+		tests.Assert(t, e != nil)
+	})
+	t.Run("match 1", func(t *testing.T) {
+		r, e := ParseTagMatchingRule("joe=crumb")
+		tests.Assert(t, r != nil)
+		tests.Assert(t, e == nil)
+		tests.Assert(t, r.Key == "joe")
+		tests.Assert(t, r.Match == "=")
+		tests.Assert(t, r.Value == "crumb")
+	})
+	t.Run("match 2", func(t *testing.T) {
+		r, e := ParseTagMatchingRule("joe!=crumb")
+		tests.Assert(t, r != nil)
+		tests.Assert(t, e == nil)
+		tests.Assert(t, r.Key == "joe")
+		tests.Assert(t, r.Match == "!=")
+		tests.Assert(t, r.Value == "crumb")
+	})
+}
+
+func TestTagMatchingRuleTest(t *testing.T) {
+	t.Run("match", func(t *testing.T) {
+		tmr := &TagMatchingRule{"foo", "=", "bar"}
+		tests.Assert(t, tmr.Test("bar"))
+	})
+	t.Run("no match", func(t *testing.T) {
+		tmr := &TagMatchingRule{"foo", "=", "bar"}
+		tests.Assert(t, !tmr.Test("baz"))
+	})
+	t.Run("invert match", func(t *testing.T) {
+		tmr := &TagMatchingRule{"foo", "!=", "bar"}
+		tests.Assert(t, !tmr.Test("bar"))
+	})
+	t.Run("invert no match", func(t *testing.T) {
+		tmr := &TagMatchingRule{"foo", "!=", "bar"}
+		tests.Assert(t, tmr.Test("blob"))
+	})
+}

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -46,6 +46,7 @@ const (
 	HEKETI_ARBITER_KEY           = "user.heketi.arbiter"
 	HEKETI_AVERAGE_FILE_SIZE_KEY = "user.heketi.average-file-size"
 	HEKETI_ZONE_CHECKING_KEY     = "user.heketi.zone-checking"
+	HEKETI_TAG_MATCH_KEY         = "user.heketi.device-tag-match"
 )
 
 var (

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -340,6 +340,14 @@ func (v *VolumeEntry) GetZoneCheckingStrategy() ZoneCheckingStrategy {
 	return ZONE_CHECKING_UNSET
 }
 
+func (v *VolumeEntry) GetTagMatchingRule() (*TagMatchingRule, error) {
+	value := v.volOptsMap()[HEKETI_TAG_MATCH_KEY]
+	if value == "" {
+		return nil, nil
+	}
+	return ParseTagMatchingRule(value)
+}
+
 func (v *VolumeEntry) BrickAdd(id string) {
 	godbc.Require(!sortedstrings.Has(v.Bricks, id))
 

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -285,6 +285,15 @@ func (v *VolumeEntry) generateDeviceFilter(db wdb.RODB) (DeviceFilter, error) {
 				"treating as 'none'", ZoneChecking)
 	}
 
+	tagMatchingRule, err := v.GetTagMatchingRule()
+	if err != nil {
+		return nil, logger.LogError(
+			"Invalid tag matching rule: %v", err)
+	} else if tagMatchingRule != nil {
+		logger.Debug("Configuring a tag matching device filter")
+		filter = appendDeviceFilter(filter, tagMatchingRule.Filter)
+	}
+
 	return filter, nil
 }
 
@@ -545,4 +554,16 @@ func (v *VolumeEntry) allocBricks(
 	}
 
 	return brick_entries, nil
+}
+
+func appendDeviceFilter(f1, f2 DeviceFilter) DeviceFilter {
+	if f1 == nil {
+		return f2
+	}
+	if f2 == nil {
+		return f1
+	}
+	return func(bs *BrickSet, d *DeviceEntry) bool {
+		return f1(bs, d) && f2(bs, d)
+	}
 }

--- a/apps/glusterfs/volume_entry_allocate.go
+++ b/apps/glusterfs/volume_entry_allocate.go
@@ -262,7 +262,7 @@ func (v *VolumeEntry) prepForBrickReplacement(db wdb.DB,
 	return
 }
 
-func (v *VolumeEntry) generateDeviceFilter(db wdb.RODB) (DeviceFilter, error) {
+func (v *VolumeEntry) generateDeviceFilter(db wdb.RODB, dsrc DeviceSource) (DeviceFilter, error) {
 
 	var filter DeviceFilter = nil
 	zoneChecking := v.GetZoneCheckingStrategy()
@@ -291,7 +291,7 @@ func (v *VolumeEntry) generateDeviceFilter(db wdb.RODB) (DeviceFilter, error) {
 			"Invalid tag matching rule: %v", err)
 	} else if tagMatchingRule != nil {
 		logger.Debug("Configuring a tag matching device filter")
-		filter = appendDeviceFilter(filter, tagMatchingRule.Filter)
+		filter = appendDeviceFilter(filter, tagMatchingRule.GetFilter(dsrc))
 	}
 
 	return filter, nil
@@ -311,9 +311,10 @@ func (v *VolumeEntry) allocBrickReplacement(db wdb.DB,
 			return oldDeviceEntry.Info.Id != d.Info.Id
 		}
 
+		dsrc := NewClusterDeviceSource(tx, v.Info.Cluster)
 		var err error
 		txdb := wdb.WrapTx(tx)
-		defaultFilter, err := v.generateDeviceFilter(txdb)
+		defaultFilter, err := v.generateDeviceFilter(txdb, dsrc)
 		if err != nil {
 			return err
 		}
@@ -328,7 +329,7 @@ func (v *VolumeEntry) allocBrickReplacement(db wdb.DB,
 
 		placer := PlacerForVolume(v)
 		r, err = placer.Replace(
-			NewClusterDeviceSource(tx, v.Info.Cluster),
+			dsrc,
 			NewVolumePlacementOpts(v, oldBrickEntry.Info.Size, bs.SetSize),
 			deviceFilter, bs, index)
 		if err == ErrNoSpace {
@@ -518,7 +519,7 @@ func (v *VolumeEntry) allocBricks(
 		placer := PlacerForVolume(v)
 
 		txdb := wdb.WrapTx(tx)
-		deviceFilter, err := v.generateDeviceFilter(txdb)
+		deviceFilter, err := v.generateDeviceFilter(txdb, dsrc)
 		if err != nil {
 			return err
 		}

--- a/tests/functional/TestErrorHandling/tests/tag_matching_test.go
+++ b/tests/functional/TestErrorHandling/tests/tag_matching_test.go
@@ -1,0 +1,262 @@
+// +build functional
+
+//
+// Copyright (c) 2019 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
+//
+
+package tests
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/heketi/pkg/testutils"
+	"github.com/heketi/tests"
+)
+
+func TestVolumeCreateTagMatchingRules(t *testing.T) {
+
+	heketiServer := testutils.NewServerCtlFromEnv("..")
+	origConf := path.Join(heketiServer.ServerDir, heketiServer.ConfPath)
+
+	heketiServer.ConfPath = tests.Tempfile()
+	defer os.Remove(heketiServer.ConfPath)
+	CopyFile(origConf, heketiServer.ConfPath)
+
+	tce := testCluster.Copy()
+	tce.Update()
+	defer func() {
+		CopyFile(origConf, heketiServer.ConfPath)
+		testutils.ServerRestarted(t, heketiServer)
+		tce.Teardown(t)
+		testutils.ServerStopped(t, heketiServer)
+	}()
+
+	tce.CustomizeNodeRequest = func(i int, req *api.NodeAddRequest) {
+		req.Zone = 1
+	}
+	testutils.ServerStarted(t, heketiServer)
+	heketiServer.KeepDB = true
+	tce.Setup(t, 3, 4)
+
+	cl, err := heketi.ClusterList()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, len(cl.Clusters) > 0,
+		"expected len(cl.Clusters) > 0, got:", len(cl.Clusters))
+	clusterId := cl.Clusters[0]
+	clusterInfo, err := heketi.ClusterInfo(clusterId)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	t.Run("testWithTagOnNodes", func(t *testing.T) {
+		var err error
+		err = heketi.NodeSetTags(clusterInfo.Nodes[0], &api.TagsChangeRequest{
+			Tags:   map[string]string{"flavor": "banana"},
+			Change: api.SetTags,
+		})
+		tests.Assert(t, err == nil, "failed to set tags", err)
+		err = heketi.NodeSetTags(clusterInfo.Nodes[1], &api.TagsChangeRequest{
+			Tags:   map[string]string{"flavor": "banana"},
+			Change: api.SetTags,
+		})
+		tests.Assert(t, err == nil, "failed to set tags", err)
+		err = heketi.NodeSetTags(clusterInfo.Nodes[2], &api.TagsChangeRequest{
+			Tags:   map[string]string{"flavor": "banana"},
+			Change: api.SetTags,
+		})
+		tests.Assert(t, err == nil, "failed to set tags", err)
+
+		volReq := &api.VolumeCreateRequest{}
+		volReq.Size = 1
+		volReq.Durability.Type = api.DurabilityReplicate
+		volReq.Durability.Replicate.Replica = 3
+		volReq.GlusterVolumeOptions = []string{
+			"user.heketi.device-tag-match flavor=banana"}
+		_, err = heketi.VolumeCreate(volReq)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	})
+	t.Run("inverseMatch", func(t *testing.T) {
+		var err error
+		err = heketi.NodeSetTags(clusterInfo.Nodes[0], &api.TagsChangeRequest{
+			Tags:   map[string]string{"flavor": "banana"},
+			Change: api.SetTags,
+		})
+		tests.Assert(t, err == nil, "failed to set tags", err)
+		err = heketi.NodeSetTags(clusterInfo.Nodes[1], &api.TagsChangeRequest{
+			Tags:   map[string]string{"flavor": "banana"},
+			Change: api.SetTags,
+		})
+		tests.Assert(t, err == nil, "failed to set tags", err)
+		err = heketi.NodeSetTags(clusterInfo.Nodes[2], &api.TagsChangeRequest{
+			Tags:   map[string]string{"flavor": "banana"},
+			Change: api.SetTags,
+		})
+		tests.Assert(t, err == nil, "failed to set tags", err)
+
+		volReq := &api.VolumeCreateRequest{}
+		volReq.Size = 1
+		volReq.Durability.Type = api.DurabilityReplicate
+		volReq.Durability.Replicate.Replica = 3
+		volReq.GlusterVolumeOptions = []string{
+			"user.heketi.device-tag-match flavor!=vanilla"}
+		_, err = heketi.VolumeCreate(volReq)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	})
+	t.Run("invalidMatch", func(t *testing.T) {
+		var err error
+		volReq := &api.VolumeCreateRequest{}
+		volReq.Size = 1
+		volReq.Durability.Type = api.DurabilityReplicate
+		volReq.Durability.Replicate.Replica = 3
+		volReq.GlusterVolumeOptions = []string{
+			"user.heketi.device-tag-match way=no"}
+		_, err = heketi.VolumeCreate(volReq)
+		tests.Assert(t, err != nil, "expected err != nil, got:", err)
+	})
+	t.Run("incompleteMatch", func(t *testing.T) {
+		var err error
+		err = heketi.NodeSetTags(clusterInfo.Nodes[0], &api.TagsChangeRequest{
+			Tags:   map[string]string{"flavor": "banana"},
+			Change: api.SetTags,
+		})
+		tests.Assert(t, err == nil, "failed to set tags", err)
+		err = heketi.NodeSetTags(clusterInfo.Nodes[1], &api.TagsChangeRequest{
+			Tags:   map[string]string{"flavor": "banana"},
+			Change: api.SetTags,
+		})
+		tests.Assert(t, err == nil, "failed to set tags", err)
+		err = heketi.NodeSetTags(clusterInfo.Nodes[2], &api.TagsChangeRequest{
+			Tags:   map[string]string{"flavor": "cherry"},
+			Change: api.SetTags,
+		})
+		tests.Assert(t, err == nil, "failed to set tags", err)
+
+		volReq := &api.VolumeCreateRequest{}
+		volReq.Size = 1
+		volReq.Durability.Type = api.DurabilityReplicate
+		volReq.Durability.Replicate.Replica = 3
+		volReq.GlusterVolumeOptions = []string{
+			"user.heketi.device-tag-match flavor=banana"}
+		_, err = heketi.VolumeCreate(volReq)
+		tests.Assert(t, err != nil, "expected err != nil, got:", err)
+	})
+	t.Run("incompleteInverseMatch", func(t *testing.T) {
+		var err error
+		err = heketi.NodeSetTags(clusterInfo.Nodes[0], &api.TagsChangeRequest{
+			Tags:   map[string]string{"flavor": "banana"},
+			Change: api.SetTags,
+		})
+		tests.Assert(t, err == nil, "failed to set tags", err)
+		err = heketi.NodeSetTags(clusterInfo.Nodes[1], &api.TagsChangeRequest{
+			Tags:   map[string]string{"flavor": "banana"},
+			Change: api.SetTags,
+		})
+		tests.Assert(t, err == nil, "failed to set tags", err)
+		err = heketi.NodeSetTags(clusterInfo.Nodes[2], &api.TagsChangeRequest{
+			Tags:   map[string]string{"flavor": "cherry"},
+			Change: api.SetTags,
+		})
+		tests.Assert(t, err == nil, "failed to set tags", err)
+
+		volReq := &api.VolumeCreateRequest{}
+		volReq.Size = 1
+		volReq.Durability.Type = api.DurabilityReplicate
+		volReq.Durability.Replicate.Replica = 3
+		volReq.GlusterVolumeOptions = []string{
+			"user.heketi.device-tag-match flavor!=banana"}
+		_, err = heketi.VolumeCreate(volReq)
+		tests.Assert(t, err != nil, "expected err != nil, got:", err)
+	})
+
+	t.Run("testWithTagsOnDevices", func(t *testing.T) {
+		var err error
+		for _, nid := range clusterInfo.Nodes {
+			ni, err := heketi.NodeInfo(nid)
+			tests.Assert(t, err == nil, "failed to set tags", err)
+
+			for i, di := range ni.DevicesInfo {
+				var tval string
+				switch i {
+				case 0:
+					tval = "red"
+				case 1:
+					tval = "green"
+				case 2:
+					tval = "ecru"
+				}
+				err = heketi.DeviceSetTags(di.Id, &api.TagsChangeRequest{
+					Tags:   map[string]string{"color": tval},
+					Change: api.SetTags,
+				})
+				tests.Assert(t, err == nil, "failed to set tags", err)
+			}
+		}
+
+		volReq := &api.VolumeCreateRequest{}
+		volReq.Size = 1
+		volReq.Durability.Type = api.DurabilityReplicate
+		volReq.Durability.Replicate.Replica = 3
+		// there are sufficient red devices
+		volReq.GlusterVolumeOptions = []string{
+			"user.heketi.device-tag-match color=red"}
+		_, err = heketi.VolumeCreate(volReq)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		// there are sufficient non-ecru devices
+		volReq.GlusterVolumeOptions = []string{
+			"user.heketi.device-tag-match color!=ecru"}
+		_, err = heketi.VolumeCreate(volReq)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		// there are no mauve devices
+		volReq.GlusterVolumeOptions = []string{
+			"user.heketi.device-tag-match color=mauve"}
+		_, err = heketi.VolumeCreate(volReq)
+		tests.Assert(t, err != nil, "expected err != nil, got:", err)
+	})
+
+	t.Run("tagsAndZoneChecking", func(t *testing.T) {
+		var err error
+		err = heketi.NodeSetTags(clusterInfo.Nodes[0], &api.TagsChangeRequest{
+			Tags:   map[string]string{"flavor": "grape"},
+			Change: api.SetTags,
+		})
+		tests.Assert(t, err == nil, "failed to set tags", err)
+		err = heketi.NodeSetTags(clusterInfo.Nodes[1], &api.TagsChangeRequest{
+			Tags:   map[string]string{"flavor": "grape"},
+			Change: api.SetTags,
+		})
+		tests.Assert(t, err == nil, "failed to set tags", err)
+		err = heketi.NodeSetTags(clusterInfo.Nodes[2], &api.TagsChangeRequest{
+			Tags:   map[string]string{"flavor": "grape"},
+			Change: api.SetTags,
+		})
+		tests.Assert(t, err == nil, "failed to set tags", err)
+
+		volReq := &api.VolumeCreateRequest{}
+		volReq.Size = 1
+		volReq.Durability.Type = api.DurabilityReplicate
+		volReq.Durability.Replicate.Replica = 3
+		// tag match is OK
+		volReq.GlusterVolumeOptions = []string{
+			"user.heketi.device-tag-match flavor=grape"}
+		_, err = heketi.VolumeCreate(volReq)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		// we set this test cluster up with one zone. zone check will fail
+		volReq.GlusterVolumeOptions = []string{
+			"user.heketi.zone-checking strict",
+			"user.heketi.device-tag-match flavor=grape"}
+		_, err = heketi.VolumeCreate(volReq)
+		tests.Assert(t, err != nil, "expected err != nil, got:", err)
+	})
+}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

As outlined in the [tag matching design doc](/heketi/heketi/blob/master/docs/design/tag-matching.md) an administrator can set up tags on nodes and devices and then when volumes are being created a tag matching rule can be specified such that the bricks that make up the volume are placed only on matching devices.

A simple use case would be devices managed by heketi with heterogeneous performance characteristics. An admin might tag some disks with "perf:fast" and others with "perf:slow". Then depending on the needs of the volume (eg. small/fast vs. large/slow) the volume can be requested with volume options like so "user.heketi.device-tag-match perf=fast" or  "user.heketi.device-tag-match perf=slow". Note that inverse matches are also supported, example "user.heketi.device-tag-match perf!=fast".
Note that this feature is generic and really has nothing to do with performance in particular as the tag keys, tag values, and match rules have no internal meaning to Heketi. Thus the matching can be used for any reason. We do suspect performance matching will be the most common.

### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #


### Notes for the reviewer

Currently the matching rule's "selector" string is either `=` or `!=`. I wondered if there could be issues here that could either cause confusion (`=` vs. `==`) or parsing issues if the options string has to be encoded in particular languages/formats (`!=` use of exclamation mark).
I was considering supporting alternate spellings of these but kept the initial PR on the simpler side (and matching the original proposal). Something we might want to discuss.

In addition, to keep this pr simple and self-contained the "Other Considerations" section was not considered at this time.