### PR TITLE
Switch to form3-tech/jwt-go.

### DIFF
--- a/apps/glusterfs/app_middleware.go
+++ b/apps/glusterfs/app_middleware.go
@@ -13,7 +13,7 @@ import (
 	"net/http"
 	"strings"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/form3tech-oss/jwt-go"
 	"github.com/urfave/negroni"
 
 	"github.com/heketi/heketi/middleware"

--- a/client/api/go-client/client.go
+++ b/client/api/go-client/client.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/form3tech-oss/jwt-go"
 	"github.com/heketi/heketi/pkg/utils"
 )
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -63,7 +63,7 @@ Showing top 10 nodes out of 93
     6.50MB  3.25% 77.23%     6.50MB  3.25%  context.WithValue
     6.50MB  3.25% 80.48%     6.50MB  3.25%  encoding/json.(*decodeState).literalStore
        6MB  3.00% 83.49%     6.50MB  3.25%  net/textproto.(*Reader).ReadLine
-    5.50MB  2.75% 86.24%    39.51MB 19.76%  github.com/heketi/heketi/vendor/github.com/dgrijalva/jwt-go.(*Parser).ParseWithClaims
+    5.50MB  2.75% 86.24%    39.51MB 19.76%  github.com/heketi/heketi/vendor/github.com/form3tech-oss/jwt-go.(*Parser).ParseWithClaims
 ```
 
 ```

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: 101a677198f95e8950ccdf32f82f219598d593b78574ecf33c638d4fb0d8ccfa
-updated: 2021-01-20T13:22:30.5695457Z
+hash: 02e8083c8690a2db4784253725de50585de6ebd0b0851ea8bba9993d134541c8
+updated: 2021-01-24T17:27:58.064758501-05:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: f9ffefc3facfbe0caee3fea233cbb6e8208f4541
 - name: github.com/auth0/go-jwt-middleware
-  version: 36081240882bbf356af6efb152969e4b0bcf4456
+  version: 1c6db3ceac5f4d28b35ee4b9949a3f80030aa6a3
 - name: github.com/beorn7/perks
   version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
   subpackages:
@@ -15,8 +15,6 @@ imports:
   version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
-- name: github.com/dgrijalva/jwt-go
-  version: 01aeca54ebda6e0fbfafd0a524d234159c05ec20
 - name: github.com/docker/spdystream
   version: 449fdfce4d962303d702fec724ef0ad181c92528
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 6bd1a11a1f60b05b812c7e761c52889ad4177b55ebd9125ab7e9ba619a5c71e3
-updated: 2019-09-12T11:09:15.14308-04:00
+hash: 101a677198f95e8950ccdf32f82f219598d593b78574ecf33c638d4fb0d8ccfa
+updated: 2021-01-20T13:22:30.5695457Z
 imports:
 - name: github.com/asaskevich/govalidator
   version: f9ffefc3facfbe0caee3fea233cbb6e8208f4541
@@ -16,13 +16,15 @@ imports:
   subpackages:
   - spew
 - name: github.com/dgrijalva/jwt-go
-  version: 06ea1031745cb8b3dab3f6a236daf2b0aa468b7e
+  version: 01aeca54ebda6e0fbfafd0a524d234159c05ec20
 - name: github.com/docker/spdystream
   version: 449fdfce4d962303d702fec724ef0ad181c92528
   subpackages:
   - spdy
 - name: github.com/evanphx/json-patch
   version: 5858425f75500d40c52783dce87d085a483ce135
+- name: github.com/form3tech-oss/jwt-go
+  version: 9162a5abdbc046b7c8b03ee90052cee67e25caa7
 - name: github.com/go-ozzo/ozzo-validation
   version: 85dcd8368eba387e65a03488b003e233994e87e9
   subpackages:
@@ -107,6 +109,7 @@ imports:
   - poly1305
   - ssh
   - ssh/agent
+  - ssh/knownhosts
   - ssh/terminal
 - name: golang.org/x/net
   version: cdfb69ac37fc6fa907650654115ebebb3aae2087

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,10 +1,11 @@
 package: github.com/heketi/heketi
 import:
 - package: github.com/auth0/go-jwt-middleware
+  version: 36081240882bbf356af6efb152969e4b0bcf4456
 - package: github.com/boltdb/bolt
   version: ^1.3.0
-- package: github.com/dgrijalva/jwt-go
-  version: ^3.0.0
+- package: github.com/form3tech-oss/jwt-go
+  version: ^3.2.2
 - package: github.com/gorilla/context
 - package: github.com/gorilla/mux
 - package: github.com/heketi/rest

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/heketi/heketi
 import:
 - package: github.com/auth0/go-jwt-middleware
-  version: 36081240882bbf356af6efb152969e4b0bcf4456
+  version: v1.0.0
 - package: github.com/boltdb/bolt
   version: ^1.3.0
 - package: github.com/form3tech-oss/jwt-go

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	jwtmiddleware "github.com/auth0/go-jwt-middleware"
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/form3tech-oss/jwt-go"
 	"github.com/heketi/heketi/pkg/logging"
 )
 
@@ -42,7 +42,7 @@ func init() {
 	}
 }
 
-// From https://github.com/dgrijalva/jwt-go/pull/139 it is understood
+// From https://github.com/form3tech-oss/jwt-go/pull/139 it is understood
 // that if the machine where jwt token is generated and/or the machine
 // where jwt token is verified have any clock skew then there is a
 // possibility of getting a "Token used before issued" error.

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -42,7 +42,7 @@ func init() {
 	}
 }
 
-// From https://github.com/form3tech-oss/jwt-go/pull/139 it is understood
+// From https://github.com/dgrijalva/jwt-go/pull/139 it is understood
 // that if the machine where jwt token is generated and/or the machine
 // where jwt token is verified have any clock skew then there is a
 // possibility of getting a "Token used before issued" error.

--- a/middleware/jwt_test.go
+++ b/middleware/jwt_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/form3tech-oss/jwt-go"
 	"github.com/heketi/heketi/pkg/utils"
 	"github.com/heketi/tests"
 	"github.com/urfave/negroni"
@@ -981,7 +981,7 @@ func TestJwtWrongSigningMethod(t *testing.T) {
 	// Setup pre-req bits needed to make our PS256 valid.
 	// Should we use a fake source of randomness instead of real
 	// rand.Reader here?
-	pk, err := rsa.GenerateKey(rand.Reader, 256*2)
+	pk, err := rsa.GenerateKey(rand.Reader, 512*2)
 	tests.Assert(t, err == nil, "rsa.GenerateKey failed:", err)
 	tokenString, err := token.SignedString(pk)
 	tests.Assert(t, err == nil, "token.SignedString failed:", err)


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

The old library is abaondoned and has some severe CVEs in it. The form3-tech
fork has fixed those CVEs and is the most popular fork. CVE is here:
https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMDGRIJALVAJWTGO-596515

### Does this PR fix issues?
Fixes #

### Notes for the reviewer

I understand this is going toward maintenance mode. Hoping to get this update in to help unblock other libraries that import heketi from updating.

