### PR TITLE
Fix topology never load on first run

### DIFF
--- a/extras/container/heketi-start.sh
+++ b/extras/container/heketi-start.sh
@@ -123,7 +123,9 @@ if [[ ! -f "${HEKETI_PATH}/heketi.db" ]]; then
             ((check+=1))
         done
     fi
+fi
 
+if [[ -f "${HEKETI_PATH}/heketi.db" ]]; then
     stat "${HEKETI_PATH}/heketi.db" 2>/dev/null | tee -a "${LOG}"
     # Workaround for scenario where a lock on the heketi.db has not been
     # released.

--- a/extras/container/heketi-start.sh
+++ b/extras/container/heketi-start.sh
@@ -123,24 +123,24 @@ if [[ ! -f "${HEKETI_PATH}/heketi.db" ]]; then
             ((check+=1))
         done
     fi
-fi
 
-stat "${HEKETI_PATH}/heketi.db" 2>/dev/null | tee -a "${LOG}"
-# Workaround for scenario where a lock on the heketi.db has not been
-# released.
-# This code uses a non-blocking flock in a loop rather than a blocking
-# lock with timeout due to issues with current gluster and flock
-# ( see rhbz#1613260 )
-for _ in $(seq 1 60); do
-    flock --nonblock "${HEKETI_PATH}/heketi.db" true
-    flock_status=$?
-    if [[ $flock_status -eq 0 ]]; then
-        break
+    stat "${HEKETI_PATH}/heketi.db" 2>/dev/null | tee -a "${LOG}"
+    # Workaround for scenario where a lock on the heketi.db has not been
+    # released.
+    # This code uses a non-blocking flock in a loop rather than a blocking
+    # lock with timeout due to issues with current gluster and flock
+    # ( see rhbz#1613260 )
+    for _ in $(seq 1 60); do
+        flock --nonblock "${HEKETI_PATH}/heketi.db" true
+        flock_status=$?
+        if [[ $flock_status -eq 0 ]]; then
+            break
+        fi
+        sleep 1
+    done
+    if [[ $flock_status -ne 0 ]]; then
+        fail "Database file is read-only"
     fi
-    sleep 1
-done
-if [[ $flock_status -ne 0 ]]; then
-    fail "Database file is read-only"
 fi
 
 # this creates archival copies of the db if needed for disaster


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is appreciated.

Here are some tips for you:

1. Read the contributing guide at [https://github.com/heketi/heketi/blob/master/docs/contributing.md]
2. Split the changes up into minimal and atomic commits.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#splitting-your-change-into-commits]
3. Write meaningful commit messages [https://github.com/heketi/heketi/blob/master/docs/contributing.md#good-commit-messages]
4. Test your changes: run `make test`.  [https://github.com/heketi/heketi/blob/master/docs/contributing.md#testing-the-change]
5. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?

On first run, flock function create file heketi.db if not exists, and topology isn't load after.

### Does this PR fix issues?

<!-- This is optional, 'fixes #<issue-number>' lines will close the issue if the PR is merged.  -->

Function flock is call only if file heketi.db is present.

### Notes for the reviewer


