### PR TITLE
fix inconsistent db after (failing) volume expand operation

### DIFF
--- a/apps/glusterfs/operations_volume.go
+++ b/apps/glusterfs/operations_volume.go
@@ -356,7 +356,7 @@ func (ve *VolumeExpandOperation) CleanDone() error {
 		}
 		bricks, err := bricksFromOp(txdb, ve.op, v.Info.Gid)
 		for _, brick := range bricks {
-			err := brick.removeAndFree(tx, v, ve.reclaimed[brick.Info.Id])
+			err := brick.removeAndFree(tx, v, ve.reclaimed[brick.Info.DeviceId])
 			if err != nil {
 				return err
 			}

--- a/apps/glusterfs/pendingop_entry.go
+++ b/apps/glusterfs/pendingop_entry.go
@@ -390,13 +390,18 @@ func (p *PendingOperationEntry) consistencyCheck(db Db) (response DbEntryCheckRe
 			if p.Id != db.Bricks[action.Id].Pending.Id {
 				response.Inconsistencies = append(response.Inconsistencies, fmt.Sprintf("pending op %v id in change missing %v not found in bricks", p.Id, action.Id))
 			}
-		case OpAddVolume, OpDeleteVolume, OpExpandVolume, OpCloneVolume, OpSnapshotVolume, OpAddVolumeClone:
+		case OpAddVolume, OpDeleteVolume, OpCloneVolume, OpSnapshotVolume, OpAddVolumeClone:
 			if p.Id != db.Volumes[action.Id].Pending.Id {
 				response.Inconsistencies = append(response.Inconsistencies, fmt.Sprintf("pending op %v id in change missing %v not found in volumes", p.Id, action.Id))
 			}
 		case OpAddBlockVolume, OpDeleteBlockVolume:
 			if p.Id != db.BlockVolumes[action.Id].Pending.Id {
 				response.Inconsistencies = append(response.Inconsistencies, fmt.Sprintf("pending op %v id in change missing %v not found in blockvolumes", p.Id, action.Id))
+			}
+		case OpExpandVolume:
+			if _, found := db.Volumes[action.Id]; !found {
+				response.Inconsistencies = append(response.Inconsistencies,
+					fmt.Sprintf("pending op %v: change id missing %v not found in volumes", p.Id, action.Id))
 			}
 		case OpRemoveDevice:
 			// This is a noop


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

It was found that a volume expand operation that fails due to errors in the exec phase would leave a trivial setup inconsistent with regards to the sizes of devices. This PR fixes that issue as well as some ancillary items found while working on this problem.

### Does this PR fix issues?


Fixes rhbz#1653567


### Notes for the reviewer


