### PR TITLE
apps: Fix regression in brickEvict/"execGetReplacmentInfo"

### DIFF
--- a/apps/glusterfs/operations_device.go
+++ b/apps/glusterfs/operations_device.go
@@ -505,7 +505,15 @@ func (beo *BrickEvictOperation) execGetReplacmentInfo(
 	if err != nil {
 		return err
 	}
+
 	node := old.node.ManageHostName()
+	err = executor.GlusterdCheck(node)
+	if err != nil {
+		node, err = GetVerifiedManageHostname(beo.db, executor, old.node.Info.NodeAddRequest.ClusterId)
+		if err != nil {
+			return err
+		}
+	}
 
 	bs, index, err := old.volume.getBrickSetForBrickId(
 		beo.db, executor, old.brick.Info.Id, node)


### PR DESCRIPTION
Device remove fails while running gluster commands on the same node where
device/brick is present if the node is down.

Fix the same via passing the working node from the same cluster.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

### What does this PR achieve? Why do we need it?
The Pr fix the regression which is introduced recently with brick evict patches.

### Does this PR fix issues?
Fixes #1744
