### PR TITLE
makefile: set a timeout on glide but allow a 2nd attempt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ endif
 glide.lock: glide.yaml
 	echo "Glide.yaml has changed, updating glide.lock"
 	if [ "$(GLIDE_HOME)" ]; then mkdir -p "$(GLIDE_HOME)"; fi
-	$(GLIDE) update -v
+	timeout -v 20m $(GLIDE) update -v || timeout -v 20m $(GLIDE) update -v
 
 client: vendor glide.lock
 	@$(MAKE) -C client/cli/go


### PR DESCRIPTION
Set a timeout of 20minutes on running glide but if glide fails
run it again. This is just an experiment to see if it makes the
CI behave better.
