### PR TITLE
functional tests: add a way to debug g-block test failures

### DIFF
--- a/tests/functional/lib.sh
+++ b/tests/functional/lib.sh
@@ -118,6 +118,12 @@ teardown_environment() {
     esac
 }
 
+dump_logs() {
+    local envdump="${HEKETI_TEST_ENVIRONMENT_DUMP}"
+    [ "${envdump}" ] || envdump="${DEFAULT_TESTENV}/dump.sh"
+    _sudo "${envdump}"
+}
+
 teardown() {
     teardown_environment
     rm -f heketi.db > /dev/null 2>&1
@@ -155,6 +161,9 @@ functional_tests() {
     pause_test "$HEKETI_TEST_PAUSE_BEFORE"
     run_go_tests
     pause_test "$HEKETI_TEST_PAUSE_AFTER"
+    if [[ $gotest_result -ne 0 ]]; then
+        dump_logs
+    fi
 
     stop_heketi
     if [[ "$HEKETI_TEST_CLEANUP" != "no" ]]

--- a/tests/functional/vagrant/dump.sh
+++ b/tests/functional/vagrant/dump.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+set +e
+set -x
+for hn in storage0 storage1 storage2 storage3; do
+    echo '+++' $hn
+    vagrant ssh $hn -- rpm -qa | grep gluster
+    vagrant ssh $hn -- systemctl status gluster-blockd
+    vagrant ssh $hn -- sudo grep . /var/log/gluster-block/gluster-block-cli.log /var/log/gluster-block/gluster-block-configshell.log /var/log/gluster-block/gluster-block-gfapi.log /var/log/gluster-block/gluster-blockd.log
+done
+
+exit 0


### PR DESCRIPTION


### What does this PR achieve? Why do we need it?

Lately, the tests are failing due to mysterious error within
gluster-block in the CI environment. This is my 2nd, slightly cleaner,
attempt at diagnosing gluster block errors when the tests fail in the
CI.

### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #


### Notes for the reviewer


