### PR TITLE
Assorted brick eviction fixes

### DIFF
--- a/apps/glusterfs/operations_device.go
+++ b/apps/glusterfs/operations_device.go
@@ -278,6 +278,10 @@ func (beo *BrickEvictOperation) buildNewBrick(bs *BrickSet, index int) error {
 		if err != nil {
 			return err
 		}
+		logger.Debug(
+			"brick evict wants to replace [%s] on [%s] with [%s] on [%s]",
+			old.brick.Id(), old.device.Id(),
+			newBrickEntry.Id(), newDeviceEntry.Id())
 		// update pending op with new brick info
 		for _, action := range beo.op.Actions {
 			if action.Change == OpAddBrick {
@@ -573,6 +577,7 @@ func (beo *BrickEvictOperation) CleanDone() error {
 }
 
 func (beo *BrickEvictOperation) finishNeverStarted(db wdb.DB, bes brickEvictStatus) error {
+	logger.Debug("finishing operation: no changes")
 	return db.Update(func(tx *bolt.Tx) error {
 		b, err := NewBrickEntryFromId(tx, bes.oldBrickId)
 		if err != nil {
@@ -587,6 +592,9 @@ func (beo *BrickEvictOperation) finishNeverStarted(db wdb.DB, bes brickEvictStat
 }
 
 func (beo *BrickEvictOperation) finishAccept(tx *bolt.Tx) error {
+	logger.Debug(
+		"finishing operation: accepting new brick [%v]",
+		beo.newBrickEntryId)
 	old, err := beo.current(beo.db)
 	if err != nil {
 		return err
@@ -628,6 +636,9 @@ func (beo *BrickEvictOperation) finishAccept(tx *bolt.Tx) error {
 }
 
 func (beo *BrickEvictOperation) finishRevert(tx *bolt.Tx) error {
+	logger.Debug(
+		"finishing operation: reverting new brick [%s]",
+		beo.newBrickEntryId)
 	old, err := beo.current(beo.db)
 	if err != nil {
 		return err

--- a/apps/glusterfs/operations_device.go
+++ b/apps/glusterfs/operations_device.go
@@ -150,12 +150,11 @@ type BrickEvictOperation struct {
 	BrickId string
 
 	// internal caching params
-	replaceBrickSet  *BrickSet
-	replaceIndex     int
-	newBrickEntryId  string
-	newDeviceEntryId string
-	reclaimed        ReclaimMap
-	wasReplaced      bool
+	replaceBrickSet *BrickSet
+	replaceIndex    int
+	newBrickEntryId string
+	reclaimed       ReclaimMap
+	wasReplaced     bool
 }
 
 type brickContext struct {
@@ -285,9 +284,8 @@ func (beo *BrickEvictOperation) buildNewBrick(bs *BrickSet, index int) error {
 		if e := newBrickEntry.Save(tx); e != nil {
 			return e
 		}
-		// update operation cached entries for new brick and device entries
+		// update operation cached entries for new brick
 		beo.newBrickEntryId = newBrickEntry.Id()
-		beo.newDeviceEntryId = newDeviceEntry.Id()
 		return nil
 	})
 }
@@ -588,7 +586,7 @@ func (beo *BrickEvictOperation) finishAccept(tx *bolt.Tx) error {
 	}
 	// update (new) device with new brick
 	// reminder: New brick function takes space from device (!!!)
-	newDevice, err := NewDeviceEntryFromId(tx, beo.newDeviceEntryId)
+	newDevice, err := NewDeviceEntryFromId(tx, newBrick.Info.DeviceId)
 	if err != nil {
 		return err
 	}

--- a/apps/glusterfs/operations_device.go
+++ b/apps/glusterfs/operations_device.go
@@ -553,7 +553,7 @@ func (beo *BrickEvictOperation) Clean(executor executors.Executor) error {
 func (beo *BrickEvictOperation) CleanDone() error {
 	logger.Info("Clean is done for %v op:%v", beo.Label(), beo.op.Id)
 	return beo.db.Update(func(tx *bolt.Tx) error {
-		if e := beo.refreshOp(beo.db); e != nil {
+		if e := beo.refreshOp(wdb.WrapTx(tx)); e != nil {
 			return e
 		}
 		bes, err := evictStatus(beo.op)

--- a/apps/glusterfs/operations_device.go
+++ b/apps/glusterfs/operations_device.go
@@ -656,7 +656,7 @@ func evictStatus(op *PendingOperationEntry) (brickEvictStatus, error) {
 			logger.Info("found replacement brick: %v", action.Id)
 			bes.newBrickId = action.Id
 		default:
-			logger.Info("found invalied action: %v, %v",
+			logger.Info("found invalid action: %v, %v",
 				action.Change, action.Id)
 			return bes, fmt.Errorf(
 				"Malformed pending operation entry for brick evict operation")

--- a/tests/functional/TestErrorHandling/tests/brick_evict_test.go
+++ b/tests/functional/TestErrorHandling/tests/brick_evict_test.go
@@ -204,7 +204,7 @@ func TestBrickEvict(t *testing.T) {
 
 		toEvict := vinfo1.Bricks[0].Id
 		err = heketi.BrickEvict(toEvict, nil)
-		tests.Assert(t, err != nil, "expected err == nil, got:", err)
+		tests.Assert(t, err != nil, "expected err != nil, got:", err)
 
 		vinfo2, err := heketi.VolumeInfo(vinfo1.Id)
 		tests.Assert(t, err == nil, "expected err == nil, got:", err)
@@ -242,7 +242,7 @@ func TestBrickEvict(t *testing.T) {
 
 		toEvict := vinfo1.Bricks[0].Id
 		err = heketi.BrickEvict(toEvict, nil)
-		tests.Assert(t, err != nil, "expected err == nil, got:", err)
+		tests.Assert(t, err != nil, "expected err != nil, got:", err)
 
 		// in this case even tho the operation "failed" the state of
 		// the gluster system is as if the replace succeeded. The state
@@ -296,7 +296,7 @@ func TestBrickEvict(t *testing.T) {
 
 		toEvict := vinfo1.Bricks[0].Id
 		err = heketi.BrickEvict(toEvict, nil)
-		tests.Assert(t, err != nil, "expected err == nil, got:", err)
+		tests.Assert(t, err != nil, "expected err != nil, got:", err)
 
 		// the pending op should remain because lvremove is in the
 		// clean/rollback path.


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Fixes some issues in the brick eviction operation, primary around the operation clean up path.
The three issues are a bad device ID reference when clean+clean-done is run outside of the rollback code; an invalid nested db transaction; and the inability to tell the difference between never checking the status of brick replace from gluster vs. the brick was not replaced. It also adds some debug logging and a test for the first error condition.


