### PR TITLE
Gorilla Context Memory leak

### DIFF
--- a/apps/glusterfs/app_middleware.go
+++ b/apps/glusterfs/app_middleware.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/gorilla/context"
 	"github.com/urfave/negroni"
 
 	"github.com/heketi/heketi/middleware"
@@ -29,7 +28,7 @@ var (
 func (a *App) Auth(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 
 	// Value saved by the JWT middleware.
-	data := context.Get(r, "jwt")
+	data := r.Context().Value("jwt")
 
 	// Need to change from interface{} to the jwt.Token type
 	token := data.(*jwt.Token)

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -10,6 +10,7 @@
 package middleware
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -22,7 +23,6 @@ import (
 
 	jwtmiddleware "github.com/auth0/go-jwt-middleware"
 	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/gorilla/context"
 	"github.com/heketi/heketi/pkg/logging"
 )
 
@@ -187,8 +187,10 @@ func (j *JwtAuth) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.Ha
 	}
 
 	// Store token in request for other middleware to access
-	context.Set(r, "jwt", token)
+	ctx := r.Context()
+	ctx = context.WithValue(ctx, "jwt", token)
+	newR := r.WithContext(ctx)
 
 	// Everything passes call next middleware
-	next(w, r)
+	next(w, newR)
 }

--- a/middleware/jwt_test.go
+++ b/middleware/jwt_test.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/gorilla/context"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/heketi/tests"
 	"github.com/urfave/negroni"
@@ -343,7 +342,7 @@ func TestJwt(t *testing.T) {
 	// Create a simple middleware to check if it was called
 	called := false
 	mw := func(rw http.ResponseWriter, r *http.Request) {
-		data := context.Get(r, "jwt")
+		data := r.Context().Value("jwt")
 		tests.Assert(t, data != nil)
 
 		token := data.(*jwt.Token)
@@ -407,7 +406,7 @@ func TestJwtLeewayIAT(t *testing.T) {
 
 	called := false
 	mw := func(rw http.ResponseWriter, r *http.Request) {
-		data := context.Get(r, "jwt")
+		data := r.Context().Value("jwt")
 		tests.Assert(t, data != nil)
 
 		token := data.(*jwt.Token)
@@ -479,7 +478,7 @@ func TestJwtExceedLeewayIAT(t *testing.T) {
 
 	called := false
 	mw := func(rw http.ResponseWriter, r *http.Request) {
-		data := context.Get(r, "jwt")
+		data := r.Context().Value("jwt")
 		tests.Assert(t, data != nil)
 
 		token := data.(*jwt.Token)
@@ -553,7 +552,7 @@ func TestJwtModifiedLeewayIATSuccess(t *testing.T) {
 
 		called := false
 		mw := func(rw http.ResponseWriter, r *http.Request) {
-			data := context.Get(r, "jwt")
+			data := r.Context().Value("jwt")
 			tests.Assert(t, data != nil)
 
 			token := data.(*jwt.Token)
@@ -639,7 +638,7 @@ func TestJwtModifiedLeewayIATFailure(t *testing.T) {
 
 		called := false
 		mw := func(rw http.ResponseWriter, r *http.Request) {
-			data := context.Get(r, "jwt")
+			data := r.Context().Value("jwt")
 			tests.Assert(t, data != nil)
 
 			token := data.(*jwt.Token)
@@ -727,7 +726,7 @@ func TestJwtNegativeLeewayIATFailure(t *testing.T) {
 
 		called := false
 		mw := func(rw http.ResponseWriter, r *http.Request) {
-			data := context.Get(r, "jwt")
+			data := r.Context().Value("jwt")
 			tests.Assert(t, data != nil)
 
 			token := data.(*jwt.Token)
@@ -950,7 +949,7 @@ func TestJwtWrongSigningMethod(t *testing.T) {
 	tests.Assert(t, n != nil, "negroni.New failed")
 
 	mw := func(rw http.ResponseWriter, r *http.Request) {
-		data := context.Get(r, "jwt")
+		data := r.Context().Value("jwt")
 		tests.Assert(t, data != nil, "context.Get failed")
 
 		token := data.(*jwt.Token)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?
Using gorilla/context leads to memory leaks on go version more than 1.7. https://github.com/gorilla/context.

### Does this PR fix issues?
fixes #1777 
<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #
In this MR I changed gorilla context to http.Request.Context()



