### PR TITLE
Fix brick eviction when a volume is not present in gluster

### DIFF
--- a/executors/cmdexec/volume.go
+++ b/executors/cmdexec/volume.go
@@ -285,6 +285,11 @@ func (s *CmdExecutor) VolumeInfo(host string, volume string) (*executors.Volume,
 		return nil, fmt.Errorf("Unable to determine volume info of volume name: %v", volume)
 	}
 	logger.Debug("%+v\n", volumeInfo)
+	if volumeInfo.OpErrStr != "" {
+		// gluster failed but didn't set a non-zero exit code!
+		return nil, fmt.Errorf("Unable to get info for %v: %v",
+			volume, volumeInfo.OpErrStr)
+	}
 	return &volumeInfo.VolInfo.Volumes.VolumeList[0], nil
 }
 


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

There's a panic that can occur in heketi when brick evict is run. If there's  an eviction to be done, including if part of a device remove, and the volume exists in heketi but not gluster heketi will panic.   This happens because gluster command fails to set a non-zero exit code. Heketi treats this as a success and tries to index into the "list of volumes" for the requested volume but there's a zero-length list, and that triggers a go panic.


### Does this PR fix issues?

Fixes rhbz#1888760


### Notes for the reviewer

At first I didn't like the idea of actually removing the volume from gluster in the test and wanted to just use error injection. However, I concluded that doing it with an actual command is more "real world" and could possibly help find other quirks in this workflow in the future rather than the "mocking" approach of error injection which needs to know what commands to hook.

