### PR TITLE
Fix(cli): correct example given in add device cmd help

### DIFF
--- a/client/cli/go/cmds/device.go
+++ b/client/cli/go/cmds/device.go
@@ -69,7 +69,7 @@ var deviceAddCommand = &cobra.Command{
 	Short: "Add new device to node to be managed by Heketi",
 	Long:  "Add new device to node to be managed by Heketi",
 	Example: `  $ heketi-cli device add \
-      --name=/dev/sdb
+      --name=/dev/sdb \
       --node=3e098cb4407d7109806bb196d9e8f095 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Check arguments

--- a/docs/admin/maintenance.md
+++ b/docs/admin/maintenance.md
@@ -32,7 +32,7 @@ Using the Heketi cli, a single device can be added to a node:
 
 ```
 $ heketi-cli device add \
-      --name=/dev/sdb
+      --name=/dev/sdb \
       --node=3e098cb4407d7109806bb196d9e8f095
 ```
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?

The example given in `heketi-cli device add -h` is missing a trailing backslash. 
This PR corrects that example, and updates the corresponding part in `maintenance.md` file as well.

### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #  N/A


### Notes for the reviewer


