### PR TITLE
readme: remove unhelpful/uninteresting badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-[![Build Status](https://travis-ci.org/heketi/heketi.svg?branch=master)](https://travis-ci.org/heketi/heketi)
-[![Coverage Status](https://coveralls.io/repos/heketi/heketi/badge.svg)](https://coveralls.io/r/heketi/heketi)
-[![Go Report Card](https://goreportcard.com/badge/github.com/heketi/heketi)](https://goreportcard.com/report/github.com/heketi/heketi)
 
 # Heketi
 Heketi provides a RESTful management interface which can be used to manage the life cycle of GlusterFS volumes.  With Heketi, cloud services like OpenStack Manila, Kubernetes, and OpenShift can dynamically provision GlusterFS volumes with any of the supported durability types.  Heketi will automatically determine the location for bricks across the cluster, making sure to place bricks and its replicas across different failure domains.  Heketi also supports any number of GlusterFS clusters, allowing cloud services to provide network file storage without being limited to a single GlusterFS cluster.


### PR DESCRIPTION
Removes the "badges" from the README.md file. These badges are a
combination of uninteresting, misleading, and distracting, in some
proportion depending on wether you are a newcomer to the project or an
old timer. They add so little value it is better to remove them.
