### PR TITLE
blockvolume: tuning the semantics of expand command

### DIFF
--- a/client/cli/go/cmds/block_volume.go
+++ b/client/cli/go/cmds/block_volume.go
@@ -54,7 +54,7 @@ func init() {
 			"\n\tfor this volume only in the clusters specified.")
 	blockVolumeExpandCommand.Flags().IntVar(&bvNewSize, "new-size", 0,
 		"\n\tNet new size of block volume in GiB")
-	blockVolumeExpandCommand.Flags().StringVar(&bvId, "block-volume", "",
+	blockVolumeExpandCommand.Flags().StringVar(&bvId, "blockvolume", "",
 		"\n\tId of block volume to expand")
 	blockVolumeCreateCommand.SilenceUsage = true
 	blockVolumeDeleteCommand.SilenceUsage = true
@@ -250,17 +250,28 @@ var blockVolumeListCommand = &cobra.Command{
 }
 
 var blockVolumeExpandCommand = &cobra.Command{
-	Use:     "expand",
-	Short:   "Expand an existing block volume",
-	Long:    "Expand an existing block volume",
-	Example: "  $ heketi-cli blockvolume expand --block-volume=60d46d518074b13a04ce1022c8c7193c --new-size=10",
+	Use:   "expand",
+	Short: "Expand an existing block volume",
+	Long:  "Expand an existing block volume",
+	Example: `  * Expand a block volume to net new size 100GiB
+      $ heketi-cli blockvolume expand 60d46d518074b13a04ce1022c8c7193c --new-size=100
+                     [or, you can also use]
+      $ heketi-cli blockvolume expand --blockvolume=60d46d518074b13a04ce1022c8c7193c --new-size=100
+`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+
 		if bvId == "" {
-			return errors.New("Missing --block-volume=$id")
+			s := cmd.Flags().Args()
+			if len(s) < 1 {
+				return errors.New("Missing block volume id")
+			}
+
+			// Set block volume id
+			bvId = cmd.Flags().Arg(0)
 		}
 
 		if bvNewSize == 0 {
-			return errors.New("Missing --new-size=$GiB")
+			return errors.New("Missing block volume net new size")
 		}
 
 		// Create request

--- a/client/cli/go/cmds/volume.go
+++ b/client/cli/go/cmds/volume.go
@@ -283,6 +283,8 @@ var volumeExpandCommand = &cobra.Command{
 	Short: "Expand a volume",
 	Long:  "Expand a volume",
 	Example: `  * Add 10GiB to a volume
+    $ heketi-cli volume expand 60d46d518074b13a04ce1022c8c7193c --expand-size=10
+                   [or, you can also use]
     $ heketi-cli volume expand --volume=60d46d518074b13a04ce1022c8c7193c --expand-size=10
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -292,7 +294,13 @@ var volumeExpandCommand = &cobra.Command{
 		}
 
 		if id == "" {
-			return errors.New("Missing volume id")
+			s := cmd.Flags().Args()
+			if len(s) < 1 {
+				return errors.New("Missing volume id")
+			}
+
+			// Set block volume id
+			id = cmd.Flags().Arg(0)
 		}
 
 		// Create request


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?
Currently:
------------


##### Filevolume:
$ heketi-cli volume expand --volume=60d46d518074b13a04ce1022c8c7193c --expand-size=10 

##### Blockvolume:
$ heketi-cli blockvolume expand --block-volume=60d46d518074b13a04ce1022c8c7193c --new-size=10

Fix:
----

I see info and delete commands doesn't use any flag or extra option name specific to collecting volume id, instead, they simply read the arg(0) as volumeId.

Just to keep the semantics in alignment with other commands like info and delete, adding support for below syntax too:

##### Filevolume:
$ heketi-cli volume expand 60d46d518074b13a04ce1022c8c7193c --expand-size=10 

##### Blockvolume:
$ heketi-cli blockvolume expand 60d46d518074b13a04ce1022c8c7193c --new-size=10

But we still maintain the old syntax of using `--volume` or `--blockvolume` in expand commands of both `file` and `block` volumes for compatibility.

Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>