### PR TITLE
General support for http client customization

### DIFF
--- a/client/api/go-client/client.go
+++ b/client/api/go-client/client.go
@@ -71,6 +71,9 @@ type Client struct {
 
 	// allow plugging in custom do wrappers
 	do func(*http.Request) (*http.Response, error)
+
+	// allow plugging in custom http client fetcher
+	getClient ClientFunc
 }
 
 var defaultClientOptions = ClientOptions{
@@ -154,6 +157,10 @@ func (c *Client) SetTLSOptions(o *ClientTLSOptions) error {
 	return nil
 }
 
+func (c *Client) SetClientFunc(f ClientFunc) {
+	c.getClient = f
+}
+
 // Simple Hello test to check if the server is up
 func (c *Client) Hello() error {
 	// Create request
@@ -189,7 +196,14 @@ func (c *Client) doBasic(req *http.Request) (*http.Response, error) {
 		<-c.throttle
 	}()
 
-	httpClient := HeketiHttpClient(c.tlsClientConfig, c.checkRedirect)
+	getClient := c.getClient
+	if getClient == nil {
+		getClient = HeketiHttpClient
+	}
+	httpClient, err := getClient(c.tlsClientConfig, c.checkRedirect)
+	if err != nil {
+		return nil, err
+	}
 	return httpClient.Do(req)
 }
 
@@ -354,9 +368,19 @@ func (c *ClientOptions) retryDelay(r *http.Response) time.Duration {
 // of the CheckRedirect function of the http.Client.
 type CheckRedirectFunc func(*http.Request, []*http.Request) error
 
+// ClientFunc is an alias for the function signature needed to create custom
+// http clients.
+type ClientFunc func(*tls.Config, CheckRedirectFunc) (HttpPerformer, error)
+
+// HttpPerformer is an interface that the heketi api client needs from the http
+// client.
+type HttpPerformer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // HeketiHttpClient constructs a new http client for use by the heketi
 // api client, using the traditional heketi approach.
-func HeketiHttpClient(tlsConfig *tls.Config, checkRedirect CheckRedirectFunc) *http.Client {
+func HeketiHttpClient(tlsConfig *tls.Config, checkRedirect CheckRedirectFunc) (HttpPerformer, error) {
 	httpClient := &http.Client{}
 	if tlsConfig != nil {
 		httpClient.Transport = &http.Transport{
@@ -364,5 +388,5 @@ func HeketiHttpClient(tlsConfig *tls.Config, checkRedirect CheckRedirectFunc) *h
 		}
 	}
 	httpClient.CheckRedirect = checkRedirect
-	return httpClient
+	return httpClient, nil
 }


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Allows consumers of heketi client libs to make deep, general customization to the http.Client used by the heketi client package.

The changes should be fully backwards compatible and if the customization function is not supplied the system will continue to behave as before. If the customization function is supplied the code importing and using the heketi client can provide http clients setup any way desired, or even a non-http-client that provides the same Do method as an http client.

### Notes for the reviewer

The HeketiHttpClient is public so any code that wants to set up the client the way heketi does but intercept that and customize that (make a code sandwich ;-)) can do so.
