### PR TITLE
gluster-block: implement expand feature interface

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -620,6 +620,11 @@ func (a *App) SetRoutes(router *mux.Router) error {
 			Method:      "GET",
 			Pattern:     "/blockvolumes",
 			HandlerFunc: a.BlockVolumeList},
+		rest.Route{
+			Name:        "BlockVolumeExpand",
+			Method:      "POST",
+			Pattern:     "/blockvolumes/{id:[A-Fa-f0-9]+}/expand",
+			HandlerFunc: a.BlockVolumeExpand},
 
 		// Brick (special)
 		rest.Route{

--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -320,6 +320,24 @@ func (v *BlockVolumeEntry) destroyFromHost(
 	return nil
 }
 
+func (v *BlockVolumeEntry) BlockVolumeInfoFromHost(executor executors.Executor,
+	hvname string, h string) (*executors.BlockVolumeInfo, error) {
+
+	godbc.Require(hvname != "")
+	godbc.Require(h != "")
+
+	blockVolumeInfo, err := executor.BlockVolumeInfo(h, hvname, v.Info.Name)
+	if _, ok := err.(*executors.VolumeDoesNotExistErr); ok {
+		logger.Warning("Block volume %v (%v) does not exist",
+			v.Info.Id, v.Info.Name)
+		return nil, err
+	} else if err != nil {
+		logger.LogError("Unable to get block volume info: %v", err)
+		return nil, err
+	}
+	return blockVolumeInfo, nil
+}
+
 func (v *BlockVolumeEntry) removeComponents(db wdb.DB, keepSize bool) error {
 	return db.Update(func(tx *bolt.Tx) error {
 		// Remove volume from cluster

--- a/apps/glusterfs/operations_load.go
+++ b/apps/glusterfs/operations_load.go
@@ -51,6 +51,8 @@ func LoadOperation(
 		op, err = loadBlockVolumeCreateOperation(db, p)
 	case OperationDeleteBlockVolume:
 		op, err = loadBlockVolumeDeleteOperation(db, p)
+	case OperationExpandBlockVolume:
+		op, err = loadBlockVolumeExpandOperation(db, p)
 	case OperationBrickEvict:
 		op, err = loadBrickEvictOperation(db, p)
 	case OperationRemoveDevice:

--- a/apps/glusterfs/pendingop.go
+++ b/apps/glusterfs/pendingop.go
@@ -34,6 +34,7 @@ const (
 	OperationExpandVolume
 	OperationCreateBlockVolume
 	OperationDeleteBlockVolume
+	OperationExpandBlockVolume
 	OperationRemoveDevice
 	OperationCloneVolume
 	OperationBrickEvict
@@ -52,6 +53,7 @@ const (
 	OpExpandVolume
 	OpAddBlockVolume
 	OpDeleteBlockVolume
+	OpExpandBlockVolume
 	OpRemoveDevice
 	OpCloneVolume
 	OpSnapshotVolume
@@ -112,6 +114,8 @@ func (v PendingOperationType) Name() string {
 		return "create-block-volume"
 	case OperationDeleteBlockVolume:
 		return "delete-block-volume"
+	case OperationExpandBlockVolume:
+		return "expand-block-volume"
 	case OperationRemoveDevice:
 		return "remove-device"
 	case OperationCloneVolume:
@@ -139,6 +143,8 @@ func (c PendingChangeType) Name() string {
 		return "Add block volume"
 	case OpDeleteBlockVolume:
 		return "Delete block volume"
+	case OpExpandBlockVolume:
+		return "Expand block volume"
 	case OpRemoveDevice:
 		return "Remove device"
 	case OpCloneVolume:

--- a/client/api/go-client/block_volume.go
+++ b/client/api/go-client/block_volume.go
@@ -157,3 +157,56 @@ func (c *Client) BlockVolumeDelete(id string) error {
 
 	return nil
 }
+
+func (c *Client) BlockVolumeExpand(id string, request *api.BlockVolumeExpandRequest) (
+	*api.BlockVolumeInfoResponse, error) {
+
+	// Marshal request to JSON
+	buffer, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a request
+	req, err := http.NewRequest("POST",
+		c.host+"/blockvolumes/"+id+"/expand",
+		bytes.NewBuffer(buffer))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Set token
+	err = c.setToken(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Send request
+	r, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusAccepted {
+		return nil, utils.GetErrorFromResponse(r)
+	}
+
+	// Wait for response
+	r, err = c.pollResponse(r)
+	if err != nil {
+		return nil, err
+	}
+	if r.StatusCode != http.StatusOK {
+		return nil, utils.GetErrorFromResponse(r)
+	}
+
+	// Read JSON response
+	var blockvolume api.BlockVolumeInfoResponse
+	err = utils.GetJsonFromResponse(r, &blockvolume)
+	if err != nil {
+		return nil, err
+	}
+
+	return &blockvolume, nil
+}

--- a/client/cli/go/cmds/block_volume.go
+++ b/client/cli/go/cmds/block_volume.go
@@ -25,6 +25,9 @@ var (
 	bv_auth     bool
 	bv_clusters string
 	bv_ha       int
+
+	bvNewSize int
+	bvId      string
 )
 
 func init() {
@@ -33,6 +36,7 @@ func init() {
 	blockVolumeCommand.AddCommand(blockVolumeDeleteCommand)
 	blockVolumeCommand.AddCommand(blockVolumeInfoCommand)
 	blockVolumeCommand.AddCommand(blockVolumeListCommand)
+	blockVolumeCommand.AddCommand(blockVolumeExpandCommand)
 
 	blockVolumeCreateCommand.Flags().IntVar(&bv_size, "size", 0,
 		"\n\tSize of volume in GiB")
@@ -48,10 +52,15 @@ func init() {
 			"\n\ton any of the configured clusters which have the available space."+
 			"\n\tProviding a set of clusters will ensure Heketi allocates storage"+
 			"\n\tfor this volume only in the clusters specified.")
+	blockVolumeExpandCommand.Flags().IntVar(&bvNewSize, "new-size", 0,
+		"\n\tNet new size of block volume in GiB")
+	blockVolumeExpandCommand.Flags().StringVar(&bvId, "block-volume", "",
+		"\n\tId of block volume to expand")
 	blockVolumeCreateCommand.SilenceUsage = true
 	blockVolumeDeleteCommand.SilenceUsage = true
 	blockVolumeInfoCommand.SilenceUsage = true
 	blockVolumeListCommand.SilenceUsage = true
+	blockVolumeExpandCommand.SilenceUsage = true
 }
 
 var blockVolumeCommand = &cobra.Command{
@@ -236,6 +245,49 @@ var blockVolumeListCommand = &cobra.Command{
 			}
 		}
 
+		return nil
+	},
+}
+
+var blockVolumeExpandCommand = &cobra.Command{
+	Use:     "expand",
+	Short:   "Expand an existing block volume",
+	Long:    "Expand an existing block volume",
+	Example: "  $ heketi-cli blockvolume expand --block-volume=60d46d518074b13a04ce1022c8c7193c --new-size=10",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if bvId == "" {
+			return errors.New("Missing --block-volume=$id")
+		}
+
+		if bvNewSize == 0 {
+			return errors.New("Missing --new-size=$GiB")
+		}
+
+		// Create request
+		req := &api.BlockVolumeExpandRequest{}
+		req.Size = bvNewSize
+
+		// Create a client
+		heketi, err := newHeketiClient()
+		if err != nil {
+			return err
+		}
+
+		// Expand volume
+		blockvolume, err := heketi.BlockVolumeExpand(bvId, req)
+		if err != nil {
+			return err
+		}
+
+		if options.Json {
+			data, err := json.Marshal(blockvolume)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(stdout, string(data))
+		} else {
+			fmt.Fprintf(stdout, "%v", blockvolume)
+		}
 		return nil
 	},
 }

--- a/executors/cmdexec/block_volume_test.go
+++ b/executors/cmdexec/block_volume_test.go
@@ -1,0 +1,89 @@
+//
+// Copyright (c) 2020 The heketi Authors
+//
+// This file is licensed to you under your choice of the GNU Lesser
+// General Public License, version 3 or any later version (LGPLv3 or
+// later), or the GNU General Public License, version 2 (GPLv2), in all
+// cases as published by the Free Software Foundation.
+//
+
+package cmdexec
+
+import (
+	"testing"
+
+	"github.com/heketi/tests"
+)
+
+func TestToGigaBytes(t *testing.T) {
+	var (
+		input string
+		size  int
+		err   error
+	)
+
+	input = ""
+	size, err = toGigaBytes(input)
+	tests.Assert(t, err != nil, "expected err != nil, got:", err)
+	tests.Assert(t, size == 0, "expected: size == 0, got:", size)
+
+	input = "."
+	size, err = toGigaBytes(input)
+	tests.Assert(t, err != nil, "expected err != nil, got:", err)
+	tests.Assert(t, size == 0, "expected: size == 0, got:", size)
+
+	input = " "
+	size, err = toGigaBytes(input)
+	tests.Assert(t, err != nil, "expected err != nil, got:", err)
+	tests.Assert(t, size == 0, "expected: size == 0, got:", size)
+
+	input = "xyz"
+	size, err = toGigaBytes(input)
+	tests.Assert(t, err != nil, "expected err != nil, got:", err)
+	tests.Assert(t, size == 0, "expected: size == 0, got:", size)
+
+	input = "1.0 V"
+	size, err = toGigaBytes(input)
+	tests.Assert(t, err != nil, "expected err != nil, got:", err)
+	tests.Assert(t, size == 0, "expected: size == 0, got:", size)
+
+	input = "1.0 GiB"
+	size, err = toGigaBytes(input)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, size == 1, "expected: size == 1, got:", size)
+
+	input = "2    GiB"
+	size, err = toGigaBytes(input)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, size == 2, "expected: size == 2, got:", size)
+
+	input = "3  G"
+	size, err = toGigaBytes(input)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, size == 3, "expected: size == 3, got:", size)
+
+	input = "10.0 GB"
+	size, err = toGigaBytes(input)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, size == 10, "expected: size == 10, got:", size)
+
+	input = "1.0 TiB"
+	size, err = toGigaBytes(input)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, size == 1024, "expected: size == 1024, got:", size)
+
+	input = "5   T"
+	size, err = toGigaBytes(input)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, size == 5120, "expected: size == 5120, got:", size)
+
+	input = "1.0 P"
+	size, err = toGigaBytes(input)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, size == 1048576, "expected: size == 1048576, got:", size)
+
+	input = "6   EiB"
+	size, err = toGigaBytes(input)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, size == 6442450944, "expected: size == 6442450944, got:", size)
+}

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -41,6 +41,8 @@ type Executor interface {
 	SetLogLevel(level string)
 	BlockVolumeCreate(host string, blockVolume *BlockVolumeRequest) (*BlockVolumeInfo, error)
 	BlockVolumeDestroy(host string, blockHostingVolumeName string, blockVolumeName string) error
+	BlockVolumeExpand(host string, blockHostingVolumeName string, blockVolumeName string, newSize int) error
+	BlockVolumeInfo(host string, blockhostingvolume string, blockVolumeName string) (*BlockVolumeInfo, error)
 	PVS(host string) (*PVSCommandOutput, error)
 	VGS(host string) (*VGSCommandOutput, error)
 	LVS(host string) (*LVSCommandOutput, error)

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -42,6 +42,8 @@ type MockExecutor struct {
 	MockHealInfo                 func(host string, volume string) (*executors.HealInfo, error)
 	MockBlockVolumeCreate        func(host string, blockVolume *executors.BlockVolumeRequest) (*executors.BlockVolumeInfo, error)
 	MockBlockVolumeDestroy       func(host string, blockHostingVolumeName string, blockVolumeName string) error
+	MockInfoBlockVolume          func(host string, blockHostingVolumeName string, blockVolumeName string) (*executors.BlockVolumeInfo, error)
+	MockBlockVolumeExpand        func(host string, blockHostingVolumeName string, blockVolumeName string, newSize int) error
 	MockPVS                      func(host string) (*executors.PVSCommandOutput, error)
 	MockVGS                      func(host string) (*executors.VGSCommandOutput, error)
 	MockLVS                      func(host string) (*executors.LVSCommandOutput, error)
@@ -233,6 +235,14 @@ func NewMockExecutor() (*MockExecutor, error) {
 		return nil
 	}
 
+	m.MockInfoBlockVolume = func(host string, blockHostingVolumeName string, blockVolumeName string) (*executors.BlockVolumeInfo, error) {
+		return nil, nil
+	}
+
+	m.MockBlockVolumeExpand = func(host string, blockHostingVolumeName string, blockVolumeName string, newSize int) error {
+		return nil
+	}
+
 	m.MockPVS = func(host string) (*executors.PVSCommandOutput, error) {
 		return &executors.PVSCommandOutput{}, nil
 	}
@@ -369,6 +379,14 @@ func (m *MockExecutor) BlockVolumeCreate(host string, blockVolume *executors.Blo
 
 func (m *MockExecutor) BlockVolumeDestroy(host string, blockHostingVolumeName string, blockVolumeName string) error {
 	return m.MockBlockVolumeDestroy(host, blockHostingVolumeName, blockVolumeName)
+}
+
+func (m *MockExecutor) BlockVolumeExpand(host string, blockHostingVolumeName string, blockVolumeName string, newSize int) error {
+	return m.MockBlockVolumeExpand(host, blockHostingVolumeName, blockVolumeName, newSize)
+}
+
+func (m *MockExecutor) BlockVolumeInfo(host string, blockHostingVolumeName string, blockVolumeName string) (*executors.BlockVolumeInfo, error) {
+	return m.MockInfoBlockVolume(host, blockHostingVolumeName, blockVolumeName)
 }
 
 func (m *MockExecutor) PVS(host string) (*executors.PVSCommandOutput, error) {

--- a/executors/stack/stack.go
+++ b/executors/stack/stack.go
@@ -232,6 +232,26 @@ func (es *ExecutorStack) BlockVolumeDestroy(host string, blockHostingVolumeName 
 	return NotSupportedError
 }
 
+func (es *ExecutorStack) BlockVolumeInfo(host string, blockHostingVolumeName string, blockVolumeName string) (*executors.BlockVolumeInfo, error) {
+	for _, e := range es.executors {
+		bvi, err := e.BlockVolumeInfo(host, blockHostingVolumeName, blockVolumeName)
+		if err != NotSupportedError {
+			return bvi, err
+		}
+	}
+	return nil, NotSupportedError
+}
+
+func (es *ExecutorStack) BlockVolumeExpand(host string, blockHostingVolumeName string, blockVolumeName string, newSize int) error {
+	for _, e := range es.executors {
+		err := e.BlockVolumeExpand(host, blockHostingVolumeName, blockVolumeName, newSize)
+		if err != NotSupportedError {
+			return err
+		}
+	}
+	return NotSupportedError
+}
+
 func (es *ExecutorStack) VolumeClone(
 	host string, vsr *executors.VolumeCloneRequest) (*executors.Volume, error) {
 

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -432,6 +432,16 @@ type BlockVolumeListResponse struct {
 	BlockVolumes []string `json:"blockvolumes"`
 }
 
+type BlockVolumeExpandRequest struct {
+	Size int `json:"new_size"`
+}
+
+func (blockVolExpandReq BlockVolumeExpandRequest) Validate() error {
+	return validation.ValidateStruct(&blockVolExpandReq,
+		validation.Field(&blockVolExpandReq.Size, validation.Required, validation.Min(1)),
+	)
+}
+
 type LogLevelInfo struct {
 	// should contain one or more logger to log-level-name mapping
 	LogLevel map[string]string `json:"loglevel"`


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?
Implement block volume expand interface in heketi

### Notes for the reviewer

Pushing it live with the intention that I will have my code side review comments ready by that time I finish on the TODO list.

The RFE just works fine now but also check for TODO list at the end of this comment which I got from John and Talur in a demo meeting.


```
Before Expand:
-------------
[root@server1 ~]# heketi-cli blockvolume create --size 1
Name: blockvol_365f428f2bf4b5a37f644c239f148058
Size: 1
Volume Id: 365f428f2bf4b5a37f644c239f148058
Cluster Id: 0b5740b0e3c34e935c1cd73e8bbf3c71
Hosts: [192.168.121.42 192.168.121.68 192.168.121.155]
IQN: iqn.2016-12.org.gluster-block:afcc41a3-1c46-4102-812b-5a0767cfb16a
LUN: 0
Hacount: 3
Username:
Password:
Block Hosting Volume: 7b3e7fceae17a57e0fc9ddedcce75912

[root@server1 ~]# heketi-cli volume info 7b3e7fceae17a57e0fc9ddedcce75912 | grep "Free Size"
Free Size: 8

[root@server1 ~]# targetcli ls | grep vol_7b3e7fceae17a57e0fc9ddedcce75912
 o- blockvol_365f428f2bf4b5a37f644c239f148058 [vol_7b3e7fceae17a57e0fc9ddedcce75912@... (1.0GiB) activated]

After Expand:
------------
[root@server1 ~]# heketi-cli blockvolume expand --block-volume 365f428f2bf4b5a37f644c239f148058 --new-size 2
Name: blockvol_365f428f2bf4b5a37f644c239f148058
Size: 2
Volume Id: 365f428f2bf4b5a37f644c239f148058
Cluster Id: 0b5740b0e3c34e935c1cd73e8bbf3c71
Hosts: [192.168.121.42 192.168.121.68 192.168.121.155]
IQN: iqn.2016-12.org.gluster-block:afcc41a3-1c46-4102-812b-5a0767cfb16a
LUN: 0
Hacount: 3
Username:
Password:
Block Hosting Volume: 7b3e7fceae17a57e0fc9ddedcce75912

[root@server1 ~]# heketi-cli volume info 7b3e7fceae17a57e0fc9ddedcce75912 | grep "Free Size"
Free Size: 7

[root@server1 ~]# targetcli ls | grep vol_7b3e7fceae17a57e0fc9ddedcce75912
 o- blockvol_365f428f2bf4b5a37f644c239f148058 [vol_7b3e7fceae17a57e0fc9ddedcce75912@... (2.0GiB) activated]

```

TODO:
1. Implement Clean() and CleanDone() methods  --> Done with V2
2. Add unit tests
3. defer the block volume delete in the functional test case --> Done with V2