### PR TITLE
workflows: add go versions 1.15 & 1.16 to actions runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.12", "1.13", "1.14"]
+        go: ["1.12", "1.13", "1.14", "1.15", "1.16"]
     steps:
     - uses: actions/setup-go@v2
       with:


### PR DESCRIPTION
We're only testing "old" go versions currently. We should test old versions as needed, but also test versions actually supported by Go.