### PR TITLE
Evict a Brick

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -621,6 +621,13 @@ func (a *App) SetRoutes(router *mux.Router) error {
 			Pattern:     "/blockvolumes",
 			HandlerFunc: a.BlockVolumeList},
 
+		// Brick (special)
+		rest.Route{
+			Name:        "BrickEvict",
+			Method:      "POST",
+			Pattern:     "/bricks/to-evict/{id:[A-Fa-f0-9]+}",
+			HandlerFunc: a.BrickEvict},
+
 		// Backup
 		rest.Route{
 			Name:        "Backup",

--- a/apps/glusterfs/operations_device.go
+++ b/apps/glusterfs/operations_device.go
@@ -141,3 +141,501 @@ func (dro *DeviceRemoveOperation) Finalize() error {
 		return dro.op.Delete(tx)
 	})
 }
+
+// BrickEvictOperation removes exactly one brick from a volume
+// automatically replacing it to maintain any other volume restrictions.
+type BrickEvictOperation struct {
+	OperationManager
+	noRetriesOperation
+	BrickId string
+
+	// internal caching params
+	replaceBrickSet  *BrickSet
+	replaceIndex     int
+	newBrickEntryId  string
+	newDeviceEntryId string
+	reclaimed        ReclaimMap
+	wasReplaced      bool
+}
+
+type brickContext struct {
+	brick  *BrickEntry
+	volume *VolumeEntry
+	device *DeviceEntry
+	node   *NodeEntry
+}
+
+func (bc brickContext) bhmap() brickHostMap {
+	return brickHostMap{
+		bc.brick: bc.node.ManageHostName(),
+	}
+}
+
+func NewBrickEvictOperation(
+	brickId string, db wdb.DB) *BrickEvictOperation {
+
+	return &BrickEvictOperation{
+		OperationManager: OperationManager{
+			db: db,
+			op: NewPendingOperationEntry(NEW_ID),
+		},
+		BrickId: brickId,
+	}
+}
+
+func (beo *BrickEvictOperation) Label() string {
+	return "Evict Brick"
+}
+
+func (beo *BrickEvictOperation) ResourceUrl() string {
+	return ""
+}
+
+func (beo *BrickEvictOperation) Build() error {
+	// this build is pretty minimal as it only can record the brick
+	// in need of eviction. The replacement brick can not be determined
+	// without running (gluster) commands.
+	return beo.db.Update(func(tx *bolt.Tx) error {
+		old, err := beo.current(wdb.WrapTx(tx))
+		if err != nil {
+			return err
+		}
+		if old.brick.Pending.Id != "" {
+			return fmt.Errorf(
+				"Can not evict brick %v: brick is pending", old.brick.Id())
+		}
+		for _, bid := range old.volume.Bricks {
+			b, err := NewBrickEntryFromId(tx, bid)
+			if err != nil {
+				return err
+			}
+			if b.Pending.Id != "" {
+				logger.Warning("Found pending brick %v on volume %v",
+					bid, old.volume.Info.Id)
+				return fmt.Errorf(
+					"Can not evict brick %v from volume %v: volume has pending bricks",
+					old.brick.Id(), old.volume.Info.Id)
+			}
+		}
+
+		brickEntry, err := NewBrickEntryFromId(tx, beo.BrickId)
+		if err != nil {
+			return err
+		}
+		beo.op.Type = OperationBrickEvict
+		beo.op.RecordDeleteBrick(brickEntry)
+		if e := brickEntry.Save(tx); e != nil {
+			return e
+		}
+		if e := beo.op.Save(tx); e != nil {
+			return e
+		}
+		return nil
+	})
+}
+
+func (beo *BrickEvictOperation) buildNewBrick(bs *BrickSet, index int) error {
+	return beo.db.Update(func(tx *bolt.Tx) error {
+		old, err := beo.current(wdb.WrapTx(tx))
+		if err != nil {
+			return err
+		}
+		// determine the placement for the new brick
+		newBrickEntry, newDeviceEntry, err := old.volume.allocBrickReplacement(
+			wdb.WrapTx(tx), old.brick, old.device, bs, index)
+		if err != nil {
+			return err
+		}
+		// update pending op with new brick info
+		for _, action := range beo.op.Actions {
+			if action.Change == OpAddBrick {
+				return fmt.Errorf("operation already has a new brick")
+			}
+		}
+		beo.op.RecordAddBrick(newBrickEntry)
+		if e := beo.op.Save(tx); e != nil {
+			return e
+		}
+		// save new brick entry
+		if e := newBrickEntry.Save(tx); e != nil {
+			return e
+		}
+		// update operation cached entries for new brick and device entries
+		beo.newBrickEntryId = newBrickEntry.Id()
+		beo.newDeviceEntryId = newDeviceEntry.Id()
+		return nil
+	})
+}
+
+// current returns the brickContext containing a brick entry, volume entry,
+// device entry and node entry for the brick to be removed.
+func (beo *BrickEvictOperation) current(db wdb.RODB) (brickContext, error) {
+
+	var bc brickContext
+	err := beo.db.View(func(tx *bolt.Tx) error {
+		var err error
+		bc.brick, err = NewBrickEntryFromId(tx, beo.BrickId)
+		if err != nil {
+			return err
+		}
+		bc.device, err = NewDeviceEntryFromId(tx, bc.brick.Info.DeviceId)
+		if err != nil {
+			return err
+		}
+		bc.node, err = NewNodeEntryFromId(tx, bc.brick.Info.NodeId)
+		if err != nil {
+			return err
+		}
+		bc.volume, err = NewVolumeEntryFromId(tx, bc.brick.Info.VolumeId)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	return bc, err
+}
+
+func (beo *BrickEvictOperation) execGetReplacmentInfo(
+	executor executors.Executor) error {
+
+	old, err := beo.current(beo.db)
+	if err != nil {
+		return err
+	}
+	node := old.node.ManageHostName()
+
+	bs, index, err := old.volume.getBrickSetForBrickId(
+		beo.db, executor, old.brick.Info.Id, node)
+	if err != nil {
+		return err
+	}
+
+	err = old.volume.canReplaceBrickInBrickSet(beo.db, executor, node, bs, index)
+	if err != nil {
+		return err
+	}
+	beo.replaceBrickSet = bs
+	beo.replaceIndex = index
+	return nil
+}
+
+func (beo *BrickEvictOperation) execReplaceBrick(
+	executor executors.Executor) error {
+
+	var (
+		err               error
+		old               brickContext
+		newBrickEntry     *BrickEntry
+		newBrickNodeEntry *NodeEntry
+	)
+	err = beo.db.View(func(tx *bolt.Tx) error {
+		var err error
+		old, err = beo.current(beo.db)
+		if err != nil {
+			return err
+		}
+		newBrickEntry, err = NewBrickEntryFromId(tx, beo.newBrickEntryId)
+		if err != nil {
+			return err
+		}
+		newBrickNodeEntry, err = NewNodeEntryFromId(
+			tx, newBrickEntry.Info.NodeId)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	brickEntries := []*BrickEntry{newBrickEntry}
+	err = CreateBricks(beo.db, executor, brickEntries)
+	if err != nil {
+		return err
+	}
+
+	var (
+		oldBrick executors.BrickInfo
+		newBrick executors.BrickInfo
+	)
+	oldBrick.Path = old.brick.Info.Path
+	oldBrick.Host = old.node.StorageHostName()
+	newBrick.Path = newBrickEntry.Info.Path
+	newBrick.Host = newBrickNodeEntry.StorageHostName()
+
+	node := newBrickNodeEntry.ManageHostName()
+	err = executor.VolumeReplaceBrick(
+		node, old.volume.Info.Name, &oldBrick, &newBrick)
+	if err != nil {
+		return err
+	}
+
+	beo.reclaimed, err = old.bhmap().destroy(executor)
+	if err != nil {
+		return logger.LogError("Error destroying old brick: %v", err)
+	}
+	return nil
+}
+
+func (beo *BrickEvictOperation) Exec(executor executors.Executor) error {
+	// PHASE I
+	// first we need to determine a) if we can remove a brick at this
+	// time. and b) what brick set our current brick belongs to.
+	// This updates the operation state.
+	err := beo.execGetReplacmentInfo(executor)
+	if err != nil {
+		return err
+	}
+	// PHASE II
+	// update the operation metadata with the new brick
+	if e := beo.buildNewBrick(beo.replaceBrickSet, beo.replaceIndex); e != nil {
+		return e
+	}
+	// PHASE III
+	// actually perform the replacement of the brick
+	return beo.execReplaceBrick(executor)
+}
+
+func (beo *BrickEvictOperation) Rollback(executor executors.Executor) error {
+	return rollbackViaClean(beo, executor)
+}
+
+func (beo *BrickEvictOperation) Finalize() error {
+	return beo.db.Update(func(tx *bolt.Tx) error {
+		return beo.finishAccept(tx)
+	})
+}
+
+func (beo *BrickEvictOperation) refreshOp(db wdb.RODB) error {
+	return db.View(func(tx *bolt.Tx) error {
+		op, err := NewPendingOperationEntryFromId(tx, beo.op.Id)
+		if err != nil {
+			return err
+		}
+		beo.op = op
+		return nil
+	})
+}
+
+func (beo *BrickEvictOperation) Clean(executor executors.Executor) error {
+	logger.Info("Starting Clean for %v op:%v", beo.Label(), beo.op.Id)
+	// ensure our cached op is synced with the db state
+	if e := beo.refreshOp(beo.db); e != nil {
+		return e
+	}
+	bes, err := evictStatus(beo.op)
+	if err != nil {
+		return err
+	}
+
+	if bes.newBrickId == "" {
+		// no new brick has been allocated by heketi yet. thus no changes have
+		// been made on the backend. We can just clean up our db w/o making
+		// any backend clean ups.
+		return nil
+	}
+	beo.newBrickEntryId = bes.newBrickId
+
+	// The operation reached some point after having decided to create a
+	// new brick. At any point before requesting gluster do the brick replace
+	// we can just "unroll" the new brick components but if gluster accepted
+	// our brick replace call we're past a point of no return as that brick
+	// is probably in use and we should just "push forward" with the
+	// replacement. Therefore we must start off by querying gluster's state.
+	old, err := beo.current(beo.db)
+	if err != nil {
+		return err
+	}
+	node := old.node.ManageHostName() // TODO: try on multiple nodes?
+	vinfo, err := executor.VolumeInfo(node, old.volume.Info.Name)
+	if err != nil {
+		logger.LogError("Unable to get volume info from gluster node %v for volume %v: %v", node, old.volume.Info.Name, err)
+		return err
+	}
+
+	var newBHMap brickHostMap
+	err = beo.db.View(func(tx *bolt.Tx) error {
+		txdb := wdb.WrapTx(tx)
+		bmap, err := old.volume.brickNameMap(txdb)
+		if err != nil {
+			return err
+		}
+		newBrick, err := NewBrickEntryFromId(tx, beo.newBrickEntryId)
+		if err != nil {
+			return err
+		}
+		newBrickNodeEntry, err := NewNodeEntryFromId(
+			tx, newBrick.Info.NodeId)
+		if err != nil {
+			return err
+		}
+		newBHMap = brickHostMap{
+			newBrick: newBrickNodeEntry.ManageHostName(),
+		}
+		newBrickHostPath, err := brickHostPath(txdb, newBrick)
+		if err != nil {
+			return err
+		}
+		for _, gbrick := range vinfo.Bricks.BrickList {
+			if _, found := bmap[gbrick.Name]; found {
+				logger.Info(
+					"Found existing gluster brick in volume: %v", gbrick.Name)
+			} else if newBrickHostPath == gbrick.Name {
+				beo.wasReplaced = true
+				logger.Info(
+					"Found new brick in gluster volume: %v", newBrickHostPath)
+			} else {
+				return logger.LogError(
+					"Found gluster brick not matching in heketi db: %v",
+					gbrick.Name)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if beo.wasReplaced {
+		logger.Info("Destroying old brick contents")
+		beo.reclaimed, err = old.bhmap().destroy(executor)
+		if err != nil {
+			return logger.LogError("Error destroying old brick: %v", err)
+		}
+	} else {
+		logger.Info("Destroying unused new brick contents")
+		beo.reclaimed, err = newBHMap.destroy(executor)
+		if err != nil {
+			return logger.LogError("Error destroying new brick: %v", err)
+		}
+	}
+	return nil
+}
+
+func (beo *BrickEvictOperation) CleanDone() error {
+	logger.Info("Clean is done for %v op:%v", beo.Label(), beo.op.Id)
+	return beo.db.Update(func(tx *bolt.Tx) error {
+		if e := beo.refreshOp(beo.db); e != nil {
+			return e
+		}
+		bes, err := evictStatus(beo.op)
+		if err != nil {
+			return err
+		}
+
+		if bes.newBrickId == "" {
+			logger.Debug("no new brick: operation never started")
+			return beo.finishNeverStarted(wdb.WrapTx(tx), bes)
+		}
+		if beo.wasReplaced {
+			return beo.finishAccept(tx)
+		}
+		return beo.finishRevert(tx)
+	})
+}
+
+func (beo *BrickEvictOperation) finishNeverStarted(db wdb.DB, bes brickEvictStatus) error {
+	return db.Update(func(tx *bolt.Tx) error {
+		b, err := NewBrickEntryFromId(tx, bes.oldBrickId)
+		if err != nil {
+			return err
+		}
+		beo.op.FinalizeBrick(b)
+		if e := b.Save(tx); e != nil {
+			return e
+		}
+		return beo.op.Delete(tx)
+	})
+}
+
+func (beo *BrickEvictOperation) finishAccept(tx *bolt.Tx) error {
+	old, err := beo.current(beo.db)
+	if err != nil {
+		return err
+	}
+	newBrick, err := NewBrickEntryFromId(tx, beo.newBrickEntryId)
+	if err != nil {
+		return err
+	}
+	// remove old brick (return space + update links)
+	err = old.brick.removeAndFree(
+		tx, old.volume, beo.reclaimed[old.brick.Info.DeviceId])
+	if err != nil {
+		return err
+	}
+	// update (new) device with new brick
+	// reminder: New brick function takes space from device (!!!)
+	newDevice, err := NewDeviceEntryFromId(tx, beo.newDeviceEntryId)
+	if err != nil {
+		return err
+	}
+	newDevice.BrickAdd(newBrick.Id())
+	// add new brick to volume
+	old.volume.BrickAdd(newBrick.Id())
+	// save volume
+	if e := old.volume.Save(tx); e != nil {
+		return e
+	}
+	// save new device
+	if e := newDevice.Save(tx); e != nil {
+		return e
+	}
+	// save new brick
+	beo.op.FinalizeBrick(newBrick)
+	if e := newBrick.Save(tx); e != nil {
+		return e
+	}
+	// remove pending markers
+	return beo.op.Delete(tx)
+}
+
+func (beo *BrickEvictOperation) finishRevert(tx *bolt.Tx) error {
+	old, err := beo.current(beo.db)
+	if err != nil {
+		return err
+	}
+	newBrick, err := NewBrickEntryFromId(tx, beo.newBrickEntryId)
+	if err != nil {
+		return err
+	}
+	// remove new brick (return space + update links)
+	err = newBrick.removeAndFree(
+		tx, old.volume, beo.reclaimed[newBrick.Info.DeviceId])
+	if err != nil {
+		return err
+	}
+	// the old brick has not been replaced. remove pending state
+	beo.op.FinalizeBrick(old.brick)
+	if e := old.brick.Save(tx); e != nil {
+		return e
+	}
+	// save volume
+	if e := old.volume.Save(tx); e != nil {
+		return e
+	}
+	// remove pending markers
+	return beo.op.Delete(tx)
+}
+
+type brickEvictStatus struct {
+	oldBrickId string
+	newBrickId string
+}
+
+func evictStatus(op *PendingOperationEntry) (brickEvictStatus, error) {
+	bes := brickEvictStatus{}
+	for _, action := range op.Actions {
+		switch action.Change {
+		case OpDeleteBrick:
+			logger.Info("found brick to be replaced: %v", action.Id)
+			bes.oldBrickId = action.Id
+		case OpAddBrick:
+			logger.Info("found replacement brick: %v", action.Id)
+			bes.newBrickId = action.Id
+		default:
+			logger.Info("found invalied action: %v, %v",
+				action.Change, action.Id)
+			return bes, fmt.Errorf(
+				"Malformed pending operation entry for brick evict operation")
+		}
+	}
+	return bes, nil
+}

--- a/apps/glusterfs/operations_device.go
+++ b/apps/glusterfs/operations_device.go
@@ -183,6 +183,31 @@ func NewBrickEvictOperation(
 	}
 }
 
+// loadBrickEvictOperation returns a BrickEvictOperation populated
+// from an existing pending operation entry in the db.
+func loadBrickEvictOperation(
+	db wdb.DB, p *PendingOperationEntry) (*BrickEvictOperation, error) {
+
+	var brickId string
+	for _, action := range p.Actions {
+		if action.Change == OpDeleteBrick {
+			brickId = action.Id
+		}
+	}
+	if brickId == "" {
+		return nil, fmt.Errorf(
+			"Missing brick to evict in operation")
+	}
+
+	return &BrickEvictOperation{
+		OperationManager: OperationManager{
+			db: db,
+			op: p,
+		},
+		BrickId: brickId,
+	}, nil
+}
+
 func (beo *BrickEvictOperation) Label() string {
 	return "Evict Brick"
 }

--- a/apps/glusterfs/operations_device_test.go
+++ b/apps/glusterfs/operations_device_test.go
@@ -676,3 +676,74 @@ func TestBrickEvictOperationError(t *testing.T) {
 		return nil
 	})
 }
+
+func TestBrickEvictOperationErrorAfterBrick(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		1,    // clusters
+		3,    // nodes_per_cluster
+		3,    // devices_per_node,
+		8*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	vreq := &api.VolumeCreateRequest{}
+	vreq.Size = 100
+	vreq.Durability.Type = api.DurabilityReplicate
+	vreq.Durability.Replicate.Replica = 3
+	v := NewVolumeEntryFromRequest(vreq)
+	err = v.Create(app.db, app.executor)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	var b *BrickEntry
+	app.db.View(func(tx *bolt.Tx) error {
+		bl, err := BrickList(tx)
+		tests.Assert(t, err == nil)
+		tests.Assert(t, len(bl) == 3)
+		b, err = NewBrickEntryFromId(tx, bl[0])
+		tests.Assert(t, err == nil)
+		return nil
+	})
+
+	app.xo.MockVolumeInfo = func(host string, volume string) (*executors.Volume, error) {
+		return mockVolumeInfoFromDb(app.db, volume)
+	}
+	app.xo.MockHealInfo = func(host string, volume string) (*executors.HealInfo, error) {
+		return mockHealStatusFromDb(app.db, volume)
+	}
+	app.xo.MockVolumeReplaceBrick = func(host string, volume string, oldBrick *executors.BrickInfo, newBrick *executors.BrickInfo) error {
+		return fmt.Errorf("Whoopsie")
+	}
+
+	beo := NewBrickEvictOperation(b.Info.Id, app.db)
+	err = RunOperation(beo, app.executor)
+	tests.Assert(t, err != nil, "expected err != nil, got:", err)
+
+	// operation is over. we should _not_ have a pending op now
+	err = app.db.View(func(tx *bolt.Tx) error {
+		l, err := PendingOperationList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(l) == 0, "expected len(l) == 0, got:", len(l))
+
+		bl, err := BrickList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(bl) == 3, "expected len(l) == 1, got:", len(l))
+		pc := 0
+		for _, brickId := range bl {
+			b, err := NewBrickEntryFromId(tx, brickId)
+			tests.Assert(t, err == nil, "expected err == nil, got:", err)
+			if b.Pending.Id != "" {
+				logger.Info("Pending Brick: %v", b.Id())
+				pc += 1
+			}
+		}
+		tests.Assert(t, pc == 0, "expected 0 pending bricks, got:", pc)
+		return nil
+	})
+}

--- a/apps/glusterfs/operations_load.go
+++ b/apps/glusterfs/operations_load.go
@@ -51,6 +51,8 @@ func LoadOperation(
 		op, err = loadBlockVolumeCreateOperation(db, p)
 	case OperationDeleteBlockVolume:
 		op, err = loadBlockVolumeDeleteOperation(db, p)
+	case OperationBrickEvict:
+		op, err = loadBrickEvictOperation(db, p)
 	default:
 		err = NewErrNotLoadable(p.Id, p.Type)
 	}

--- a/apps/glusterfs/pendingop.go
+++ b/apps/glusterfs/pendingop.go
@@ -36,6 +36,7 @@ const (
 	OperationDeleteBlockVolume
 	OperationRemoveDevice
 	OperationCloneVolume
+	OperationBrickEvict
 )
 
 // PendingChangeType identifies what kind of lower-level new item or change
@@ -113,6 +114,8 @@ func (v PendingOperationType) Name() string {
 		return "remove-device"
 	case OperationCloneVolume:
 		return "clone-volume"
+	case OperationBrickEvict:
+		return "evict-brick"
 	}
 	return "unknown"
 }

--- a/client/api/go-client/brick.go
+++ b/client/api/go-client/brick.go
@@ -1,0 +1,72 @@
+//
+// Copyright (c) 2019 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
+//
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/heketi/pkg/utils"
+)
+
+// BrickEvict requests that Heketi evict the given brick from the
+// underlying gluster volume, automatically replacing it with a new brick.
+//
+// NOTE: options is currently empty but reserved for future extensions
+// to the api.
+func (c *Client) BrickEvict(id string, request *api.BrickEvictOptions) error {
+	var buf io.Reader
+	if request != nil {
+		b, err := json.Marshal(request)
+		if err != nil {
+			return err
+		}
+		buf = bytes.NewBuffer(b)
+	}
+
+	// Create a request
+	req, err := http.NewRequest("POST", c.host+"/bricks/to-evict/"+id, buf)
+	if err != nil {
+		return err
+	}
+
+	// Set token
+	err = c.setToken(req)
+	if err != nil {
+		return err
+	}
+
+	// Send request
+	r, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusAccepted {
+		return utils.GetErrorFromResponse(r)
+	}
+
+	// Wait for response
+	r, err = c.pollResponse(r)
+	if err != nil {
+		return err
+	}
+	if r.StatusCode != http.StatusNoContent {
+		return utils.GetErrorFromResponse(r)
+	}
+
+	return nil
+}

--- a/client/cli/go/cmds/brick.go
+++ b/client/cli/go/cmds/brick.go
@@ -1,0 +1,56 @@
+//
+// Copyright (c) 2019 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package cmds
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(brickCommand)
+	brickCommand.AddCommand(brickEvictCommand)
+	brickCommand.SilenceUsage = true
+}
+
+var brickCommand = &cobra.Command{
+	Use:   "brick",
+	Short: "Heketi Brick Management",
+	Long:  "Heketi Brick Management",
+}
+
+var brickEvictCommand = &cobra.Command{
+	Use:     "evict",
+	Short:   "Evict (remove) a brick from a volume",
+	Long:    "Evict (remove) a brick from a volume",
+	Example: "  $ heketi-cli brick evict ee6a86a868711bef8300c",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var err error
+
+		if len(args) < 1 {
+			return fmt.Errorf("Brick id missing")
+		} else if len(args) > 1 {
+			return fmt.Errorf("Too many arguments provided")
+		}
+		brickId := args[0]
+
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
+
+		err = heketi.BrickEvict(brickId, nil)
+		if err == nil {
+			fmt.Fprintf(stdout, "Brick %v evicted\n", brickId)
+		}
+		return err
+	},
+}

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -680,3 +680,7 @@ func ValidateIds(v interface{}) error {
 	}
 	return nil
 }
