### PR TITLE
fix glide "install" in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
         GOPATH: /home/runner/go
       run: |
         export PATH=$PATH:$GOPATH/bin
-        curl https://glide.sh/get | sh
+        curl -L -o /tmp/glide-v0.13.3-linux-amd64.tar.gz https://github.com/Masterminds/glide/releases/download/v0.13.3/glide-v0.13.3-linux-amd64.tar.gz
+        tar -xO -f /tmp/glide-v0.13.3-linux-amd64.tar.gz "linux-amd64/glide" > "$GOPATH/bin/glide"
+        chmod 0777 "$GOPATH/bin/glide"
         cd /home/runner/go/src/github.com/heketi/heketi
         make all test COVERAGE=true TESTOPTIONS="-vcstdout"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ install:
       tar -xzf glide-v0.13.1-linux-s390x.tar.gz linux-s390x/glide --strip=1;
       export PATH=$PWD:$PATH;
   else
-      curl https://glide.sh/get | sh;
+      wget https://github.com/Masterminds/glide/releases/download/v0.13.1/glide-v0.13.1-linux-amd64.tar.gz;
+      tar -xzf glide-v0.13.1-linux-amd64.tar.gz linux-amd64/glide --strip=1;
+      export PATH=$PWD:$PATH;
   fi
 env:
   global:

--- a/tests/functional/run.sh
+++ b/tests/functional/run.sh
@@ -55,7 +55,6 @@ fi
 # install glide
 if ! command -v glide ; then
 	echo glide is not installed, please install it to continue
-	echo 'get it from your package manager, or unsafely via: "curl https://glide.sh/get | sh"'
 	exit 1
 fi
 


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

glide.sh is down. I don't know if its coming back because glide is kinda "dead" anyway. Even if it does we don't really need to rely on the (distasteful IMO) technique of curl-pipe-bash.

### Does this PR fix issues?

Fixes the CI not working.

