### PR TITLE
Docs: remove reference to freenode

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Please visit [Vagrant-Heketi](https://github.com/heketi/vagrant-heketi) to try o
 # Community
 
 * Mailing list: [Join our mailing list](http://lists.gluster.org/mailman/listinfo/heketi-devel)
-* IRC: #heketi on Freenode
 
 # Talks
 

--- a/extras/docker/centos/README.md
+++ b/extras/docker/centos/README.md
@@ -10,10 +10,8 @@ This directory contains two files from creating images:
 2. `Dockerfile.testing` for building an image from packages in testing
 
 These images are maintained by the Heketi Developers, for questions or problem
-reports they can be reached on
-[heketi-devel@gluster.org](mailto:heketi-devel@gluster.org), on Freenode IRC in
-#heketi or by opening an [issue on
-Gitub](https://github.com/heketi/heketi/issues/new).
+reports they can be reached by opening an [issue on
+Github](https://github.com/heketi/heketi/issues/new).
 
 
 ## Build Process


### PR DESCRIPTION
Due to the recent changes at freenode and also due to the current
maintenance status of heketi, we are removing the references to freenode
from our documentation. Github should be the best place to contact the
developers for anything related to heketi.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>

<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?


### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes #


### Notes for the reviewer


