### PR TITLE
fix test scripts for default testenv teardown

### DIFF
--- a/tests/functional/TestSmokeTest/teardown.sh
+++ b/tests/functional/TestSmokeTest/teardown.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-CURRENT_DIR="$(pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
 export HEKETI_SERVER_BUILD_DIR=../../..
-FUNCTIONAL_DIR="${CURRENT_DIR}/.."
+FUNCTIONAL_DIR="${SCRIPT_DIR}/.."
 export HEKETI_SERVER="${FUNCTIONAL_DIR}/heketi-server"
 
 source "${FUNCTIONAL_DIR}/lib.sh"

--- a/tests/functional/lib.sh
+++ b/tests/functional/lib.sh
@@ -118,9 +118,14 @@ teardown_environment() {
     esac
 }
 
-teardown() {
+_teardown() {
     teardown_environment
     rm -f heketi.db > /dev/null 2>&1
+}
+
+teardown() {
+    init_testenv
+    _teardown
 }
 
 setup_test_paths() {
@@ -139,9 +144,12 @@ pause_test() {
     fi
 }
 
-functional_tests() {
+init_testenv() {
     DEFAULT_TESTENV="${SCRIPT_DIR}/../vagrant"
+}
+functional_tests() {
 
+    init_testenv
     setup_test_paths
     setup_test_environment
     if [[ "$HEKETI_TEST_SERVER" == "no" ]]; then
@@ -159,7 +167,7 @@ functional_tests() {
     stop_heketi
     if [[ "$HEKETI_TEST_CLEANUP" != "no" ]]
     then
-        teardown
+        _teardown
     fi
 
     exit $gotest_result


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
The teardown.sh script fails to run down.sh because the variable evaluates to /down.sh. With these changes the teardown.sh sets the global variables properly and the path evaluates correctly.


