### PR TITLE
Remove devices by nested brick evict operations

### DIFF
--- a/apps/glusterfs/device_entry.go
+++ b/apps/glusterfs/device_entry.go
@@ -174,7 +174,7 @@ func (d *DeviceEntry) SetState(db wdb.DB,
 	case api.EntryStateFailed:
 		if err := d.Remove(db, e); err != nil {
 			if err == ErrNoReplacement {
-				return logger.LogError("Unable to delete device [%v] as no device was found to replace it", d.Id())
+				return logger.LogError("Unable to delete device [%v] as no device was found to replace it: %v", d.Id(), err)
 			}
 			return err
 		}

--- a/apps/glusterfs/operations_cleanup.go
+++ b/apps/glusterfs/operations_cleanup.go
@@ -56,6 +56,12 @@ func (oc OperationCleaner) Clean() error {
 		} else if err != nil {
 			return err
 		}
+		if pop.IsChild() {
+			logger.Warning(
+				"%v operation %v is a child. skipping direct clean",
+				op.Label(), pop.Id)
+			continue
+		}
 		cop, ok := op.(CleanableOperation)
 		if !ok {
 			logger.Warning("%v operation %v not cleanable", op.Label(), pop.Id)

--- a/apps/glusterfs/operations_device.go
+++ b/apps/glusterfs/operations_device.go
@@ -45,6 +45,31 @@ func NewDeviceRemoveOperation(
 	}
 }
 
+// loadDeviceRemoveOperation returns a DeviceRemoveOperation populated
+// from an existing pending operation entry in the db.
+func loadDeviceRemoveOperation(
+	db wdb.DB, p *PendingOperationEntry) (*DeviceRemoveOperation, error) {
+
+	var deviceId string
+	for _, action := range p.Actions {
+		if action.Change == OpRemoveDevice {
+			deviceId = action.Id
+		}
+	}
+	if deviceId == "" {
+		return nil, fmt.Errorf(
+			"Missing device to remove in device-remove operation")
+	}
+
+	return &DeviceRemoveOperation{
+		OperationManager: OperationManager{
+			db: db,
+			op: p,
+		},
+		DeviceId: deviceId,
+	}, nil
+}
+
 func (dro *DeviceRemoveOperation) Label() string {
 	return "Remove Device"
 }

--- a/apps/glusterfs/operations_device_test.go
+++ b/apps/glusterfs/operations_device_test.go
@@ -1038,3 +1038,129 @@ func TestDeviceRemoveOperationChildOpError(t *testing.T) {
 		return nil
 	})
 }
