### PR TITLE
Fix using newer block volume related executor functions with the error injection executor

### DIFF
--- a/apps/glusterfs/block_volume_expand_test.go
+++ b/apps/glusterfs/block_volume_expand_test.go
@@ -404,7 +404,7 @@ func TestBlockVolumeExpandOperationRollbackGbCliFailedCompletely(t *testing.T) {
 
 	// pretend that we have called gluster-block cli and got some info
 	// assumption, gluster-block failed way before expanding the backend file
-	app.xo.MockInfoBlockVolume = func(host string, blockhostingvolume string,
+	app.xo.MockBlockVolumeInfo = func(host string, blockhostingvolume string,
 		blockVolumeName string) (*executors.BlockVolumeInfo, error) {
 		var blockVolumeInfo executors.BlockVolumeInfo
 
@@ -585,7 +585,7 @@ func TestBlockVolumeExpandOperationRollbackGbCliFailedPartially(t *testing.T) {
 
 	// pretend that we have called gluster-block cli and got some info
 	// assumption, gluster-block failed after expanding the backend file
-	app.xo.MockInfoBlockVolume = func(host string, blockhostingvolume string,
+	app.xo.MockBlockVolumeInfo = func(host string, blockhostingvolume string,
 		blockVolumeName string) (*executors.BlockVolumeInfo, error) {
 		var blockVolumeInfo executors.BlockVolumeInfo
 
@@ -778,7 +778,7 @@ func TestBlockVolumeExpandOperationBuildParallel(t *testing.T) {
 
 	// pretend that we have called gluster-block cli and got some info
 	// assumption, gluster-block failed way before expanding the backend file
-	app.xo.MockInfoBlockVolume = func(host string, blockhostingvolume string,
+	app.xo.MockBlockVolumeInfo = func(host string, blockhostingvolume string,
 		blockVolumeName string) (*executors.BlockVolumeInfo, error) {
 		var blockVolumeInfo executors.BlockVolumeInfo
 

--- a/executors/injectexec/mock_base.go
+++ b/executors/injectexec/mock_base.go
@@ -107,5 +107,11 @@ func newMockBase() *mockexec.MockExecutor {
 	m.MockVolumeModify = func(host string, mod *executors.VolumeModifyRequest) error {
 		return NotSupportedError
 	}
+	m.MockBlockVolumeExpand = func(host string, blockHostingVolumeName string, blockVolumeName string, newSize int) error {
+		return NotSupportedError
+	}
+	m.MockBlockVolumeInfo = func(host string, blockHostingVolumeName string, blockVolumeName string) (*executors.BlockVolumeInfo, error) {
+		return nil, NotSupportedError
+	}
 	return m
 }

--- a/executors/mockexec/mock.go
+++ b/executors/mockexec/mock.go
@@ -42,7 +42,7 @@ type MockExecutor struct {
 	MockHealInfo                 func(host string, volume string) (*executors.HealInfo, error)
 	MockBlockVolumeCreate        func(host string, blockVolume *executors.BlockVolumeRequest) (*executors.BlockVolumeInfo, error)
 	MockBlockVolumeDestroy       func(host string, blockHostingVolumeName string, blockVolumeName string) error
-	MockInfoBlockVolume          func(host string, blockHostingVolumeName string, blockVolumeName string) (*executors.BlockVolumeInfo, error)
+	MockBlockVolumeInfo          func(host string, blockHostingVolumeName string, blockVolumeName string) (*executors.BlockVolumeInfo, error)
 	MockBlockVolumeExpand        func(host string, blockHostingVolumeName string, blockVolumeName string, newSize int) error
 	MockPVS                      func(host string) (*executors.PVSCommandOutput, error)
 	MockVGS                      func(host string) (*executors.VGSCommandOutput, error)
@@ -235,7 +235,7 @@ func NewMockExecutor() (*MockExecutor, error) {
 		return nil
 	}
 
-	m.MockInfoBlockVolume = func(host string, blockHostingVolumeName string, blockVolumeName string) (*executors.BlockVolumeInfo, error) {
+	m.MockBlockVolumeInfo = func(host string, blockHostingVolumeName string, blockVolumeName string) (*executors.BlockVolumeInfo, error) {
 		return nil, nil
 	}
 
@@ -386,7 +386,7 @@ func (m *MockExecutor) BlockVolumeExpand(host string, blockHostingVolumeName str
 }
 
 func (m *MockExecutor) BlockVolumeInfo(host string, blockHostingVolumeName string, blockVolumeName string) (*executors.BlockVolumeInfo, error) {
-	return m.MockInfoBlockVolume(host, blockHostingVolumeName, blockVolumeName)
+	return m.MockBlockVolumeInfo(host, blockHostingVolumeName, blockVolumeName)
 }
 
 func (m *MockExecutor) PVS(host string) (*executors.PVSCommandOutput, error) {


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

* rename inner mock exec functions to match proper names in the executor interface
* fix missing default functions for inject exec mock functions

### Does this PR fix issues?

The latter change is the important one as it allows the use of the new executor functions for block volume expand and block volume info to function as designed.


### Notes for the reviewer

I see an opportunity here for making the mock executor and thus the error injection executor less boilerplate-y in the future and avoid issues like this down the road. I'll try to file a PR for that soonish. This one should just fix the immediate issue.