+
+// reserving a type for future options for brick evict
+type BrickEvictOptions struct {
+}

--- a/tests/functional/TestErrorHandling/tests/brick_evict_test.go
+++ b/tests/functional/TestErrorHandling/tests/brick_evict_test.go
@@ -1,0 +1,289 @@
+// +build functional
+
+//
+// Copyright (c) 2019 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
+//
+
+package tests
+
+import (
+	"os"
+	"path"
+	"sync"
+	"testing"
+
+	"github.com/heketi/tests"
+
+	inj "github.com/heketi/heketi/executors/injectexec"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/heketi/pkg/testutils"
+	"github.com/heketi/heketi/server/config"
+)
+
+func TestBrickEvict(t *testing.T) {
+	heketiServer := testutils.NewServerCtlFromEnv("..")
+	origConf := path.Join(heketiServer.ServerDir, heketiServer.ConfPath)
+
+	baseConf := tests.Tempfile()
+	defer os.Remove(baseConf)
+	UpdateConfig(origConf, baseConf, func(c *config.Config) {
+		// we want the background cleaner disabled for all
+		// of the sub-tests we'll be running as we are testing
+		// on demand cleaning and want predictable behavior.
+		c.GlusterFS.DisableBackgroundCleaner = true
+	})
+
+	heketiServer.ConfPath = tests.Tempfile()
+	defer os.Remove(heketiServer.ConfPath)
+	CopyFile(baseConf, heketiServer.ConfPath)
+
+	defer func() {
+		CopyFile(baseConf, heketiServer.ConfPath)
+		testutils.ServerRestarted(t, heketiServer)
+		testCluster.Teardown(t)
+		testutils.ServerStopped(t, heketiServer)
+	}()
+
+	resetConf := func() {
+		CopyFile(baseConf, heketiServer.ConfPath)
+		testutils.ServerRestarted(t, heketiServer)
+	}
+
+	testutils.ServerStarted(t, heketiServer)
+	heketiServer.KeepDB = true
+	testCluster.Setup(t, 3, 2)
+
+	volReq := &api.VolumeCreateRequest{}
+	volReq.Size = 1
+	volReq.Durability.Type = api.DurabilityReplicate
+	volReq.Durability.Replicate.Replica = 3
+
+	t.Run("basicEvict", func(t *testing.T) {
+		resetConf()
+
+		vinfo1, err := heketi.VolumeCreate(volReq)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		aggUsed := deviceAggregateUsedSize(t)
+
+		toEvict := vinfo1.Bricks[0].Id
+		err = heketi.BrickEvict(toEvict, nil)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		vinfo2, err := heketi.VolumeInfo(vinfo1.Id)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		oldIds := map[string]bool{}
+		for _, b := range vinfo1.Bricks {
+			oldIds[b.Id] = true
+		}
+		tests.Assert(t, len(oldIds) == 3,
+			"expected len(oldIds) == 3, got:", len(oldIds))
+		found := 0
+		for _, b := range vinfo2.Bricks {
+			if oldIds[b.Id] {
+				found++
+			} else {
+				tests.Assert(t, b.Id != toEvict,
+					"expected b.Id != toEvict, got", b.Id, toEvict)
+			}
+		}
+		tests.Assert(t, found == 2)
+		newAggUsed := deviceAggregateUsedSize(t)
+		tests.Assert(t, newAggUsed == aggUsed,
+			"expected device used aggregate sizes to match", newAggUsed, aggUsed)
+		checkConsistent(t, heketiServer)
+	})
+	t.Run("tripleEvict", func(t *testing.T) {
+		resetConf()
+
+		vinfo1, err := heketi.VolumeCreate(volReq)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		aggUsed := deviceAggregateUsedSize(t)
+
+		evictBricks := map[string]bool{}
+		for _, b := range vinfo1.Bricks {
+			evictBricks[b.Id] = true
+		}
+		for toEvict, _ := range evictBricks {
+			err = heketi.BrickEvict(toEvict, nil)
+			tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		}
+
+		vinfo2, err := heketi.VolumeInfo(vinfo1.Id)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		for _, b := range vinfo2.Bricks {
+			tests.Assert(t, !evictBricks[b.Id],
+				"expected brick id not in evictBricks map", b.Id, evictBricks)
+		}
+		newAggUsed := deviceAggregateUsedSize(t)
+		tests.Assert(t, newAggUsed == aggUsed,
+			"expected device used aggregate sizes to match", newAggUsed, aggUsed)
+		checkConsistent(t, heketiServer)
+	})
+	t.Run("tripleEvictTryParallel", func(t *testing.T) {
+		resetConf()
+
+		vinfo1, err := heketi.VolumeCreate(volReq)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		aggUsed := deviceAggregateUsedSize(t)
+
+		evictBricks := map[string]bool{}
+		for _, b := range vinfo1.Bricks {
+			evictBricks[b.Id] = true
+		}
+
+		evictResults := map[string]error{}
+		wg := sync.WaitGroup{}
+		l := sync.Mutex{}
+		for toEvict, _ := range evictBricks {
+			wg.Add(1)
+			go func(toEvict string) {
+				defer wg.Done()
+				err = heketi.BrickEvict(toEvict, nil)
+				l.Lock()
+				defer l.Unlock()
+				evictResults[toEvict] = err
+			}(toEvict)
+		}
+		wg.Wait()
+
+		tests.Assert(t, len(evictResults) == 3,
+			"expected len(evictResults) == 3, got:", len(evictResults))
+		var errCount int
+		for _, err := range evictResults {
+			if err != nil {
+				errCount += 1
+			}
+		}
+		tests.Assert(t, errCount == 2, "expected errCount == 2, got:", errCount)
+
+		vinfo2, err := heketi.VolumeInfo(vinfo1.Id)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		for _, b := range vinfo2.Bricks {
+			if evictResults[b.Id] == nil {
+				tests.Assert(t, !evictBricks[b.Id],
+					"expected brick id not in evictBricks map", b.Id, evictBricks)
+			} else {
+				tests.Assert(t, evictBricks[b.Id],
+					"expected brick id in evictBricks map", b.Id, evictBricks)
+			}
+		}
+		newAggUsed := deviceAggregateUsedSize(t)
+		tests.Assert(t, newAggUsed == aggUsed,
+			"expected device used aggregate sizes to match", newAggUsed, aggUsed)
+		checkConsistent(t, heketiServer)
+	})
+
+	t.Run("simpleEarlyError", func(t *testing.T) {
+		resetConf()
+
+		vinfo1, err := heketi.VolumeCreate(volReq)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		UpdateConfig(origConf, heketiServer.ConfPath, func(c *config.Config) {
+			c.GlusterFS.Executor = "inject/ssh"
+			c.GlusterFS.InjectConfig.CmdInjection.CmdHooks = inj.CmdHooks{
+				inj.CmdHook{
+					Cmd: ".*lvcreate.*",
+					Reaction: inj.Reaction{
+						Err: "thwack!",
+					},
+				},
+			}
+		})
+		testutils.ServerRestarted(t, heketiServer)
+
+		toEvict := vinfo1.Bricks[0].Id
+		err = heketi.BrickEvict(toEvict, nil)
+		tests.Assert(t, err != nil, "expected err == nil, got:", err)
+
+		vinfo2, err := heketi.VolumeInfo(vinfo1.Id)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		for i, b := range vinfo2.Bricks {
+			tests.Assert(t, vinfo1.Bricks[i].Id == b.Id,
+				"expected brick id to match, got:",
+				vinfo1.Bricks[i].Id, b.Id)
+		}
+		checkConsistent(t, heketiServer)
+	})
+
+	t.Run("errorAfterReplace", func(t *testing.T) {
+		resetConf()
+
+		vinfo1, err := heketi.VolumeCreate(volReq)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		aggUsed := deviceAggregateUsedSize(t)
+
+		UpdateConfig(origConf, heketiServer.ConfPath, func(c *config.Config) {
+			c.GlusterFS.Executor = "inject/ssh"
+			c.GlusterFS.InjectConfig.CmdInjection.ResultHooks = inj.ResultHooks{
+				inj.ResultHook{
+					CmdHook: inj.CmdHook{
+						Cmd: ".*volume replace-brick.*",
+						Reaction: inj.Reaction{
+							Err: "thwack!",
+						},
+					},
+					Result: ".*",
+				},
+			}
+		})
+		testutils.ServerRestarted(t, heketiServer)
+
+		toEvict := vinfo1.Bricks[0].Id
+		err = heketi.BrickEvict(toEvict, nil)
+		tests.Assert(t, err != nil, "expected err == nil, got:", err)
+
+		// in this case even tho the operation "failed" the state of
+		// the gluster system is as if the replace succeeded. The state
+		// of the system after the operation should be similar to
+		// the state of a successful op.
+
+		vinfo2, err := heketi.VolumeInfo(vinfo1.Id)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		oldIds := map[string]bool{}
+		for _, b := range vinfo1.Bricks {
+			oldIds[b.Id] = true
+		}
+		tests.Assert(t, len(oldIds) == 3,
+			"expected len(oldIds) == 3, got:", len(oldIds))
+		found := 0
+		for _, b := range vinfo2.Bricks {
+			if oldIds[b.Id] {
+				found++
+			} else {
+				tests.Assert(t, b.Id != toEvict,
+					"expected b.Id != toEvict, got", b.Id, toEvict)
+			}
+		}
+		tests.Assert(t, found == 2)
+		newAggUsed := deviceAggregateUsedSize(t)
+		tests.Assert(t, newAggUsed == aggUsed,
+			"expected device used aggregate sizes to match", newAggUsed, aggUsed)
+		checkConsistent(t, heketiServer)
+	})
+}
+
+func deviceAggregateUsedSize(t *testing.T) uint64 {
+	var agg uint64
+	topo, err := heketi.TopologyInfo()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	for _, c := range topo.ClusterList {
+		for _, n := range c.Nodes {
+			for _, d := range n.DevicesInfo {
+				agg += d.Storage.Used
+			}
+		}
+	}
+	return agg
+}


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

The ability to evict (aka remove but that word is overused in heketi) a single brick. Since all other conditions must be met, evicting an existing brick always means that a new brick is created to take the old brick's place. This means its effecitvely brick add + gluster brick replace + brick remove.

Command line example: `heketi-cli brick evict f37409fe4ab83a150307a1b622b3da4f`


### Does this PR fix issues?

Fixes #1596

### Notes for the reviewer

PR Includes:
* Core operation code
* Server Side API Support
* Go API
* CLI Interface
* Module tests
* Functional tests