+
+func TestDeviceRemoveOperationChildOpCleanup(t *testing.T) {
+	tmpfile := tests.Tempfile()
+	defer os.Remove(tmpfile)
+
+	// Create the app
+	app := NewTestApp(tmpfile)
+	defer app.Close()
+
+	err := setupSampleDbWithTopology(app,
+		1,    // clusters
+		3,    // nodes_per_cluster
+		3,    // devices_per_node,
+		8*TB, // disksize)
+	)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	vreq := &api.VolumeCreateRequest{}
+	vreq.Size = 100
+	vreq.Durability.Type = api.DurabilityReplicate
+	vreq.Durability.Replicate.Replica = 3
+	// create two volumes
+	for i := 0; i < 5; i++ {
+		v := NewVolumeEntryFromRequest(vreq)
+		err = v.Create(app.db, app.executor)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	}
+
+	// grab a devices that has bricks
+	var d *DeviceEntry
+	err = app.db.View(func(tx *bolt.Tx) error {
+		dl, err := DeviceList(tx)
+		if err != nil {
+			return err
+		}
+		for _, id := range dl {
+			d, err = NewDeviceEntryFromId(tx, id)
+			if err != nil {
+				return err
+			}
+			if len(d.Bricks) > 0 {
+				return nil
+			}
+		}
+		t.Fatalf("should have at least one device with bricks")
+		return nil
+	})
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	err = d.SetState(app.db, app.executor, api.EntryStateOffline)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	dro := NewDeviceRemoveOperation(d.Info.Id, app.db)
+	err = dro.Build()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	// because there were bricks on this device it needs to perform
+	// a full "operation cycle"
+	err = app.db.View(func(tx *bolt.Tx) error {
+		l, err := PendingOperationList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(l) == 1, "expected len(l) == 1, got:", len(l))
+		return nil
+	})
+
+	app.xo.MockVolumeInfo = func(host string, volume string) (*executors.Volume, error) {
+		return mockVolumeInfoFromDb(app.db, volume)
+	}
+	app.xo.MockHealInfo = func(host string, volume string) (*executors.HealInfo, error) {
+		return mockHealStatusFromDb(app.db, volume)
+	}
+	app.xo.MockVolumeReplaceBrick = func(host string, volume string, oldBrick *executors.BrickInfo, newBrick *executors.BrickInfo) error {
+		panic("ARGLE")
+	}
+
+	err = func() (x error) {
+		defer func() {
+			if r := recover(); r != nil {
+				x = fmt.Errorf("panicked")
+			}
+		}()
+		x = dro.Exec(app.executor)
+		t.Fatalf("Test should not reach this line")
+		return x
+	}()
+	tests.Assert(t, err != nil, "expected err != nil, got:", err)
+
+	// exec failed. check pending ops status
+	var popRemove, popEvict *PendingOperationEntry
+	err = app.db.View(func(tx *bolt.Tx) error {
+		l, err := PendingOperationList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		// because we panicked within the child operation we
+		// should have two pending ops
+		tests.Assert(t, len(l) == 2, "expected len(l) == 2, got:", len(l))
+
+		for _, id := range l {
+			p, err := NewPendingOperationEntryFromId(tx, id)
+			tests.Assert(t, err == nil, "expected err == nil, got:", err)
+			switch p.Type {
+			case OperationRemoveDevice:
+				popRemove = p
+			case OperationBrickEvict:
+				popEvict = p
+			default:
+				t.Fatalf("Invalid pending operation type for this test")
+			}
+		}
+		return nil
+	})
+	_ = popRemove
+	_ = popEvict
+
+	err = dro.Clean(app.executor)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	err = dro.CleanDone()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+	app.db.View(func(tx *bolt.Tx) error {
+		l, err := PendingOperationList(tx)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(l) == 0, "expected len(l) == 0, got:", len(l))
+		return nil
+	})
+}

--- a/apps/glusterfs/operations_load.go
+++ b/apps/glusterfs/operations_load.go
@@ -53,6 +53,8 @@ func LoadOperation(
 		op, err = loadBlockVolumeDeleteOperation(db, p)
 	case OperationBrickEvict:
 		op, err = loadBrickEvictOperation(db, p)
+	case OperationRemoveDevice:
+		op, err = loadDeviceRemoveOperation(db, p)
 	default:
 		err = NewErrNotLoadable(p.Id, p.Type)
 	}

--- a/apps/glusterfs/pendingop.go
+++ b/apps/glusterfs/pendingop.go
@@ -56,6 +56,8 @@ const (
 	OpCloneVolume
 	OpSnapshotVolume
 	OpAddVolumeClone
+	OpChildOperation
+	OpParentOperation
 )
 
 // PendingOperationAction tracks individual changes to entries within the
@@ -145,6 +147,10 @@ func (c PendingChangeType) Name() string {
 		return "Snapshot volume"
 	case OpAddVolumeClone:
 		return "Expand volume to"
+	case OpChildOperation:
+		return "Performing child operation"
+	case OpParentOperation:
+		return "Belongs to parent operation"
 	}
 	return "Unknown"
 }

