### PR TITLE
 db: introduce UsableSize flag in block volume Info

### DIFF
--- a/apps/glusterfs/block_volume_entry.go
+++ b/apps/glusterfs/block_volume_entry.go
@@ -126,10 +126,16 @@ func (v *BlockVolumeEntry) NewInfoResponse(tx *bolt.Tx) (*api.BlockVolumeInfoRes
 	info.Cluster = v.Info.Cluster
 	info.BlockVolume = v.Info.BlockVolume
 	info.Size = v.Info.Size
+	info.UsableSize = v.Info.UsableSize
 	info.Name = v.Info.Name
 	info.Hacount = v.Info.Hacount
 	info.BlockHostingVolume = v.Info.BlockHostingVolume
 
+	// Handle block volumes which where created
+	// before introducing UsableSize flag in the db
+	if info.UsableSize == 0 && info.Size > 0 {
+		info.UsableSize = info.Size
+	}
 	return info, nil
 }
 

--- a/apps/glusterfs/block_volume_expand_test.go
+++ b/apps/glusterfs/block_volume_expand_test.go
@@ -68,7 +68,7 @@ func TestBlockVolumeExpandOperationFinalize(t *testing.T) {
 	// verify,
 	// the block volume, block hosting volume and bricks exist
 	// there are no pending ops
-	// the size of block volume and FreeSize on block hosting volume
+	// the size, usable size of block volume and FreeSize on block hosting volume
 	app.db.View(func(tx *bolt.Tx) error {
 		bvols, e := BlockVolumeList(tx)
 		tests.Assert(t, e == nil, "expected e == nil, got", e)
@@ -94,6 +94,7 @@ func TestBlockVolumeExpandOperationFinalize(t *testing.T) {
 			bv, e := NewBlockVolumeEntryFromId(tx, id)
 			tests.Assert(t, e == nil, "expected e == nil, got", e)
 			tests.Assert(t, bv.Info.Size == 100, "expected block volume size == 100, got:", bv.Info.Size)
+			tests.Assert(t, bv.Info.UsableSize == 100, "expected block volume usable size == 100, got:", bv.Info.UsableSize)
 		}
 		return nil
 	})
@@ -131,6 +132,7 @@ func TestBlockVolumeExpandOperationFinalize(t *testing.T) {
 			bv, e := NewBlockVolumeEntryFromId(tx, id)
 			tests.Assert(t, e == nil, "expected e == nil, got", e)
 			tests.Assert(t, bv.Info.Size == 100, "expected block volume size == 100, got:", bv.Info.Size)
+			tests.Assert(t, bv.Info.UsableSize == 100, "expected block volume usable size == 100, got:", bv.Info.UsableSize)
 		}
 		return nil
 	})
@@ -143,7 +145,7 @@ func TestBlockVolumeExpandOperationFinalize(t *testing.T) {
 
 	// verify,
 	// the pending op is gone
-	// new block volume size is effective
+	// new block volume size and usable size is effective
 	app.db.View(func(tx *bolt.Tx) error {
 		bvols, e := BlockVolumeList(tx)
 		tests.Assert(t, e == nil, "expected e == nil, got", e)
@@ -169,6 +171,7 @@ func TestBlockVolumeExpandOperationFinalize(t *testing.T) {
 			bv, e := NewBlockVolumeEntryFromId(tx, id)
 			tests.Assert(t, e == nil, "expected e == nil, got", e)
 			tests.Assert(t, bv.Info.Size == 150, "expected block volume size == 150, got:", bv.Info.Size)
+			tests.Assert(t, bv.Info.UsableSize == 150, "expected block volume usable size == 150, got:", bv.Info.UsableSize)
 		}
 		return nil
 	})
@@ -324,7 +327,7 @@ func TestBlockVolumeExpandOperationRollbackGbCliFailedCompletely(t *testing.T) {
 	// verify,
 	// the block volume, block hosting volume and bricks exist
 	// there are no pending ops
-	// the size of block volume and FreeSize on block hosting volume
+	// the size, usable size of block volume and FreeSize on block hosting volume
 	app.db.View(func(tx *bolt.Tx) error {
 		bvols, e := BlockVolumeList(tx)
 		tests.Assert(t, e == nil, "expected e == nil, got", e)
@@ -350,6 +353,7 @@ func TestBlockVolumeExpandOperationRollbackGbCliFailedCompletely(t *testing.T) {
 			bv, e := NewBlockVolumeEntryFromId(tx, id)
 			tests.Assert(t, e == nil, "expected e == nil, got", e)
 			tests.Assert(t, bv.Info.Size == 100, "expected block volume size == 100, got:", bv.Info.Size)
+			tests.Assert(t, bv.Info.UsableSize == 100, "expected block volume usable size == 100, got:", bv.Info.UsableSize)
 		}
 		return nil
 	})
@@ -389,6 +393,7 @@ func TestBlockVolumeExpandOperationRollbackGbCliFailedCompletely(t *testing.T) {
 			blockvolume, e = NewBlockVolumeEntryFromId(tx, id)
 			tests.Assert(t, e == nil, "expected e == nil, got", e)
 			tests.Assert(t, blockvolume.Info.Size == 100, "expected block volume size == 100, got:", blockvolume.Info.Size)
+			tests.Assert(t, blockvolume.Info.UsableSize == 100, "expected block volume usable size == 100, got:", blockvolume.Info.UsableSize)
 		}
 		return nil
 	})
