### PR TITLE
cli: avoid treating characters in db dump as format strings

### DIFF
--- a/client/cli/go/cmds/db.go
+++ b/client/cli/go/cmds/db.go
@@ -45,7 +45,7 @@ var dumpDbCommand = &cobra.Command{
 			return err
 		}
 
-		fmt.Fprintf(stdout, dump)
+		fmt.Fprintf(stdout, "%s", dump)
 
 		return nil
 	},
@@ -67,7 +67,7 @@ var checkDbCommand = &cobra.Command{
 			return err
 		}
 
-		fmt.Fprintf(stdout, checkResponse)
+		fmt.Fprintf(stdout, "%s", checkResponse)
 
 		return nil
 	},


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

Previously, the cli code for printing a db dump gathered from the server
was passing the string as the first string argument to a print function.
This print will then use any characters in the text from the server,
like %-signs, as format strings and potentially mangle the output. My
lazy fix is to just use a single "%s" format string and move the json
data from the server to a secondary argument.

### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #


### Notes for the reviewer

It's not trivial to put '%' chars into the db dump, but can be done by setting volume options with these chars. AFAIK, this isn't valid for gluster but since heketi doesn't validate the values it happily stores thems and then running `heketi-cli db dump` will give you mangled-by-Printf non-json.
