### PR TITLE
Fix s390x builds in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_install:
     - sudo apt-get update -qq
     - sudo apt-get install -qq python python-pip
     - sudo pip install tox nose
+    - sudo chown -R travis:travis /home/travis/.cache/pip
 install:
 - bash .travis-fork-fix
 - go get github.com/mattn/goveralls


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

While setting up the test environment on Travis CI, pip is run as root.
This seems to create a .cache/pip directory in the travis users home
directory. Subsequently running pip as user travis fails:

    WARNING: Building wheel for d2to1 failed: [Errno 13] Permission denied: '/home/travis/.cache/pip/wheels/4d'

### Does this PR fix issues?

Issue was noticed in #1649. All recent builds failed the same way.