### PR TITLE
Stop the madness of the "mock" executor

### DIFF
--- a/apps/glusterfs/app.go
+++ b/apps/glusterfs/app.go
@@ -136,7 +136,7 @@ func (app *App) setup(conf *GlusterFSConfig) error {
 
 	// Setup executor
 	switch app.conf.Executor {
-	case "mock":
+	case "testing-only-mock":
 		app.xo, err = mockexec.NewMockExecutor()
 		app.executor = app.xo
 	case "kube", "kubernetes":
@@ -152,7 +152,11 @@ func (app *App) setup(conf *GlusterFSConfig) error {
 		app.executor = injectexec.NewInjectExecutor(
 			app.executor, &app.conf.InjectConfig)
 	default:
-		return fmt.Errorf("invalid executor: %v", app.conf.Executor)
+		return fmt.Errorf(
+			"unknown executor %q"+
+				" (valid executors include \"ssh\" and \"kubernetes\"."+
+				" \"mock\" has been removed, it was for testing heketi only)",
+			app.conf.Executor)
 	}
 	if err != nil {
 		logger.Err(err)

--- a/apps/glusterfs/app_test.go
+++ b/apps/glusterfs/app_test.go
@@ -22,11 +22,13 @@ import (
 	"github.com/heketi/tests"
 )
 
+const mockExec = "testing-only-mock"
+
 func TestAppAdvsettings(t *testing.T) {
 
 	dbfile := tests.Tempfile()
 	defer os.Remove(dbfile)
-	os.Setenv("HEKETI_EXECUTOR", "mock")
+	os.Setenv("HEKETI_EXECUTOR", mockExec)
 	defer os.Unsetenv("HEKETI_EXECUTOR")
 	os.Setenv("HEKETI_DB_PATH", dbfile)
 	defer os.Unsetenv("HEKETI_DB_PATH")
@@ -48,7 +50,7 @@ func TestAppAdvsettings(t *testing.T) {
 	app, _ := NewApp(conf)
 	defer app.Close()
 	tests.Assert(t, app != nil)
-	tests.Assert(t, app.conf.Executor == "mock")
+	tests.Assert(t, app.conf.Executor == mockExec)
 	tests.Assert(t, app.conf.DBfile == dbfile)
 	tests.Assert(t, BrickMaxNum == 33)
 	tests.Assert(t, BrickMaxSize == 1*TB)
@@ -71,7 +73,7 @@ func TestAppLogLevel(t *testing.T) {
 	logger.SetLevel(logging.LEVEL_DEBUG)
 	for _, level := range levels {
 		conf := &GlusterFSConfig{
-			Executor:  "mock",
+			Executor:  mockExec,
 			Allocator: "simple",
 			DBfile:    dbfile,
 			Loglevel:  level,
@@ -100,7 +102,7 @@ func TestAppLogLevel(t *testing.T) {
 	// Test that an unknown value does not change the loglevel
 	logger.SetLevel(logging.LEVEL_NOLOG)
 	conf := &GlusterFSConfig{
-		Executor:  "mock",
+		Executor:  mockExec,
 		Allocator: "simple",
 		DBfile:    dbfile,
 		Loglevel:  "blah",
@@ -119,7 +121,7 @@ func TestAppReadOnlyDb(t *testing.T) {
 
 	// First, create a db
 	conf := &GlusterFSConfig{
-		Executor: "mock",
+		Executor: mockExec,
 		DBfile:   dbfile,
 	}
 	app, _ := NewApp(conf)
@@ -174,7 +176,7 @@ func TestAppBlockSettings(t *testing.T) {
 
 	dbfile := tests.Tempfile()
 	defer os.Remove(dbfile)
-	os.Setenv("HEKETI_EXECUTOR", "mock")
+	os.Setenv("HEKETI_EXECUTOR", mockExec)
 	defer os.Unsetenv("HEKETI_EXECUTOR")
 	os.Setenv("HEKETI_DB_PATH", dbfile)
 	defer os.Unsetenv("HEKETI_DB_PATH")
@@ -196,7 +198,7 @@ func TestAppBlockSettings(t *testing.T) {
 	app, _ := NewApp(conf)
 	defer app.Close()
 	tests.Assert(t, app != nil)
-	tests.Assert(t, app.conf.Executor == "mock")
+	tests.Assert(t, app.conf.Executor == mockExec)
 	tests.Assert(t, app.conf.DBfile == dbfile)
 	tests.Assert(t, CreateBlockHostingVolumes == true)
 	tests.Assert(t, BlockHostingVolumeSize == 500)

--- a/apps/glusterfs/app_volume_test.go
+++ b/apps/glusterfs/app_volume_test.go
@@ -167,7 +167,7 @@ func TestVolumeCreateSmallSize(t *testing.T) {
 	defer os.Remove(tmpfile)
 
 	conf := &GlusterFSConfig{
-		Executor:     "mock",
+		Executor:     mockExec,
 		DBfile:       tmpfile,
 		BrickMinSize: 4,
 	}

--- a/apps/glusterfs/testapp_mock.go
+++ b/apps/glusterfs/testapp_mock.go
@@ -18,7 +18,7 @@ func NewTestApp(dbfile string) *App {
 	// Create simple configuration for unit tests
 	appConfig := &GlusterFSConfig{
 		DBfile:                    dbfile,
-		Executor:                  "mock",
+		Executor:                  "testing-only-mock",
 		CreateBlockHostingVolumes: true,
 		BlockHostingVolumeSize:    1100,
 		MaxInflightOperations:     64, // avoid throttling test code

--- a/client/api/python/test/unit/heketi.json
+++ b/client/api/python/test/unit/heketi.json
@@ -19,14 +19,7 @@
 
   "_glusterfs_comment": "GlusterFS Configuration",
   "glusterfs": {
-    "_executor_comment": [
-      "Execute plugin. Possible choices: mock, ssh",
-      "mock: This setting is used for testing and development.",
-      "      It will not send commands to any node.",
-      "ssh:  This setting will notify Heketi to ssh to the nodes.",
-      "      It will need the values in sshexec to be configured."
-    ],
-    "executor": "mock",
+    "executor": "testing-only-mock",
 
     "_sshexec_comment": "SSH username and private key file information",
     "sshexec": {

--- a/etc/heketi.json
+++ b/etc/heketi.json
@@ -39,14 +39,12 @@
   "glusterfs": {
     "_executor_comment": [
       "Execute plugin. Possible choices: mock, ssh",
-      "mock: This setting is used for testing and development.",
-      "      It will not send commands to any node.",
       "ssh:  This setting will notify Heketi to ssh to the nodes.",
       "      It will need the values in sshexec to be configured.",
       "kubernetes: Communicate with GlusterFS containers over",
       "            Kubernetes exec api."
     ],
-    "executor": "mock",
+    "executor": "CONFIGURE ME",
 
     "_sshexec_comment": "SSH username and private key file information",
     "sshexec": {

--- a/extras/container/heketi.json
+++ b/extras/container/heketi.json
@@ -21,7 +21,7 @@
 	"glusterfs" : {
 
 		"_executor_comment": "Execute plugin. Possible choices: mock, ssh",
-		"executor" : "mock",
+		"executor" : "CONFIGURE ME",
 
 		"_db_comment": "Database file name",
 		"db" : "/var/lib/heketi/heketi.db"

--- a/extras/docker/ci/heketi.json
+++ b/extras/docker/ci/heketi.json
@@ -21,7 +21,7 @@
 	"glusterfs" : {
 
 		"_executor_comment": "Execute plugin. Possible choices: mock, ssh",
-		"executor" : "mock",
+		"executor" : "CONFIGURE ME",
 
 		"_db_comment": "Database file name",
 		"db" : "/var/lib/heketi/heketi.db"

--- a/pkg/heketitest/heketitest.go
+++ b/pkg/heketitest/heketitest.go
@@ -79,7 +79,7 @@ func NewHeketiMockTestServer(
 
 	// Create simple configuration for unit tests
 	appConfig := &glusterfs.GlusterFSConfig{
-		Executor: "mock",
+		Executor: mockExec,
 		Loglevel: loglevel,
 		DBfile:   h.DbFile,
 	}

--- a/tests/functional/TestDbExportImport/heketi.json
+++ b/tests/functional/TestDbExportImport/heketi.json
@@ -22,16 +22,7 @@
 
   "_glusterfs_comment": "GlusterFS Configuration",
   "glusterfs": {
-    "_executor_comment": [
-      "Execute plugin. Possible choices: mock, ssh",
-      "mock: This setting is used for testing and development.",
-      "      It will not send commands to any node.",
-      "ssh:  This setting will notify Heketi to ssh to the nodes.",
-      "      It will need the values in sshexec to be configured.",
-      "kubernetes: Communicate with GlusterFS containers over",
-      "            Kubernetes exec api."
-    ],
-    "executor": "mock",
+    "executor": "testing-only-mock",
 
     "_sshexec_comment": "SSH username and private key file information",
     "sshexec": {

--- a/tests/functional/TestEnabledTLS/heketi.json
+++ b/tests/functional/TestEnabledTLS/heketi.json
@@ -32,16 +32,7 @@
 
   "_glusterfs_comment": "GlusterFS Configuration",
   "glusterfs": {
-    "_executor_comment": [
-      "Execute plugin. Possible choices: mock, ssh",
-      "mock: This setting is used for testing and development.",
-      "      It will not send commands to any node.",
-      "ssh:  This setting will notify Heketi to ssh to the nodes.",
-      "      It will need the values in sshexec to be configured.",
-      "kubernetes: Communicate with GlusterFS containers over",
-      "            Kubernetes exec api."
-    ],
-    "executor": "mock",
+    "executor": "testing-only-mock",
 
     "_sshexec_comment": "SSH username and private key file information",
     "sshexec": {

--- a/tests/functional/TestErrorHandling/tests/error_inject_test.go
+++ b/tests/functional/TestErrorHandling/tests/error_inject_test.go
@@ -61,7 +61,7 @@ func TestConfigChange(t *testing.T) {
 
 	// verify that we can enable the mock executor and use it
 	UpdateConfig(origConf, heketiServer.ConfPath, func(c *config.Config) {
-		c.GlusterFS.Executor = "mock"
+		c.GlusterFS.Executor = "testing-only-mock"
 	})
 	heketiServer.HelloPort = "8080"
 	testutils.ServerRestarted(t, heketiServer)

--- a/tests/functional/TestUpgrade/heketi.json
+++ b/tests/functional/TestUpgrade/heketi.json
@@ -22,16 +22,7 @@
 
   "_glusterfs_comment": "GlusterFS Configuration",
   "glusterfs": {
-    "_executor_comment": [
-      "Execute plugin. Possible choices: mock, ssh",
-      "mock: This setting is used for testing and development.",
-      "      It will not send commands to any node.",
-      "ssh:  This setting will notify Heketi to ssh to the nodes.",
-      "      It will need the values in sshexec to be configured.",
-      "kubernetes: Communicate with GlusterFS containers over",
-      "            Kubernetes exec api."
-    ],
-    "executor": "mock",
+    "executor": "testing-only-mock",
 
     "_sshexec_comment": "SSH username and private key file information",
     "sshexec": {


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

Replace the name of the mock executor with "testing-only-mock".
Improperly configured setups that are trying to use "mock" in production will fail to start rather then pretend to work.

Testing configs in the tree are swapped over. Example jsons now say "CONFIGURE ME" instead of "mock".


### Does this PR fix issues?


Fixes #1734 


### Notes for the reviewer