@@ -414,7 +419,8 @@ func TestBlockVolumeExpandOperationRollbackGbCliFailedCompletely(t *testing.T) {
 		blockVolumeInfo.Hacount = blockvolume.Info.Hacount
 		blockVolumeInfo.Iqn = "Fake Iqn"
 		blockVolumeInfo.Name = blockvolume.Info.Name
-		blockVolumeInfo.Size = 100 // original/old size
+		blockVolumeInfo.Size = 100       // original/old size
+		blockVolumeInfo.UsableSize = 100 // original/old size
 		blockVolumeInfo.Username = "Fake Username"
 		blockVolumeInfo.Password = "Fake Password"
 
@@ -427,7 +433,7 @@ func TestBlockVolumeExpandOperationRollbackGbCliFailedCompletely(t *testing.T) {
 	// verify,
 	// there are no pending ops
 	// block hosting volume free size is reset
-	// block volume size is same as Initial
+	// block volume size, usable size is same as Initial
 	app.db.View(func(tx *bolt.Tx) error {
 		bvols, e := BlockVolumeList(tx)
 		tests.Assert(t, e == nil, "expected e == nil, got", e)
@@ -453,6 +459,7 @@ func TestBlockVolumeExpandOperationRollbackGbCliFailedCompletely(t *testing.T) {
 			bv, e := NewBlockVolumeEntryFromId(tx, id)
 			tests.Assert(t, e == nil, "expected e == nil, got", e)
 			tests.Assert(t, bv.Info.Size == 100, "expected block volume size == 100, got:", bv.Info.Size)
+			tests.Assert(t, bv.Info.UsableSize == 100, "expected block volume usable size == 100, got:", bv.Info.UsableSize)
 		}
 		return nil
 	})
@@ -505,7 +512,7 @@ func TestBlockVolumeExpandOperationRollbackGbCliFailedPartially(t *testing.T) {
 	// verify,
 	// the block volume, block hosting volume and bricks exist
 	// there are no pending ops
-	// the size of block volume and FreeSize on block hosting volume
+	// the size, usable size of block volume and FreeSize on block hosting volume
 	app.db.View(func(tx *bolt.Tx) error {
 		bvols, e := BlockVolumeList(tx)
 		tests.Assert(t, e == nil, "expected e == nil, got", e)
@@ -531,6 +538,7 @@ func TestBlockVolumeExpandOperationRollbackGbCliFailedPartially(t *testing.T) {
 			bv, e := NewBlockVolumeEntryFromId(tx, id)
 			tests.Assert(t, e == nil, "expected e == nil, got", e)
 			tests.Assert(t, bv.Info.Size == 100, "expected block volume size == 100, got:", bv.Info.Size)
+			tests.Assert(t, bv.Info.UsableSize == 100, "expected block volume usable size == 100, got:", bv.Info.UsableSize)
 		}
 		return nil
 	})
@@ -570,6 +578,7 @@ func TestBlockVolumeExpandOperationRollbackGbCliFailedPartially(t *testing.T) {
 			blockvolume, e = NewBlockVolumeEntryFromId(tx, id)
 			tests.Assert(t, e == nil, "expected e == nil, got", e)
 			tests.Assert(t, blockvolume.Info.Size == 100, "expected block volume size == 100, got:", blockvolume.Info.Size)
+			tests.Assert(t, blockvolume.Info.UsableSize == 100, "expected block volume usable size == 100, got:", blockvolume.Info.UsableSize)
 		}
 		return nil
 	})
@@ -595,7 +604,8 @@ func TestBlockVolumeExpandOperationRollbackGbCliFailedPartially(t *testing.T) {
 		blockVolumeInfo.Hacount = blockvolume.Info.Hacount
 		blockVolumeInfo.Iqn = "Fake Iqn"
 		blockVolumeInfo.Name = blockvolume.Info.Name
-		blockVolumeInfo.Size = 150 // new size
+		blockVolumeInfo.Size = 150       // new size
+		blockVolumeInfo.UsableSize = 100 // old size, as there is a partial failure
 		blockVolumeInfo.Username = "Fake Username"
 		blockVolumeInfo.Password = "Fake Password"
 
@@ -634,6 +644,7 @@ func TestBlockVolumeExpandOperationRollbackGbCliFailedPartially(t *testing.T) {
 			bv, e := NewBlockVolumeEntryFromId(tx, id)
 			tests.Assert(t, e == nil, "expected e == nil, got", e)
 			tests.Assert(t, bv.Info.Size == 150, "expected block volume size == 150, got:", bv.Info.Size)
+			tests.Assert(t, bv.Info.UsableSize == 100, "expected block volume usable size == 100, got:", bv.Info.UsableSize)
 		}
 		return nil
 	})