--- a/tests/functional/TestErrorHandling/tests/device_remove_test.go
+++ b/tests/functional/TestErrorHandling/tests/device_remove_test.go
@@ -1,0 +1,439 @@
+// +build functional
+
+//
+// Copyright (c) 2020 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), as published by the Free Software Foundation,
+// or under the Apache License, Version 2.0 <LICENSE-APACHE2 or
+// http://www.apache.org/licenses/LICENSE-2.0>.
+//
+// You may not use this file except in compliance with those terms.
+//
+
+package tests
+
+import (
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/heketi/tests"
+
+	inj "github.com/heketi/heketi/executors/injectexec"
+	"github.com/heketi/heketi/pkg/glusterfs/api"
+	"github.com/heketi/heketi/pkg/testutils"
+	"github.com/heketi/heketi/server/config"
+)
+
+func TestDeviceRemoveOperation(t *testing.T) {
+	heketiServer := testutils.NewServerCtlFromEnv("..")
+	origConf := path.Join(heketiServer.ServerDir, heketiServer.ConfPath)
+
+	baseConf := tests.Tempfile()
+	defer os.Remove(baseConf)
+	UpdateConfig(origConf, baseConf, func(c *config.Config) {
+		// we want the background cleaner disabled for all
+		// of the sub-tests we'll be running as we are testing
+		// on demand cleaning and want predictable behavior.
+		c.GlusterFS.DisableBackgroundCleaner = true
+	})
+
+	heketiServer.ConfPath = tests.Tempfile()
+	defer os.Remove(heketiServer.ConfPath)
+	CopyFile(baseConf, heketiServer.ConfPath)
+
+	defer func() {
+		CopyFile(baseConf, heketiServer.ConfPath)
+		testutils.ServerRestarted(t, heketiServer)
+		testCluster.Teardown(t)
+		testutils.ServerStopped(t, heketiServer)
+	}()
+
+	resetConfFile := func() {
+		CopyFile(baseConf, heketiServer.ConfPath)
+	}
+
+	testutils.ServerStarted(t, heketiServer)
+	heketiServer.KeepDB = true
+	testCluster.Setup(t, 3, 2)
+
+	volReq := &api.VolumeCreateRequest{}
+	volReq.Size = 1
+	volReq.Durability.Type = api.DurabilityReplicate
+	volReq.Durability.Replicate.Replica = 3
+
+	// create a few volumes
+	for i := 0; i < 6; i++ {
+		_, err := heketi.VolumeCreate(volReq)
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	}
+
+	t.Run("happyPath", func(t *testing.T) {
+		var err error
+		deviceToRemove := getDeviceToRemove(t)
+		defer enableAllDevices(t)
+
+		err = heketi.DeviceState(deviceToRemove, &api.StateRequest{
+			api.EntryStateOffline,
+		})
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		err = heketi.DeviceState(deviceToRemove, &api.StateRequest{
+			api.EntryStateFailed,
+		})
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		// there should not be any pending ops in the db
+		l, err := heketi.PendingOperationList()
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(l.PendingOperations) == 0,
+			"expected len(l.PendingOperations) == 0, got:",
+			len(l.PendingOperations))
+
+		dused := perDeviceUsedSize(t)
+		tests.Assert(t, dused[deviceToRemove] == 0,
+			"expected dused[deviceToRemove] == 0, got:",
+			dused[deviceToRemove])
+	})
+
+	t.Run("lvcreateError", func(t *testing.T) {
+		var err error
+		resetConfFile()
+		UpdateConfig(origConf, heketiServer.ConfPath, func(c *config.Config) {
+			c.GlusterFS.Executor = "inject/ssh"
+			c.GlusterFS.InjectConfig.CmdInjection.CmdHooks = inj.CmdHooks{
+				inj.CmdHook{
+					Cmd: ".*lvcreate.*",
+					Reaction: inj.Reaction{
+						Err: "thwack!",
+					},
+				},
+			}
+		})
+		testutils.ServerRestarted(t, heketiServer)
+		deviceToRemove := getDeviceToRemove(t)
+		defer enableAllDevices(t)
+
+		err = heketi.DeviceState(deviceToRemove, &api.StateRequest{
+			api.EntryStateOffline,
+		})
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		err = heketi.DeviceState(deviceToRemove, &api.StateRequest{
+			api.EntryStateFailed,
+		})
+		tests.Assert(t, err != nil, "expected err != nil, got:", err)
+
+		// there should not be any pending ops in the db
+		l, err := heketi.PendingOperationList()
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(l.PendingOperations) == 0,
+			"expected len(l.PendingOperations) == 0, got:",
+			len(l.PendingOperations))
+	})
+
+	t.Run("lvremoveError", func(t *testing.T) {
+		var err error
+		resetConfFile()
+		UpdateConfig(origConf, heketiServer.ConfPath, func(c *config.Config) {
+			c.GlusterFS.Executor = "inject/ssh"
+			c.GlusterFS.InjectConfig.CmdInjection.CmdHooks = inj.CmdHooks{
+				inj.CmdHook{
+					Cmd: ".*lvremove.*",
+					Reaction: inj.Reaction{
+						Err: "thwack!",
+					},
+				},
+			}
+		})
+		testutils.ServerRestarted(t, heketiServer)
+		deviceToRemove := getDeviceToRemove(t)
+		defer enableAllDevices(t)
+
+		err = heketi.DeviceState(deviceToRemove, &api.StateRequest{
+			api.EntryStateOffline,
+		})
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		err = heketi.DeviceState(deviceToRemove, &api.StateRequest{
+			api.EntryStateFailed,
+		})
+		tests.Assert(t, err != nil, "expected err != nil, got:", err)
+
+		// there should be two pending ops in the db:
+		// * the parent op: device remove
+		// * the child op: brick evict
+		l, err := heketi.PendingOperationList()
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(l.PendingOperations) == 2,
+			"expected len(l.PendingOperations) == 2, got:",
+			len(l.PendingOperations))
+
+		// remove our lvremove injected failure - let clean do its thing
+		logger.Info("restoring heketi default behavior")
+		resetConfFile()
+		testutils.ServerRestarted(t, heketiServer)
+
+		// request a clean
+		err = heketi.PendingOperationCleanUp(
+			&api.PendingOperationsCleanRequest{})
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		for i := 0; i < 15; i++ {
+			l, err = heketi.PendingOperationList()
+			tests.Assert(t, err == nil, "expected err == nil, got:", err)
+			if len(l.PendingOperations) == 0 {
+				break
+			}
+			time.Sleep(time.Second)
+		}
+		tests.Assert(t, len(l.PendingOperations) == 0,
+			"expected len(l.PendingOperations) == 0, got:",
+			len(l.PendingOperations))
+	})
+
+	t.Run("lvcreatePanicRetry", func(t *testing.T) {
+		var err error
+		resetConfFile()
+		UpdateConfig(origConf, heketiServer.ConfPath, func(c *config.Config) {
+			c.GlusterFS.Executor = "inject/ssh"
+			c.GlusterFS.InjectConfig.CmdInjection.CmdHooks = inj.CmdHooks{
+				inj.CmdHook{
+					Cmd: ".*lvcreate.*",
+					Reaction: inj.Reaction{
+						Panic: "panicking on lvcreate command",
+					},
+				},
+			}
+		})
+		testutils.ServerRestarted(t, heketiServer)
+		deviceToRemove := getDeviceToRemove(t)
+		defer enableAllDevices(t)
+
+		err = heketi.DeviceState(deviceToRemove, &api.StateRequest{
+			api.EntryStateOffline,
+		})
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		err = heketi.DeviceState(deviceToRemove, &api.StateRequest{
+			api.EntryStateFailed,
+		})
+		tests.Assert(t, err != nil, "expected err != nil, got:", err)
+
+		// remove our injected panic & restart the server
+		logger.Info("restoring heketi default behavior")
+		resetConfFile()
+		testutils.ServerRestarted(t, heketiServer)
+
+		// there should be two pending ops in the db:
+		// * the parent op: device remove
+		// * the child op: brick evict
+		l, err := heketi.PendingOperationList()
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(l.PendingOperations) == 2,
+			"expected len(l.PendingOperations) == 2, got:",
+			len(l.PendingOperations))
+
+		// request a clean
+		err = heketi.PendingOperationCleanUp(
+			&api.PendingOperationsCleanRequest{})
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		for i := 0; i < 15; i++ {
+			l, err = heketi.PendingOperationList()
+			tests.Assert(t, err == nil, "expected err == nil, got:", err)
+			if len(l.PendingOperations) == 0 {
+				break
+			}
+			time.Sleep(time.Second)
+		}
+		tests.Assert(t, len(l.PendingOperations) == 0,
+			"expected len(l.PendingOperations) == 0, got:",
+			len(l.PendingOperations))
+
+		// now that the db is free of pending ops it's safe
+		// to try removing this device once again
+		err = heketi.DeviceState(deviceToRemove, &api.StateRequest{
+			api.EntryStateFailed,
+		})
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		// the device should now be empty after the 2nd remove
+		dused := perDeviceUsedSize(t)
+		tests.Assert(t, dused[deviceToRemove] == 0,
+			"expected dused[deviceToRemove] == 0, got:",
+			dused[deviceToRemove])
+	})
+
+	// replaceBrickErrorBefore - inject an error before gluster has replaced
+	// the brick to test the recovery path where we keep the old brick
+	// and remove the new brick
+	t.Run("replaceBrickErrorBefore", func(t *testing.T) {
+		var err error
+		resetConfFile()
+		UpdateConfig(origConf, heketiServer.ConfPath, func(c *config.Config) {
+			c.GlusterFS.Executor = "inject/ssh"
+			c.GlusterFS.InjectConfig.CmdInjection.CmdHooks = inj.CmdHooks{
+				inj.CmdHook{
+					Cmd: ".*volume replace-brick.*",
+					Reaction: inj.Reaction{
+						Err: "ouch!",
+					},
+				},
+			}
+		})
+		testutils.ServerRestarted(t, heketiServer)
+		deviceToRemove := getDeviceToRemove(t)
+		defer enableAllDevices(t)
+
+		bCountBefore := getBrickCounts(t)
+
+		err = heketi.DeviceState(deviceToRemove, &api.StateRequest{
+			api.EntryStateOffline,
+		})
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		err = heketi.DeviceState(deviceToRemove, &api.StateRequest{
+			api.EntryStateFailed,
+		})
+		tests.Assert(t, err != nil, "expected err != nil, got:", err)
+
+		// there should not be any pending ops in the db
+		l, err := heketi.PendingOperationList()
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(l.PendingOperations) == 0,
+			"expected len(l.PendingOperations) == 0, got:",
+			len(l.PendingOperations))
+
+		// we failed "before" gluster took the replacement brick
+		// the number of bricks on the device shouldn't have changed
+		bCountAfter := getBrickCounts(t)
+		tests.Assert(t,
+			bCountBefore[deviceToRemove] == bCountAfter[deviceToRemove],
+			"expected before count == after count, got:",
+			bCountBefore[deviceToRemove], bCountAfter[deviceToRemove])
+	})
+
+	// replaceBrickErrorAfter - inject an error after gluster has replaced
+	// the brick to test the recovery path where we keep the new brick
+	// and remove the old
+	t.Run("replaceBrickErrorAfter", func(t *testing.T) {
+		var err error
+		resetConfFile()
+		UpdateConfig(origConf, heketiServer.ConfPath, func(c *config.Config) {
+			c.GlusterFS.Executor = "inject/ssh"
+			c.GlusterFS.InjectConfig.CmdInjection.ResultHooks = inj.ResultHooks{
+				inj.ResultHook{
+					CmdHook: inj.CmdHook{
+						Cmd: ".*volume replace-brick.*",
+						Reaction: inj.Reaction{
+							Err: "owiee!",
+						},
+					},
+					Result: ".*",
+				},
+			}
+		})
+		testutils.ServerRestarted(t, heketiServer)
+		deviceToRemove := getDeviceToRemove(t)
+		defer enableAllDevices(t)
+
+		bCountBefore := getBrickCounts(t)
+
+		err = heketi.DeviceState(deviceToRemove, &api.StateRequest{
+			api.EntryStateOffline,
+		})
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+
+		err = heketi.DeviceState(deviceToRemove, &api.StateRequest{
+			api.EntryStateFailed,
+		})
+		tests.Assert(t, err != nil, "expected err != nil, got:", err)
+
+		// there should not be any pending ops in the db
+		l, err := heketi.PendingOperationList()
+		tests.Assert(t, err == nil, "expected err == nil, got:", err)
+		tests.Assert(t, len(l.PendingOperations) == 0,
+			"expected len(l.PendingOperations) == 0, got:",
+			len(l.PendingOperations))
+
+		// we failed "after" gluster took the replacement brick
+		// one brick should have been removed from the device in heketi
+		// even if the device has > 1 bricks; we only recover from the
+		// single "brick evict" in progress
+		bCountAfter := getBrickCounts(t)
+		tests.Assert(t,
+			(bCountBefore[deviceToRemove]-1) == bCountAfter[deviceToRemove],
+			"expected before count - 1 == after count, got:",
+			(bCountBefore[deviceToRemove] - 1), bCountAfter[deviceToRemove])
+	})
+	checkConsistent(t, heketiServer)
+}
+
+func enableAllDevices(t *testing.T) {
+	topo, err := heketi.TopologyInfo()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	for _, c := range topo.ClusterList {
+		for _, n := range c.Nodes {
+			for _, d := range n.DevicesInfo {
+				switch d.State {
+				case api.EntryStateFailed:
+					err = heketi.DeviceState(d.Id, &api.StateRequest{
+						api.EntryStateOffline,
+					})
+					tests.Assert(t, err == nil, "expected err == nil, got:", err)
+					fallthrough
+				case api.EntryStateOffline:
+					err = heketi.DeviceState(d.Id, &api.StateRequest{
+						api.EntryStateOnline,
+					})
+					tests.Assert(t, err == nil, "expected err == nil, got:", err)
+				}
+			}
+		}
+	}
+}
+
+func getBrickCounts(t *testing.T) map[string]int {
+	topo, err := heketi.TopologyInfo()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	brickCount := map[string]int{}
+	for _, c := range topo.ClusterList {
+		for _, n := range c.Nodes {
+			for _, d := range n.DevicesInfo {
+				brickCount[d.Id] += len(d.Bricks)
+			}
+		}
+	}
+	return brickCount
+}
+
+func getDeviceToRemove(t *testing.T) string {
+	brickCount := getBrickCounts(t)
+	bestDevice := ""
+	for id, count := range brickCount {
+		if count > brickCount[bestDevice] {
+			bestDevice = id
+			logger.Info("device-to-remove candidate: %v", bestDevice)
+		}
+	}
+	tests.Assert(t, bestDevice != "", "failed to find a device with bricks")
+	return bestDevice
+}
+
+func perDeviceUsedSize(t *testing.T) map[string]uint64 {
+	data := map[string]uint64{}
+	topo, err := heketi.TopologyInfo()
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	for _, c := range topo.ClusterList {
+		for _, n := range c.Nodes {
+			for _, d := range n.DevicesInfo {
+				data[d.Id] += d.Storage.Used
+			}
+		}
+	}
+	return data
+}


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Replace the old ad-hoc sequence of exec calls and db modifications made
by the device remove operation with iteration of calls into the newer
brick evict operation.

Modulo bugs this should be more reliable than the old approach because
brick evict's clean is smarter and properly handles failures or stale
operations. All the parent has to do it let the child handle the clean
up of the child operation that failed and then clean its own db state
up. Note that this means the operation is cleaned, but the operation is
not _resumed_. Any operation that is failed or incomplete will only
clean the current child and the device will remain in the offline state
and may still have one ore more bricks on it. But at this point it
should be safe to request removal of the device once again.


### Does this PR fix issues?


Probably, but I couldn't find it so far.


### Notes for the reviewer

Changes include prereqs for establishing parent-child relationships between operations, other helper functions, ability to load existing device remove ops from the db (to make them cleanable) and of course both unit-level and functional tests.

This PR is based on PR #1701 - please review/merge that first.

