### PR TITLE
Fixed Heketi database restore logic from a secret based backup

### DIFF
--- a/extras/container/heketi-start.sh
+++ b/extras/container/heketi-start.sh
@@ -116,19 +116,23 @@ fi
 
 if [[ ! -f "${HEKETI_PATH}/heketi.db" ]]; then
     info "No database file found"
+    info "Database file is expected, waiting..."
+    check=0
+    while [[ ! -f "${HEKETI_PATH}/heketi.db" ]]; do
+        sleep 5
+        if [[ ${check} -eq 5 ]]; then
+            #Try to restore BD from secret
+            restore_backup
+            break
+        fi
+        ((check+=1))
+    done
+else
+    #Added for compatibility with the old approach    
     out=$(mount | grep "${HEKETI_PATH}" | grep heketidbstorage)
-    if [[ $? -eq 0 ]]; then
-        info "Database volume found: ${out}"
-        info "Database file is expected, waiting..."
-        check=0
-        while [[ ! -f "${HEKETI_PATH}/heketi.db" ]]; do
-            sleep 5
-            if [[ ${check} -eq 5 ]]; then
-               #Try to restore the database from a secret
-               restore_backup
-            fi
-            ((check+=1))
-        done
+    if [[ $? -ne 0 ]]; then
+        info "Database volume not found"
+        restore_backup
     fi
 fi
 

--- a/extras/container/heketi-start.sh
+++ b/extras/container/heketi-start.sh
@@ -129,7 +129,7 @@ if [[ ! -f "${HEKETI_PATH}/heketi.db" ]]; then
     done
 else
     #Added for compatibility with the old approach    
-    out=$(mount | grep "${HEKETI_PATH}" | grep heketidbstorage | wc -l)
+    out=$(mount | grep "${HEKETI_PATH}" | grep -c heketidbstorage)
     if [[ $out -eq 0 ]]; then
         info "Database volume not found"
         restore_backup

--- a/extras/container/heketi-start.sh
+++ b/extras/container/heketi-start.sh
@@ -124,9 +124,8 @@ if [[ ! -f "${HEKETI_PATH}/heketi.db" ]]; then
         while [[ ! -f "${HEKETI_PATH}/heketi.db" ]]; do
             sleep 5
             if [[ ${check} -eq 5 ]]; then
-               #Try to restore BD from secret
+               #Try to restore the database from a secret
                restore_backup
-               #fail "Database file did not appear, exiting."
             fi
             ((check+=1))
         done

--- a/extras/container/heketi-start.sh
+++ b/extras/container/heketi-start.sh
@@ -129,8 +129,8 @@ if [[ ! -f "${HEKETI_PATH}/heketi.db" ]]; then
     done
 else
     #Added for compatibility with the old approach    
-    out=$(mount | grep "${HEKETI_PATH}" | grep heketidbstorage)
-    if [[ $? -ne 0 ]]; then
+    out=$(mount | grep "${HEKETI_PATH}" | grep heketidbstorage | wc -l)
+    if [[ $out -eq 0 ]]; then
         info "Database volume not found"
         restore_backup
     fi


### PR DESCRIPTION
Fixed Heketi database restore logic from a secret based backup during the startup phase

### What does this PR achieve? Why do we need it?
Currently we are always trying restore a backup from a secret, if it exists. But if we don't have a database file on the Heketi database volume, the container stops working with the error: "Database file did not appear, exiting."

Now we are trying to restore the Heketi database from a secret based backup if secret exists and the database volume doesn't have a database file.

### Notes for the reviewer