### PR TITLE
apps: Correct the logging of 'DeviceDelete'

### DIFF
--- a/apps/glusterfs/app_device.go
+++ b/apps/glusterfs/app_device.go
@@ -285,7 +285,7 @@ func (a *App) DeviceDelete(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Show that the key has been deleted
-		logger.Info("Deleted node [%s]", id)
+		logger.Info("Deleted device [%s]", id)
 
 		return "", nil
 	})


### PR DESCRIPTION
Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

### What does this PR achieve? Why do we need it?
This will achieve correct logging. The older logging can lead us to be in false impression that we have deleted a node, which is not true.