### PR TITLE
functional tests: use a recent-ish version of gluster

### DIFF
--- a/tests/functional/vagrant/roles/common/tasks/main.yml
+++ b/tests/functional/vagrant/roles/common/tasks/main.yml
@@ -14,7 +14,7 @@
   yum:
     name:
       - epel-release
-      - centos-release-gluster41
+      - centos-release-gluster6
     state: present
 
 - name: copy private key


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

Recently, the setup of the vagrant vms in the functional tests has
begun to fail due to gluster version conflicts. Use gluster 6 instead of
4.1 in the test vms. The use of 4.1 was a workaround for an issue in
5 and should hopefully have been fixed. We'll see....