@@ -701,7 +712,7 @@ func TestBlockVolumeExpandOperationBuildParallel(t *testing.T) {
 	// verify,
 	// the two block volumes, block hosting volume and bricks exist
 	// there are no pending ops
-	// the size of two block volumes and FreeSize on block hosting volume
+	// the size, usable size of two block volumes and FreeSize on block hosting volume
 	app.db.View(func(tx *bolt.Tx) error {
 		bvols, e := BlockVolumeList(tx)
 		tests.Assert(t, e == nil, "expected e == nil, got", e)
@@ -727,6 +738,7 @@ func TestBlockVolumeExpandOperationBuildParallel(t *testing.T) {
 			bv, e := NewBlockVolumeEntryFromId(tx, id)
 			tests.Assert(t, e == nil, "expected e == nil, got", e)
 			tests.Assert(t, bv.Info.Size == 100, "expected block volume size == 100, got:", bv.Info.Size)
+			tests.Assert(t, bv.Info.UsableSize == 100, "expected block volume usable size == 100, got:", bv.Info.UsableSize)
 		}
 		return nil
 	})
@@ -743,7 +755,7 @@ func TestBlockVolumeExpandOperationBuildParallel(t *testing.T) {
 	// verify,
 	// we have a pending op for the block volume 1 expand
 	// as the Build for block volume 1 is done, block hosting volume FreeSize should be 0
-	// block volumes size is same as Initial
+	// block volumes size, usable size is same as Initial
 	var volume *VolumeEntry
 	var blockvolume1 *BlockVolumeEntry
 	var blockvolume2 *BlockVolumeEntry
@@ -769,10 +781,12 @@ func TestBlockVolumeExpandOperationBuildParallel(t *testing.T) {
 		blockvolume1, e = NewBlockVolumeEntryFromId(tx, bve1.bvolId)
 		tests.Assert(t, e == nil, "expected e == nil, got", e)
 		tests.Assert(t, blockvolume1.Info.Size == 100, "expected block volume size == 100, got:", blockvolume1.Info.Size)
+		tests.Assert(t, blockvolume1.Info.UsableSize == 100, "expected block volume usable size == 100, got:", blockvolume1.Info.UsableSize)
 
 		blockvolume2, e = NewBlockVolumeEntryFromId(tx, bve2.bvolId)
 		tests.Assert(t, e == nil, "expected e == nil, got", e)
 		tests.Assert(t, blockvolume2.Info.Size == 100, "expected block volume size == 100, got:", blockvolume2.Info.Size)
+		tests.Assert(t, blockvolume2.Info.UsableSize == 100, "expected block volume usable size == 100, got:", blockvolume2.Info.UsableSize)
 		return nil
 	})
 
@@ -788,7 +802,8 @@ func TestBlockVolumeExpandOperationBuildParallel(t *testing.T) {
 		blockVolumeInfo.Hacount = blockvolume1.Info.Hacount
 		blockVolumeInfo.Iqn = "Fake Iqn"
 		blockVolumeInfo.Name = blockvolume1.Info.Name
-		blockVolumeInfo.Size = 100 // original/old size
+		blockVolumeInfo.Size = 100       // original/old size
+		blockVolumeInfo.UsableSize = 100 // old size
 		blockVolumeInfo.Username = "Fake Username"
 		blockVolumeInfo.Password = "Fake Password"
 
@@ -801,7 +816,7 @@ func TestBlockVolumeExpandOperationBuildParallel(t *testing.T) {
 	// verify,
 	// there are no pending ops
 	// block hosting volume free size is reset
-	// block volumes size is same as Initial
+	// block volumes size, usable size is same as Initial
 	app.db.View(func(tx *bolt.Tx) error {
 		bvols, e := BlockVolumeList(tx)
 		tests.Assert(t, e == nil, "expected e == nil, got", e)
@@ -827,6 +842,7 @@ func TestBlockVolumeExpandOperationBuildParallel(t *testing.T) {
 			bv, e := NewBlockVolumeEntryFromId(tx, id)
 			tests.Assert(t, e == nil, "expected e == nil, got", e)
 			tests.Assert(t, bv.Info.Size == 100, "expected block volume size == 100, got:", bv.Info.Size)
+			tests.Assert(t, bv.Info.UsableSize == 100, "expected block volume usable size == 100, got:", bv.Info.UsableSize)
 		}
 		return nil
 	})
@@ -839,7 +855,7 @@ func TestBlockVolumeExpandOperationBuildParallel(t *testing.T) {
 	// verify,
 	// we have a pending op for the block volume 2 expand
 	// as the Build for block volume 2 is done, block hosting volume FreeSize should be 0
-	// block volumes size is same as Initial
+	// block volumes size, usable size is same as Initial
 	app.db.View(func(tx *bolt.Tx) error {
 		bvols, e := BlockVolumeList(tx)
 		tests.Assert(t, e == nil, "expected e == nil, got", e)
@@ -863,6 +879,7 @@ func TestBlockVolumeExpandOperationBuildParallel(t *testing.T) {
 			bv, e := NewBlockVolumeEntryFromId(tx, id)
 			tests.Assert(t, e == nil, "expected e == nil, got", e)
 			tests.Assert(t, bv.Info.Size == 100, "expected block volume size == 100, got:", bv.Info.Size)
+			tests.Assert(t, bv.Info.UsableSize == 100, "expected block volume usable size == 100, got:", bv.Info.UsableSize)
 		}
 		return nil
 	})
@@ -875,7 +892,7 @@ func TestBlockVolumeExpandOperationBuildParallel(t *testing.T) {
 
 	// verify,
 	// the pending op is gone
-	// block volume 2 new size is effective
+	// block volume 2 new size, usable size is effective
 	app.db.View(func(tx *bolt.Tx) error {
 		bvols, e := BlockVolumeList(tx)
 		tests.Assert(t, e == nil, "expected e == nil, got", e)
@@ -898,10 +915,12 @@ func TestBlockVolumeExpandOperationBuildParallel(t *testing.T) {
 		bv1, e := NewBlockVolumeEntryFromId(tx, bve1.bvolId)
 		tests.Assert(t, e == nil, "expected e == nil, got", e)
 		tests.Assert(t, bv1.Info.Size == 100, "expected block volume size == 100, got:", bv1.Info.Size)
+		tests.Assert(t, bv1.Info.UsableSize == 100, "expected block volume usable size == 100, got:", bv1.Info.UsableSize)
 
 		bv2, e := NewBlockVolumeEntryFromId(tx, bve2.bvolId)
 		tests.Assert(t, e == nil, "expected e == nil, got", e)
 		tests.Assert(t, bv2.Info.Size == 978, "expected block volume size == 978, got:", bv2.Info.Size)
+		tests.Assert(t, bv2.Info.UsableSize == 978, "expected block volume usable size == 978, got:", bv2.Info.UsableSize)
 		return nil
 	})
 }

--- a/executors/cmdexec/block_volume.go
+++ b/executors/cmdexec/block_volume.go
@@ -337,8 +337,11 @@ func (s *CmdExecutor) BlockVolumeExpand(host string, blockHostingVolumeName stri
 			output)
 	} else if blockVolumeExpand.Result == "FAIL" {
 		// the fail flag was set in the output json
-		err = fmt.Errorf("Failed to expand block volume: %v",
-			blockVolumeExpand.ErrMsg)
+		if blockVolumeExpand.ErrMsg != "" {
+			err = fmt.Errorf("Failed to expand block volume: %v (see logs for details, and retry the operation)", blockVolumeExpand.ErrMsg)
+		} else {
+			err = fmt.Errorf("Failed to expand block volume (see logs for details, and retry the operation)")
+		}
 	} else if !results.Ok() {
 		// the fail flag is not set but the command still
 		// exited non-zero for some reason

--- a/executors/executor.go
+++ b/executors/executor.go
@@ -314,6 +314,7 @@ type BlockVolumeRequest struct {
 type BlockVolumeInfo struct {
 	Name              string
 	Size              int
+	UsableSize        int
 	GlusterVolumeName string
 	GlusterNode       string
 	Hacount           int

--- a/pkg/glusterfs/api/types.go
+++ b/pkg/glusterfs/api/types.go
@@ -422,6 +422,7 @@ type BlockVolumeInfo struct {
 	} `json:"blockvolume"`
 	Cluster            string `json:"cluster,omitempty"`
 	BlockHostingVolume string `json:"blockhostingvolume,omitempty"`
+	UsableSize         int    `json:"usablesize,omitempty"`
 }
 
 type BlockVolumeInfoResponse struct {
@@ -564,6 +565,7 @@ func NewBlockVolumeInfoResponse() *BlockVolumeInfoResponse {
 func (v *BlockVolumeInfoResponse) String() string {
 	s := fmt.Sprintf("Name: %v\n"+
 		"Size: %v\n"+
+		"UsableSize: %v\n"+
 		"Volume Id: %v\n"+
 		"Cluster Id: %v\n"+
 		"Hosts: %v\n"+
@@ -575,6 +577,7 @@ func (v *BlockVolumeInfoResponse) String() string {
 		"Block Hosting Volume: %v\n",
 		v.Name,
 		v.Size,
+		v.UsableSize,
 		v.Id,
 		v.Cluster,
 		v.BlockVolume.Hosts,

--- a/tests/functional/TestSmokeTest/tests/block_volume_test.go
+++ b/tests/functional/TestSmokeTest/tests/block_volume_test.go
@@ -342,4 +342,18 @@ func TestBlockVolumeExpand(t *testing.T) {
 	volInfo, err = heketi.VolumeInfo(bvol.BlockHostingVolume)
 	tests.Assert(t, err == nil, "expected err == nil, got:", err)
 	tests.Assert(t, volInfo.BlockInfo.FreeSize == 96, "expected volInfo.BlockInfo.FreeSize == 96 got:", volInfo.BlockInfo.FreeSize)
+
+	// Expand the block volume to 150G size and check usable size
+	bvolExpReq.Size = 150
+	_, err = heketi.BlockVolumeExpand(bvol.Id, bvolExpReq)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	// Check if block volume size and usable size matches 150G
+	bvolInfo, err = heketi.BlockVolumeInfo(bvol.Id)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, bvolInfo.Size == 150, "expected bvolInfo.Size == 150 got:", bvolInfo.Size)
+	tests.Assert(t, bvolInfo.UsableSize == 150, "expected bvolInfo.UsableSize == 150 got:", bvolInfo.UsableSize)
+	// Check if the FreeSize on block hosting volume is [196G - 150G] = 46G
+	volInfo, err = heketi.VolumeInfo(bvol.BlockHostingVolume)
+	tests.Assert(t, err == nil, "expected err == nil, got:", err)
+	tests.Assert(t, volInfo.BlockInfo.FreeSize == 46, "expected volInfo.BlockInfo.FreeSize == 46 got:", volInfo.BlockInfo.FreeSize)
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?

We should use newly expanded size on the block volume by growing filesystem on
the block device only when block volume is successfully expanded.

On partial failures (few nodes configured to size X and few nodes with size Y)
we should never proceed further for using the newly expanded size. This
might get us into block storage level inconsistencies.

To indicate the real usable size of a block volume, we have come up with
adding a new field to the block volume info.

#### Example 1:
$ heketi-cli blockvolume expand 95aaa622f466bc4ae9e5d460ac55505b --new-size=5
Name: blockvol_95aaa622f466bc4ae9e5d460ac55505b
Size: 5
UsableSize: 5
Volume Id: 95aaa622f466bc4ae9e5d460ac55505b
Cluster Id: 71d6c0a8f6e88c1ddc84b78b464aafd9
Hosts: [192.168.121.55 192.168.121.206 192.168.121.253]
IQN: iqn.2016-12.org.gluster-block:3fe22613-c669-4b04-ab6b-de279c84ca77
LUN: 0
Hacount: 3
Username:
Password:
Block Hosting Volume: b0cb4b999f9d1d386b093c81480e3964

$ heketi-cli blockvolume info 95aaa622f466bc4ae9e5d460ac55505b
Name: blockvol_95aaa622f466bc4ae9e5d460ac55505b
Size: 5
UsableSize: 5
Volume Id: 95aaa622f466bc4ae9e5d460ac55505b
Cluster Id: 71d6c0a8f6e88c1ddc84b78b464aafd9
Hosts: [192.168.121.55 192.168.121.206 192.168.121.253]
IQN: iqn.2016-12.org.gluster-block:3fe22613-c669-4b04-ab6b-de279c84ca77
LUN: 0
Hacount: 3
Username:
Password:
Block Hosting Volume: b0cb4b999f9d1d386b093c81480e3964

Here 'Size' matches 'UsableSize', hence we can proceed further to grow fs on
the device and use the 5GiB Space completely.

#### Example 2:

$ heketi-cli blockvolume expand 95aaa622f466bc4ae9e5d460ac55505b --new-size=10
Error: block volume resize failed: 192.168.121.55:[5.0 GiB] 192.168.121.206:[5.0 GiB], please check logs, and retry again.

$ heketi-cli blockvolume info 95aaa622f466bc4ae9e5d460ac55505b
Name: blockvol_95aaa622f466bc4ae9e5d460ac55505b
Size: 10
UsableSize: 5
Volume Id: 95aaa622f466bc4ae9e5d460ac55505b
Cluster Id: 71d6c0a8f6e88c1ddc84b78b464aafd9
Hosts: [192.168.121.55 192.168.121.206 192.168.121.253]
IQN: iqn.2016-12.org.gluster-block:3fe22613-c669-4b04-ab6b-de279c84ca77
LUN: 0
Hacount: 3
Username:
Password:
Block Hosting Volume: b0cb4b999f9d1d386b093c81480e3964

Here 'Size' doesn't match 'UsableSize', hence we shouldn't proceed further
to grow fs on the device, instead look at the logs, find and fix the real
problem and rerun the expand command again until we see a success i.e.
Size and UsableSize match.

Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>



### Notes for the reviewer
Supporting changes: https://github.com/gluster/gluster-block/pull/271

~~#### TODO:
Add tests for UsableSize Flag [Done now.]~~



