### PR TITLE
Add information to device metrics

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -64,49 +64,49 @@ var (
 	deviceCount = promDesc(
 		"device_count",
 		"Number of devices on host",
-		[]string{"cluster", "hostname"},
+		[]string{"cluster", "hostname", "storage_hostname"},
 	)
 
 	deviceSize = promDesc(
 		"device_size",
 		"Total size of the device",
-		[]string{"cluster", "hostname", "device"},
+		[]string{"cluster", "hostname", "storage_hostname", "id", "device", "pv_uuid"},
 	)
 
 	deviceFree = promDesc(
 		"device_free",
 		"Amount of Free space available on the device",
-		[]string{"cluster", "hostname", "device"},
+		[]string{"cluster", "hostname", "storage_hostname", "id", "device", "pv_uuid"},
 	)
 
 	deviceUsed = promDesc(
 		"device_used",
 		"Amount of space used on the device",
-		[]string{"cluster", "hostname", "device"},
+		[]string{"cluster", "hostname", "storage_hostname", "id", "device", "pv_uuid"},
 	)
 
 	deviceSizeInBytes = promDesc(
 		"device_size_bytes",
 		"Total size of the device in bytes",
-		[]string{"cluster", "hostname", "device"},
+		[]string{"cluster", "hostname", "storage_hostname", "id", "device", "pv_uuid"},
 	)
 
 	deviceFreeInBytes = promDesc(
 		"device_free_bytes",
 		"Amount of Free space available on the device in bytes",
-		[]string{"cluster", "hostname", "device"},
+		[]string{"cluster", "hostname", "storage_hostname", "id", "device", "pv_uuid"},
 	)
 
 	deviceUsedInBytes = promDesc(
 		"device_used_bytes",
 		"Amount of space used on the device in bytes",
-		[]string{"cluster", "hostname", "device"},
+		[]string{"cluster", "hostname", "storage_hostname", "id", "device", "pv_uuid"},
 	)
 
 	brickCount = promDesc(
 		"device_brick_count",
 		"Number of bricks on device",
-		[]string{"cluster", "hostname", "device"},
+		[]string{"cluster", "hostname", "storage_hostname", "id", "device", "pv_uuid"},
 	)
 
 	staleCount = promDesc(
@@ -246,6 +246,7 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 			float64(len(cluster.Nodes)),
 			cluster.Id,
 		)
+
 		for _, node := range cluster.Nodes {
 			ch <- prometheus.MustNewConstMetric(
 				deviceCount,
@@ -253,6 +254,7 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 				float64(len(node.DevicesInfo)),
 				cluster.Id,
 				node.Hostnames.Manage[0],
+				node.Hostnames.Storage[0],
 			)
 			for _, device := range node.DevicesInfo {
 				ch <- prometheus.MustNewConstMetric(
@@ -261,7 +263,10 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 					float64(device.Storage.Total),
 					cluster.Id,
 					node.Hostnames.Manage[0],
+					node.Hostnames.Storage[0],
+					device.Id,
 					device.Name,
+					device.PvUUID,
 				)
 				ch <- prometheus.MustNewConstMetric(
 					deviceFree,
@@ -269,14 +274,20 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 					float64(device.Storage.Free),
 					cluster.Id,
 					node.Hostnames.Manage[0],
+					node.Hostnames.Storage[0],
+					device.Id,
 					device.Name,
+					device.PvUUID,
 				)
 				ch <- prometheus.MustNewConstMetric(
 					deviceUsed, prometheus.GaugeValue,
 					float64(device.Storage.Used),
 					cluster.Id,
 					node.Hostnames.Manage[0],
+					node.Hostnames.Storage[0],
+					device.Id,
 					device.Name,
+					device.PvUUID,
 				)
 				ch <- prometheus.MustNewConstMetric(
 					deviceSizeInBytes,
@@ -284,7 +295,10 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 					float64(device.Storage.Total*KB),
 					cluster.Id,
 					node.Hostnames.Manage[0],
+					node.Hostnames.Storage[0],
+					device.Id,
 					device.Name,
+					device.PvUUID,
 				)
 				ch <- prometheus.MustNewConstMetric(
 					deviceFreeInBytes,
@@ -292,14 +306,20 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 					float64(device.Storage.Free*KB),
 					cluster.Id,
 					node.Hostnames.Manage[0],
+					node.Hostnames.Storage[0],
+					device.Id,
 					device.Name,
+					device.PvUUID,
 				)
 				ch <- prometheus.MustNewConstMetric(
 					deviceUsedInBytes, prometheus.GaugeValue,
 					float64(device.Storage.Used*KB),
 					cluster.Id,
 					node.Hostnames.Manage[0],
+					node.Hostnames.Storage[0],
+					device.Id,
 					device.Name,
+					device.PvUUID,
 				)
 
 				ch <- prometheus.MustNewConstMetric(
@@ -308,7 +328,10 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 					float64(len(device.Bricks)),
 					cluster.Id,
 					node.Hostnames.Manage[0],
+					node.Hostnames.Storage[0],
+					device.Id,
 					device.Name,
+					device.PvUUID,
 				)
 			}
 		}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -50,7 +50,9 @@ func TestMetricsEndpoint(t *testing.T) {
 					Id: "c1",
 					Nodes: []api.NodeInfoResponse{
 						{
-							NodeInfo: api.NodeInfo{NodeAddRequest: api.NodeAddRequest{Hostnames: api.HostAddresses{Manage: []string{"n1"}}}},
+							NodeInfo: api.NodeInfo{NodeAddRequest: api.NodeAddRequest{
+								Hostnames: api.HostAddresses{Manage: []string{"n1"}, Storage: []string{"n1"}},
+							}},
 							DevicesInfo: []api.DeviceInfoResponse{
 								{
 									DeviceInfo: api.DeviceInfo{
@@ -60,6 +62,8 @@ func TestMetricsEndpoint(t *testing.T) {
 											Free:  1,
 											Used:  1,
 										},
+										Id:     "id1",
+										PvUUID: "pv1",
 									},
 									Bricks: []api.BrickInfo{
 										{
@@ -101,9 +105,9 @@ func TestMetricsEndpoint(t *testing.T) {
 		t.Fatal("heketi_nodes_count{cluster=\"c1\"} 1 should be present in the metrics output")
 	}
 
-	match, err = regexp.Match("heketi_device_size{cluster=\"c1\",device=\"d1\",hostname=\"n1\"} 2", body)
+	match, err = regexp.Match("heketi_device_size{cluster=\"c1\",device=\"d1\",hostname=\"n1\",id=\"id1\",pv_uuid=\"pv1\",storage_hostname=\"n1\"} 2", body)
 	if !match || err != nil {
-		t.Fatal("heketi_device_size{cluster=\"c1\",device=\"d1\",hostname=\"n1\"} 2 should be present in the metrics output")
+		t.Fatal("heketi_device_size{cluster=\"c1\",device=\"d1\",hostname=\"n1\",id=\"id1\",pv_uuid=\"pv1\",storage_hostname=\"n1\"} 2 should be present in the metrics output")
 	}
 
 	match, err = regexp.Match("operations_total_count 7", body)


### PR DESCRIPTION
This commit adds several information elements to device metrics:
* Node Manage Hostname    `manage` (as a replacement of `hostname`)
* Node Storage Hostname    `storage`
* Device Id                            `id`
* Device PV UUID                 `pv_uuid`

Metrics tests have been also altered to reflect this change.

Signed-off-by: Justin Ferrieu <jferrieu@objectif-libre.com>

<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?

This PR adds more information to existing heketi device metrics. We could need these so we can make easier join queries with i.e. the gluster exporter metrics that could be useful for later use, dashboard making, etc.

Also these changes reflect more what we can see on the `topology info` of the heketi cli.
