### PR TITLE
func tests: Add missing arg '-d|--tests-dir' in help

### DIFF
--- a/tests/functional/run.sh
+++ b/tests/functional/run.sh
@@ -5,8 +5,9 @@ SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
 show_help() {
 	echo "$0 [options]"
 	echo "  Options:"
-	echo "    --test T  Run test suite T (can be specified multiple times)"
-	echo "    --help    Display this help text"
+	echo "    -d|--tests-dir    Specify the directory name"
+	echo "    --test T          Run test suite T (can be specified multiple times)"
+	echo "    --help            Display this help text"
 	echo ""
 }
 


### PR DESCRIPTION
Add mising argument '-d|--tests-dir' in --help option of script
in the functional tests run.sh script.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?


### Does this PR fix issues?
https://github.com/heketi/heketi/issues/1721

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #


### Notes for the reviewer


