### PR TITLE
utils: support reading data even if content-length is unset

### DIFF
--- a/pkg/utils/bodystring.go
+++ b/pkg/utils/bodystring.go
@@ -21,9 +21,22 @@ import (
 	"strings"
 )
 
+var (
+	errMax = int64(4096)
+	strMax = int64(8192)
+)
+
 // Return the body from a response as a string
 func GetStringFromResponse(r *http.Response) (string, error) {
-	body, err := ioutil.ReadAll(io.LimitReader(r.Body, r.ContentLength))
+	// If the content length is not set, limit reading to 8K worth of data.
+	return getResponse(r, strMax)
+}
+
+func getResponse(r *http.Response, max int64) (string, error) {
+	if r.ContentLength >= 0 {
+		max = r.ContentLength
+	}
+	body, err := ioutil.ReadAll(io.LimitReader(r.Body, max))
 	defer r.Body.Close()
 	if err != nil {
 		return "", err
@@ -33,7 +46,10 @@ func GetStringFromResponse(r *http.Response) (string, error) {
 
 // Return the body from a response as an error
 func GetErrorFromResponse(r *http.Response) error {
-	s, err := GetStringFromResponse(r)
+	// If the content length is not set, limit reading to 4K worth of data.
+	// It is probably way more than needed because an error that long is
+	// very unusual. Plus it will only cut it off rather than show nothing.
+	s, err := getResponse(r, errMax)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

### What does this PR achieve? Why do we need it?

We found that very long error messages, in one case generated by pvcreate, caused the heketi support code used in the client to incorrectly treat it as a case of no-error-message. This appears to be due to the long error messages causing the golang http libs to emit an HTTP repsonse without a content-length, where a short error message produces a response with a content-length.

### Does this PR fix issues?

Fixes rhbz#1882701


### Notes for the reviewer


