### PR TITLE
extras: disable go modules

### DIFF
--- a/extras/docker/fromsource/Dockerfile
+++ b/extras/docker/fromsource/Dockerfile
@@ -12,6 +12,7 @@ ENV PATH=$GOPATH/bin:$PATH
 # where to clone from
 ENV HEKETI_REPO="https://github.com/heketi/heketi.git"
 ENV HEKETI_BRANCH="master"
+ENV GO111MODULE=off
 
 # install dependencies, build and cleanup
 RUN mkdir $BUILD_HOME $GOPATH && \


### PR DESCRIPTION
Fedora 34 packages the 1.16 version of golang which tries to use go
modules even if a go.mod file isn't found. We don't intend to migrate to
go modules. This commit turns off the go modules in the Dockerfile.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>

<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?
Docker build fails without this commit.

